### PR TITLE
Fixed range of latitude

### DIFF
--- a/faker/providers/address.py
+++ b/faker/providers/address.py
@@ -82,7 +82,8 @@ class Provider(BaseProvider):
 
     @classmethod
     def latitude(cls):
-        return cls.geo_coordinate()
+        # Latitude has a range of -90 to 90, so divide by two.
+        return cls.geo_coordinate() / 2
 
     @classmethod
     def longitude(cls):


### PR DESCRIPTION
Latitude should only go from -90 to 90, unlike longitude which ranges from -180 to 180.  A simple solution is to just divide latitude by two.
