### PR TITLE
ne_np has been added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Included localized providers:
 * [ko_KR](http://fake-factory.readthedocs.org/en/master/locales/ko_KR.html)
 * [lt_LT](http://fake-factory.readthedocs.org/en/master/locales/lt_LT.html)
 * [lv_LV](http://fake-factory.readthedocs.org/en/master/locales/lv_LV.html)
+* [ne_NP](http://fake-factory.readthedocs.org/en/master/locales/ne_NP.html)
 * [nl_NL](http://fake-factory.readthedocs.org/en/master/locales/nl_NL.html)
 * [pl_PL](http://fake-factory.readthedocs.org/en/master/locales/pl_PL.html)
 * [pt_BR](http://fake-factory.readthedocs.org/en/master/locales/pt_BR.html)


### PR DESCRIPTION
The Provider ne_NP wasn't listed in readme. It has now been listed. 