### PR TITLE
Added function to get a list of results from a provider

### DIFF
--- a/faker/generator.py
+++ b/faker/generator.py
@@ -45,6 +45,7 @@ class Generator(object):
         for p in providers:
             if provider == p.__provider__:
                 data_provider = self.provider(p.__provider__)
+                break
         if data_provider:
             try:
                 if function:
@@ -54,7 +55,7 @@ class Generator(object):
                 for i in range(0,amount):
                     elems.append(data_provider())
                 return elems
-            except Exception, e:
+            except Exception as excpt:
                 raise AttributeError('Uknown function "{0}"'.format(function))
         else:
             raise AttributeError('Uknown provider "{0}"'.format(provider))


### PR DESCRIPTION
First of all, thank you for this great package. It's powerful yet simple. But I found something that could be really handy and yet is not there. I needed to sent templates to a printer with different data (that's where faker comes to place) and I noticed there was no way to just get a list of names or addresses. And I really needed this because making a loop inside my module would be pointless and I need this to be fast. So I created this little module that would return a list of any provider by the amount you want and with the specific function you want.

It's just as simple as:

``` python
>>> from faker import Factory
>>> fake = Factory.create()
>>> fake.get_list_of('person', 5, 'name')
[u'Christian Greenholt', u'Jasen Dach', u'Dr. Magali Hansen', u'Mr. Cora Abbott V', u'Justice Hagenes']
>>> fake.get_list_of('company', 5)
[u'Batz-Blanda', u'Langworth-Kshlerin', u'Ankunding Ltd', u'Berge, Hessel and Hickle', u'Senger, Rowe and Haley']
```
