### PR TITLE
Adding an implementation of `ssn` provider for the it_IT locale.

### DIFF
--- a/faker/providers/it_IT/ssn.py
+++ b/faker/providers/it_IT/ssn.py
@@ -33,5 +33,5 @@ class Provider(SsnProvider):
 
     @classmethod
     def ssn(cls):
-        code = cls.bothify(cls.fiscal_code_format).encode('ascii').upper()
+        code = cls.bothify(cls.fiscal_code_format).upper()
         return code + checksum(code)


### PR DESCRIPTION
This implementation generates fake syntactically correct italian fiscal codes.
The checksum character is calculated accordingly to
http://en.wikipedia.org/wiki/Italian_fiscal_code_card.
