### PR TITLE
Simplified getting name of provider

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -86,8 +86,4 @@ class Documentor(object):
 
     @staticmethod
     def get_provider_name(provider_class):
-        name = provider_class.__module__.split('.')[-1]
-        if name == 'providers':
-            name = 'base'
-        return name
-
+        return provider_class.__provider__


### PR DESCRIPTION
Looking into how python -m faker > docs.txt works to generate documentation, noticed that getting the name of a provider inside `Documentor.get_provider_name()` (a static method) was a bit complicated. Therefore this simplification to help maintenance...

Background: the following works interactively (with or without this PR applied):

```
>>> from faker import Faker
>>> from faker.documentor import Documentor
>>> fake = Faker('nl_NL')
>>> for p in fake.get_providers():
...   print p.__provider__, '\t', Documentor.get_provider_name(p)
... 
user_agent  user_agent
ssn     ssn
phone_number    phone_number
python  python
profile     profile
person  person
misc    misc
lorem   lorem
job     job
internet    internet
file    file
date_time   date_time
credit_card     credit_card
company     company
color   color
address     address
base    base
>>> 
```
