### PR TITLE
added preliminary support for localized providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
   only:
     - master
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/faker/providers/internet.py
+++ b/faker/providers/internet.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from . import BaseProvider
 import random
 
-from faker.providers.lorem import Provider as Lorem
+from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import slugify, slugify_domain
 
 

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -1,0 +1,2 @@
+localized = True
+default_locale = 'la'

--- a/faker/providers/lorem/el_GR/__init__.py
+++ b/faker/providers/lorem/el_GR/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from ..lorem import Provider as LoremProvider
+from ..la import Provider as LoremProvider
 
 
 class Provider(LoremProvider):

--- a/faker/providers/lorem/la/__init__.py
+++ b/faker/providers/lorem/la/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from . import BaseProvider
+from ... import BaseProvider
 
 
 class Provider(BaseProvider):

--- a/faker/providers/python.py
+++ b/faker/providers/python.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from . import BaseProvider
 from decimal import Decimal
-from .lorem import Provider as Lorem
+from .lorem.la import Provider as Lorem
 import sys
 
 

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -1,0 +1,6 @@
+import os
+
+
+def list_module(module):
+    path = os.path.dirname(module.__file__)
+    return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i))]


### PR DESCRIPTION
This is a backwards compatibile way to load providers to get us going. This way we can convert them as we go.

This also drops support for Python 2.6
