### PR TITLE
Make faker zipsafe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,13 @@ Changelog
 
 * Localized providers
 * Updated ko_KR provider. Thanks Lee Yeonjae.
-* Added pt_PT provider. Thanks JoÃ£o Delgado.
+* Added pt_PT provider. Thanks João Delgado.
 * Fixed mispellings for en_US company provider. Thanks Greg Meece.
-* Added currency provider. Thanks Wiktor ÅšlÄ™czka
+* Added currency provider. Thanks Wiktor Ślęczka
 * Ensure choice_distribution always uses floats. Thanks Katy Lavallee.
 * Added uk_UA provider. Thanks Cyril Tarasenko.
 * Fixed encoding issues with README, CHANGELOG and setup.py. Thanks Sven-Hendrik Haase.
-* Added Turkish person names and phone number patterns. Thanks Murat Ã‡orlu.
+* Added Turkish person names and phone number patterns. Thanks Murat Çorlu.
 * Added ne_NP provider. Thanks Sudip Kafle.
 * Added provider for Austria de_AT. Thanks Bernhard Essl.
 

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -1,20 +1,16 @@
 import os
 from importlib import import_module
 
-try:
-    import pkgutil
-
-    iter_modules = pkgutil.iter_modules
-
-    def list_module(module):
-        path = os.path.dirname(module.__file__)
-        return [name for finder, name, is_pkg in iter_modules([path]) if is_pkg]
-
-except (ImportError, NameError):
-
-    def list_module(module):
-        path = os.path.dirname(module.__file__)
-        return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
+def list_module(module):
+    path = os.path.dirname(module.__file__)
+    try:
+        import pkgutil
+        modules = [name for finder, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
+        if len(modules) > 0:
+            return modules
+    except (ImportError, AttributeError):
+        pass
+    return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
 
 
 def find_available_locales(providers):

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -1,10 +1,20 @@
 import os
 from importlib import import_module
 
+try:
+    import pkgutil
 
-def list_module(module):
-    path = os.path.dirname(module.__file__)
-    return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
+    iter_modules = pkgutil.iter_modules
+
+    def list_module(module):
+        path = os.path.dirname(module.__file__)
+        return [name for finder, name, is_pkg in iter_modules([path]) if is_pkg]
+
+except (ImportError, NameError):
+
+    def list_module(module):
+        path = os.path.dirname(module.__file__)
+        return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
 
 
 def find_available_locales(providers):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,13 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = io.open(os.path.join(here, 'README.rst'), encoding="utf8").read()
 NEWS = io.open(os.path.join(here, 'CHANGELOG.rst'), encoding="utf8").read()
 
+# this module can be zip-safe if pkgutil.iter_modules is available since it handles finding
+# modules in zipimporter.
+try:
+    import pkgutil
+    zip_safe = hasattr(pkgutil, "iter_modules")
+except ImportError:
+    zip_safe = False
 
 version = '0.5.0'
 
@@ -40,5 +47,5 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     platforms=["any"],
     test_suite='faker.tests',
-    zip_safe=False,
+    zip_safe=zip_safe,
 )


### PR DESCRIPTION
I was looking to use faker within a pex which zips up all library dependencies into a single hermetically sealed binary. The loader was breaking since it required the files to be exploded.