### PR TITLE
Enable testing on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 2.6
   - 2.7
   - 3.3
+  - 3.4
 install:
   - pip install -e .
   - pip install coveralls


### PR DESCRIPTION
As per [this Travis CI blog post](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/), testing on Python 3.4 is now supported.
