### PR TITLE
Improve names in nl_NL provider

### DIFF
--- a/faker/providers/nl_NL/person.py
+++ b/faker/providers/nl_NL/person.py
@@ -8,12 +8,10 @@ class Provider(PersonProvider):
         '{{first_name_male}} {{last_name}}',
         '{{first_name_male}} {{last_name}}',
         '{{first_name_male}} {{last_name}}',
-        '{{first_name_male}} {{last_name}} {{last_name}}',
         '{{first_name_male}} {{last_name}}-{{last_name}}',
         '{{first_name_female}} {{last_name}}',
         '{{first_name_female}} {{last_name}}',
         '{{first_name_female}} {{last_name}}',
-        '{{first_name_female}} {{last_name}} {{last_name}}',
         '{{first_name_female}} {{last_name}}-{{last_name}}',
     )
 


### PR DESCRIPTION
Improved names in the nl_NL provider (aka Dutch), allowing direct use of `first_name_male` and `first_name_female`; as well as conforming to http://nl.wikipedia.org/wiki/Achternaam#Naamswijziging / http://en.wikipedia.org/wiki/Dutch_name#Dutch_naming_law_.28surnames.29 by adding a "-" between the two last names when someone is married.
