### PR TITLE
Applied consistent coding=utf-8 (PEP 0263)

### DIFF
--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 VERSION = '0.4.0'
 
 

--- a/faker/__main__.py
+++ b/faker/__main__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 
 if __name__ == "__main__":
 

--- a/faker/bin/faker
+++ b/faker/bin/faker
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding=utf-8
+
 from faker.cli import execute_from_command_line
 
 if __name__ == '__main__':

--- a/faker/build_docs.py
+++ b/faker/build_docs.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import print_function
 from __future__ import unicode_literals
 import os

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from __future__ import print_function
 

--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 import inspect
 from faker import utils

--- a/faker/factory.py
+++ b/faker/factory.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from __future__ import absolute_import
 import locale as pylocale

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 import re
 import random

--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import re
 import random
 import string

--- a/faker/providers/address.py
+++ b/faker/providers/address.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from decimal import Decimal
 import random

--- a/faker/providers/color.py
+++ b/faker/providers/color.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from faker.providers import BaseProvider
 
 __author__ = 'joke2k'

--- a/faker/providers/company.py
+++ b/faker/providers/company.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 

--- a/faker/providers/credit_card.py
+++ b/faker/providers/credit_card.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 from .date_time import Provider as DateTimeProvider

--- a/faker/providers/date_time.py
+++ b/faker/providers/date_time.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 import random

--- a/faker/providers/file.py
+++ b/faker/providers/file.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from faker.providers import BaseProvider
 

--- a/faker/providers/internet.py
+++ b/faker/providers/internet.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 import random

--- a/faker/providers/job.py
+++ b/faker/providers/job.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from . import BaseProvider
 from .. import Generator
 

--- a/faker/providers/lorem.py
+++ b/faker/providers/lorem.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 

--- a/faker/providers/misc.py
+++ b/faker/providers/misc.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 from . import date_time

--- a/faker/providers/miscelleneous.py
+++ b/faker/providers/miscelleneous.py
@@ -1,2 +1,4 @@
+# coding=utf-8
+
 # module provided just for backward compatibility
 from .misc import *

--- a/faker/providers/person.py
+++ b/faker/providers/person.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 

--- a/faker/providers/phone_number.py
+++ b/faker/providers/phone_number.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 

--- a/faker/providers/profile.py
+++ b/faker/providers/profile.py
@@ -1,6 +1,10 @@
+# coding=utf-8
+
 from . import BaseProvider
 from .. import Generator
 import itertools
+
+
 class Provider(BaseProvider):
 	"""
 	This provider is a collection of functions to generate personal profiles and identities.

--- a/faker/providers/python.py
+++ b/faker/providers/python.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 from decimal import Decimal

--- a/faker/providers/ssn.py
+++ b/faker/providers/ssn.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 

--- a/faker/providers/user_agent.py
+++ b/faker/providers/user_agent.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 from . import BaseProvider
 from . import date_time

--- a/faker/tests.py
+++ b/faker/tests.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8
+# coding=utf-8
 
 from __future__ import unicode_literals
 import unittest

--- a/faker/utils/__init__.py
+++ b/faker/utils/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 def is_string(var):
     try:
         return isinstance(var, basestring)

--- a/faker/utils/datetime_safe.py
+++ b/faker/utils/datetime_safe.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # From django.utils.datetime_safe
 
 # Python's datetime strftime doesn't handle dates before 1900.
@@ -8,6 +10,7 @@
 #
 # >>> datetime_safe.date(1850, 8, 2).strftime("%Y/%m/%d was a %A")
 # '1850/08/02 was a Friday'
+
 from __future__ import unicode_literals
 from datetime import date as real_date, datetime as real_datetime
 import re

--- a/faker/utils/decorators.py
+++ b/faker/utils/decorators.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from functools import wraps
 
 from faker.utils import text

--- a/faker/utils/text.py
+++ b/faker/utils/text.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import re
 import unicodedata
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import os
 from setuptools import setup, find_packages


### PR DESCRIPTION
Applied consistent `# coding=utf-8` (see PEP 0263) to all of `faker` except the localized providers... which in fact may require it the most ;-)

Suggesting that localized providers are also made consistent using additional PRs (one for each locale).
