### PR TITLE
Added file_extension and file_name methods to file provider

### DIFF
--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -123,7 +123,7 @@ class Provider(BaseProvider):
     audio_file_extenstions = (
         "flac",
         "mp3",
-        "wav"
+        "wav",
     )
 
     image_file_extenstions = (
@@ -137,7 +137,7 @@ class Provider(BaseProvider):
 
     text_file_extensions = (
         "css",
-        "csv"
+        "csv",
         "html",
         "js",
         "json",
@@ -148,14 +148,14 @@ class Provider(BaseProvider):
         "mp4",
         "avi",
         "mov",
-        "webm"
+        "webm",
     )
 
     file_extensions = {
         "audio": audio_file_extenstions,
         "image": image_file_extenstions,
         "text": text_file_extensions,
-        "video": video_file_extensions
+        "video": video_file_extensions,
     }
 
 

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -171,6 +171,7 @@ class Provider(BaseProvider):
     def file_name(cls, category=None, extension=None):
         """
         :param category: audio|image|text|video
+        :param extension: file extension
         """
         extension = extension if extension else cls.file_extension(category)
         filename = WordProvider.word()

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 from .. import BaseProvider
+from ..lorem import word
 
 
 class Provider(BaseProvider):
@@ -119,6 +120,45 @@ class Provider(BaseProvider):
         'video': video_mime_types
     }
 
+    audio_file_extenstions = (
+        "flac",
+        "mp3",
+        "wav"
+    )
+
+    image_file_extenstions = (
+        "bmp",
+        "gif",
+        "jpeg",
+        "jpg",
+        "png",
+        "tiff",
+    )
+
+    text_file_extensions = (
+        "css",
+        "csv"
+        "html",
+        "js",
+        "json",
+        "txt",
+    )
+
+    video_file_extensions = (
+        "mp4",
+        "avi",
+        "mov",
+        "webm"
+    )
+
+    file_extensions = {
+        "audio": audio_file_extenstions,
+        "image": image_file_extenstions,
+        "text": text_file_extensions,
+        "video": video_file_extensions
+    }
+
+
     @classmethod
     def mime_type(cls, category=None):
         """
@@ -127,3 +167,19 @@ class Provider(BaseProvider):
         category = category if category else cls.random_element(list(cls.mime_types.keys()))
         return cls.random_element(cls.mime_types[category])
 
+    @classmethod
+    def file_name(cls, category=None, extension=None):
+        """
+        :param category: audio|image|text|video
+        """
+        extension = extension if extension else cls.file_extension(category)
+        filename = word()
+        return '{0}.{1}'.format(filename, extension)
+
+    @classmethod
+    def file_extension(cls, category=None):
+        """
+        :param category: audio|image|text|video
+        """
+        category = category if category else cls.random_element(list(cls.file_extensions.keys()))
+        return cls.random_element(cls.file_extensions[category])

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 from .. import BaseProvider
-from ..lorem import word
+from ..lorem.la import Provider as WordProvider
 
 
 class Provider(BaseProvider):
@@ -173,7 +173,7 @@ class Provider(BaseProvider):
         :param category: audio|image|text|video
         """
         extension = extension if extension else cls.file_extension(category)
-        filename = word()
+        filename = WordProvider.word()
         return '{0}.{1}'.format(filename, extension)
 
     @classmethod


### PR DESCRIPTION
This pull request adds the `file_name` and `file_extenstion` methods to the file provider. It adds tuples of common file extensions and a dictionary of the categories. This allows the user to either select a category or a random one will be chosen. 

The `file_name` method uses the `lorem.Provider.word()` method to get a filename, and joins that with a random extension. Additionally, the `file_name` method can take an extenstion to use. If none is provided, a random one will be chosen.