### PR TITLE
fixed a small typo in en_CA provider to generate Canadian postal codes

### DIFF
--- a/faker/providers/en_CA/address.py
+++ b/faker/providers/en_CA/address.py
@@ -125,7 +125,7 @@ class Provider(AddressProvider):
         '{{building_number}} {{street_name}} {{secondary_address}}',
     )
     address_formats = (
-        "{{street_address}}\n{{city}}, {{province_abbr}} {{postcode}}",
+        "{{street_address}}\n{{city}}, {{province_abbr}} {{postalcode}}",
     )
     secondary_address_formats = ('Apt. ###', 'Suite ###')
 


### PR DESCRIPTION
Looks like a 'postcode' was a leftover from en_US provider
