### PR TITLE
Fixed date_time_ad method

### DIFF
--- a/faker/providers/date_time.py
+++ b/faker/providers/date_time.py
@@ -243,7 +243,12 @@ class Provider(BaseProvider):
         :example DateTime('1265-03-22 21:15:52')
         :return datetime
         """
-        return datetime.fromtimestamp(random.randint(-62135600400, int(time())))
+        ts = random.randint(-62135600400, int(time()))
+        # NOTE: using datetime.fromtimestamp(ts) directly will raise
+        #       a "ValueError: timestamp out of range for platform time_t"
+        #       on some platforms due to system C functions;
+        #       see http://stackoverflow.com/a/10588133/2315612
+        return datetime.fromtimestamp(0) + timedelta(seconds=ts)
 
     @classmethod
     def iso8601(cls):


### PR DESCRIPTION
Fixes #118 by using a `fromtimestamp(0) + timedelta(seconds=ts)` approach, rather than a direct `fromtimestamp(ts)` (which fails on some platforms). This solves the `ValueError: timestamp out of range for platform time_t` as seen on some platforms (like my 32-bit Xubuntu 14.04 virtual machine using Python 2.7.6).

See http://stackoverflow.com/a/10588133/2315612 for details. I've included a note with this reference saying _'using datetime.fromtimestamp(ts) directly will raise a "ValueError: timestamp out of range for platform time_t" on some platforms due to system C functions'_ in-line. This is to help developers understand why this approach is needed and shouldn't be reverted.
