### PR TITLE
Make faker zipsafe.

### DIFF
--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -99,7 +99,6 @@ class UtilsTestCase(unittest.TestCase):
         result = find_available_locales(DEFAULT_PROVIDERS)
         self.assertNotEqual(len(result), 0)
 
-    @unittest.skipUnless(__import__("pkgutil") is not None)
     def test_find_available_locales_without_pkgutil_iter_modules(self):
         import pkgutil
         iter_modules = pkgutil.iter_modules

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -99,15 +99,6 @@ class UtilsTestCase(unittest.TestCase):
         result = find_available_locales(DEFAULT_PROVIDERS)
         self.assertNotEqual(len(result), 0)
 
-    def test_find_available_locales_without_pkgutil_iter_modules(self):
-        import pkgutil
-        iter_modules = pkgutil.iter_modules
-        delattr(pkgutil, "iter_modules")
-        try:
-            self.test_find_available_locales()
-        finally:
-            setattr(pkgutil, "iter_modules", iter_modules)
-
 class FactoryTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -99,6 +99,18 @@ class UtilsTestCase(unittest.TestCase):
         result = find_available_locales(DEFAULT_PROVIDERS)
         self.assertNotEqual(len(result), 0)
 
+    def test_find_available_locales_without_pkgutil_iter_modules(self):
+        try:
+            import pkgutil
+            iter_modules = pkgutil.iter_modules
+            delattr(pkgutil, "iter_modules")
+            try:
+                self.test_find_available_locales()
+            finally:
+                setattr(pkgutil, "iter_modules", iter_modules)
+        except (ImportError, AttributeError):
+            pass
+
 class FactoryTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -99,17 +99,15 @@ class UtilsTestCase(unittest.TestCase):
         result = find_available_locales(DEFAULT_PROVIDERS)
         self.assertNotEqual(len(result), 0)
 
+    @unittest.skipUnless(__import__("pkgutil") is not None)
     def test_find_available_locales_without_pkgutil_iter_modules(self):
+        import pkgutil
+        iter_modules = pkgutil.iter_modules
+        delattr(pkgutil, "iter_modules")
         try:
-            import pkgutil
-            iter_modules = pkgutil.iter_modules
-            delattr(pkgutil, "iter_modules")
-            try:
-                self.test_find_available_locales()
-            finally:
-                setattr(pkgutil, "iter_modules", iter_modules)
-        except (ImportError, AttributeError):
-            pass
+            self.test_find_available_locales()
+        finally:
+            setattr(pkgutil, "iter_modules", iter_modules)
 
 class FactoryTestCase(unittest.TestCase):
 

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -1,16 +1,13 @@
 import os
 from importlib import import_module
+import pkgutil
 
 
 def list_module(module):
     path = os.path.dirname(module.__file__)
-    try:
-        import pkgutil
-        modules = [name for finder, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
-        if len(modules) > 0:
-            return modules
-    except (ImportError, AttributeError):
-        pass
+    modules = [name for finder, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
+    if len(modules) > 0:
+        return modules
     return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
 
 

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -4,6 +4,13 @@ from importlib import import_module
 
 def list_module(module):
     path = os.path.dirname(module.__file__)
+    try:
+        import pkgutil
+        modules = [name for finder, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
+        if len(modules) > 0:
+            return modules
+    except (ImportError, AttributeError):
+        pass
     return [i for i in os.listdir(path) if os.path.isdir(os.path.join(path, i)) and not i.startswith('_')]
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,14 @@ if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
         (sys.version_info[0] == 3 and sys.version_info[1] < 1)):
     install_requires.append('importlib')
 
-# this module can be zip-safe if pkgutil.iter_modules is available since it handles finding
-# modules in zipimporter.
+# this module can be zip-safe if the zipimporter implements iter_modules or if
+# pkgutil.iter_importer_modules has registered a dispatch for the zipimporter.
 try:
     import pkgutil
-    zip_safe = hasattr(pkgutil, "iter_modules")
-except ImportError:
+    import zipimport
+    zip_safe = hasattr(zipimport.zipimporter, "iter_modules") or \
+        zipimport.zipimporter in pkgutil.iter_importer_modules.registry.keys()
+except (ImportError, AttributeError):
     zip_safe = False
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,14 @@ if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
         (sys.version_info[0] == 3 and sys.version_info[1] < 1)):
     install_requires.append('importlib')
 
+# this module can be zip-safe if pkgutil.iter_modules is available since it handles finding
+# modules in zipimporter.
+try:
+    import pkgutil
+    zip_safe = hasattr(pkgutil, "iter_modules")
+except ImportError:
+    zip_safe = False
+
 setup(
     name='fake-factory',
     version=version,
@@ -46,6 +54,6 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     platforms=["any"],
     test_suite='faker.tests',
-    zip_safe=False,
+    zip_safe=zip_safe,
     install_requires=install_requires,
 )


### PR DESCRIPTION
For loading.find_available_locales, use pkgutil.iter_modules (which works with the zipimporter) to locate the locale sub-modules.