### PR TITLE
Simplified getting __lang__ from provider

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -22,7 +22,7 @@ class Documentor(object):
         formatters = []
         providers = self.generator.get_providers()
         for provider in providers[::-1]:  # reverse
-            if locale and self.generator.provider(self.get_provider_name(provider)).__lang__ != locale:
+            if locale and provider.__lang__ != locale:
                 continue
             formatters.append(
                 (provider, self.get_provider_formatters(provider, **kwargs))


### PR DESCRIPTION
Looking into how `python -m faker > docs.txt` works to generate documentation, noticed that the approach to determine the `__lang__` of a provider was a bit strange. Therefore this simplification to help maintenance... 

Background: the following works interactively:

```
>>> from faker import Faker
>>> fake = Faker('nl_NL')
>>> for p in fake.get_providers():
...     print p.__lang__, '\t', p.__provider__
... 
None    user_agent
nl_NL   ssn
nl_NL   phone_number
None    python
None    profile
nl_NL   person
None    misc
None    lorem
None    job
None    internet
None    file
None    date_time
None    credit_card
en_US   company
None    color
nl_NL   address
None    base
>>>
```

Note also how the `company` provider is "en_US" (the default) as that hasn't been localized (yet) for "nl_NL".
