### PR TITLE
Update address.py

### DIFF
--- a/faker/providers/en_CA/address.py
+++ b/faker/providers/en_CA/address.py
@@ -48,7 +48,7 @@ class Provider(AddressProvider):
         'View', 'Views', 'Village', 'Village', 'Villages', 'Ville', 'Vista', 'Vista', 'Walk', 'Walks', 'Wall', 'Way',
         'Ways', 'Well', 'Wells')
 
-    postal_code_formats = ('?%? %?%', '?%?-%?%', '?%?%?%')
+    postal_code_formats = ('?%? %?%', '?%?%?%')
 
     provinces = (
         'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick',


### PR DESCRIPTION
According to Canada Post's website, only the format '?%? %?%' is valid. '?%?%?%' might be acceptable for testing but '?%?-%?%' isn't a case for valid data.

http://www.canadapost.ca/tools/pg/manual/PGaddress-e.asp#1402170
