### PR TITLE
Ensure choice_distribution always uses floats

### DIFF
--- a/faker/utils/distribution.py
+++ b/faker/utils/distribution.py
@@ -20,7 +20,7 @@ def choice_distribution(a, p):
 
     cdf = list(cumsum(p))
     normal = cdf[-1]
-    cdf2 = [i / normal for i in cdf]
+    cdf2 = [float(i) / float(normal) for i in cdf]
     uniform_sample = random_sample()
     idx = bisect.bisect_right(cdf2, uniform_sample)
 


### PR DESCRIPTION
Fixes a bug in versions of Python in which `integer / integer` returns another
integer instead of a float.

Closes joke2k/faker#171

(I tried updating the tests for this, but frankly the distribution code is over my head.)
