### PR TITLE
Faker is not actually zip safe.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ NEWS = io.open(os.path.join(here, 'CHANGELOG.rst'), encoding="utf8").read()
 
 version = '0.5.0'
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-zip_safe = not on_rtd
-
 setup(
     name='fake-factory',
     version=version,
@@ -43,5 +40,5 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     platforms=["any"],
     test_suite='faker.tests',
-    zip_safe=zip_safe,
+    zip_safe=False,
 )


### PR DESCRIPTION
The code in the [loading](https://github.com/joke2k/faker/blob/master/faker/utils/loading.py) module will error if called when Faker is installed as a zip file because it's trying to look in a directory that doesn't exist.

I noticed this because faker works when installed from pip but if I do setup.py install on a package with faker as a dependency it will install in a broken state that errors when I try to load the module the first time.