### PR TITLE
pt_BR: names do not contain '-' and implements catch_phrase

### DIFF
--- a/faker/providers/pt_BR/company.py
+++ b/faker/providers/pt_BR/company.py
@@ -26,14 +26,39 @@ class Provider(CompanyProvider):
     )
 
     attributes = (
-        'de maneira eficaz', 'mais rapidamentet', 'mais facilmente', 'simplesmente', 'com toda a tranquilidade',
-        'antes de tudo', 'naturellemente', 'sem preocupação', 'em estado puro', 'com força total',
+        'de maneira eficaz', 'mais rapidamente', 'mais facilmente', 'simplesmente', 'com toda a tranquilidade',
+        'antes de tudo', 'naturalmente', 'sem preocupação', 'em estado puro', 'com força total',
         'direto da fonte', 'com confiança'
     )
 
     company_suffixes = ('S/A', 'S.A.', 'Ltda.', '- ME', '- EI', 'e Filhos')
 
+    @classmethod
+    def catch_phrase_noun(cls):
+        """
+        Returns a random catch phrase noun.
+        """
+        return cls.random_element(cls.nouns)
 
+    @classmethod
+    def catch_phrase_attribute(cls):
+        """
+        Returns a random catch phrase attribute.
+        """
+        return cls.random_element(cls.attributes)
 
+    @classmethod
+    def catch_phrase_verb(cls):
+        """
+        Returns a random catch phrase verb.
+        """
+        return cls.random_element(cls.verbs)
 
-
+    def catch_phrase(self):
+        """
+        :example 'a segurança de evoluir sem preocupação'
+        """
+        pattern = self.random_element(self.catch_phrase_formats)
+        catch_phrase = self.generator.parse(pattern)
+        catch_phrase = catch_phrase[0].upper() + catch_phrase[1:]
+        return catch_phrase

--- a/faker/providers/pt_BR/person.py
+++ b/faker/providers/pt_BR/person.py
@@ -13,8 +13,8 @@ class Provider(PersonProvider):
         '{{first_name}} {{last_name}}',
         '{{first_name}} {{last_name}}',
         '{{first_name}} {{prefix}} {{last_name}}',
-        '{{first_name}} {{last_name}}-{{last_name}}',
-        '{{first_name}}-{{first_name}} {{last_name}}',
+        '{{first_name}} {{last_name}} {{last_name}}',
+        '{{first_name}} {{first_name}} {{last_name}}',
     )
 
     first_names = (


### PR DESCRIPTION
names in Portuguese of Brazil does not contain '-'
fix spelling errors and finalizes the implementation of 'catch_phrase' based on fr_FR

```python
>>> from faker import Factory
>>> f = Factory()
>>> g = f.create('pt_BR')
>>> for i in range(10):
...     print g.name()
...     
... 
Luigi Fernandes
Ana Santos
Bárbara Esther Correia
Stephany Fernanda Dias
Sarah Pinto
Gabriel Catarina Barros
Vitória Ribeiro Barros
Emanuelly Evelyn Ribeiro
Luiz Fernando Almeida
Nathan Martins
>>> for i in range(10):
...     print g.catch_phrase()
...     
... 
A segurança de realizar seus sonhos naturalmente
A arte de avançar com confiança
O poder de realizar seus sonhos com toda a tranquilidade
O prazer de realizar seus sonhos direto da fonte
A certeza de mudar antes de tudo
O direito de atingir seus objetivos mais facilmente
A segurança de mudar mais facilmente
O conforto de avançar direto da fonte
O conforto de conseguir antes de tudo
A vantagem de inovar em estado puro
>>> 
```