### PR TITLE
Fixed postcode in NLD

### DIFF
--- a/faker/providers/nl_NL/address.py
+++ b/faker/providers/nl_NL/address.py
@@ -9,7 +9,7 @@ class Provider(AddressProvider):
 
     street_suffixes = ('baan', 'boulevard', 'dreef', 'hof', 'laan', 'pad', 'ring', 'singel', 'steeg', 'straat', 'weg',)
 
-    postcode_formats = ('####??', '#### ??')
+    postcode_formats = ('%###??', '%### ??')
 
 
     city_formats = ('{{city}}')


### PR DESCRIPTION
The 4 digit numerical part of Dutch postcodes is between 1000 and 9999 inclusive; see http://nl.wikipedia.org/wiki/Postcode#Postcodes_in_Nederland (in Dutch).
