### PR TITLE
Implemented ssn for nl_NL using BSN

### DIFF
--- a/faker/providers/nl_NL/ssn.py
+++ b/faker/providers/nl_NL/ssn.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from ..ssn import Provider as SsnProvider
+import random
+
+
+class Provider(SsnProvider):
+    
+    # the Dutch "burgerservicenummer (BSN)" needs to pass the "11-proef",
+    # which is a check digit approach; this function essentially reverses
+    # the checksum steps to create a random valid BSN (which is 9 digits)
+    @classmethod
+    def ssn(cls):
+        def _checksum(digits):
+            factors = (9, 8, 7, 6, 5, 4, 3, 2, -1)
+            s = 0
+            for i in range(len(digits)):
+                s += digits[i] * factors[i]
+            return s
+
+        while True:
+            # create an array of first 8 elements initialized randomly
+            digits = random.sample(range(10), 8)
+            # sum those 8 digits according to (part of) the "11-proef"
+            s = _checksum(digits)
+            # determine the last digit to make it qualify the test
+            digits.append((s % 11) % 10)
+            # repeat steps until it does qualify the test
+            if (0 == (_checksum(digits) % 11)):
+                break
+        
+        # build the resulting BSN
+        bsn = "".join([str(e) for e in digits])
+        # finally return our random but valid BSN
+        return bsn
+  


### PR DESCRIPTION
Inspired by the `ssn` implementation found in the "en_CA" provider, this implementation provides random Dutch "burgerservicenummer (BSN)" as `ssn` in the "nl_NL" domain that will pass the related checksum method. See http://nl.wikipedia.org/wiki/Burgerservicenummer (in Dutch) for details on the BSN.

Example usage:

```
from faker import Faker
fake = Faker('nl_NL')
fake.ssn()
```
