### PR TITLE
Fix U.S. SSN generation

### DIFF
--- a/faker/providers/ssn/en_US/__init__.py
+++ b/faker/providers/ssn/en_US/__init__.py
@@ -4,4 +4,17 @@ from .. import Provider as BaseProvider
 
 
 class Provider(BaseProvider):
-    pass
+
+    @classmethod
+    def ssn(cls):
+        # Certain numbers are invalid for U.S. SSNs. The area (first 3 digits)
+        # cannot be 666 or 900-999. The group number (middle digits) cannot be
+        # 00. The serial (last 4 digits) cannot be 0000
+        area = BaseProvider.random_int(min=1, max=899)
+        if area == 666:
+            area += 1
+        group = BaseProvider.random_int(1, 99)
+        serial = BaseProvider.random_int(1, 9999)
+
+        ssn = "{0:03d}-{1:02d}-{2:04d}".format(area, group, serial)
+        return ssn

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -370,6 +370,19 @@ class FactoryTestCase(unittest.TestCase):
         sentence = provider.sentence(0)
         self.assertEqual(sentence, '')
 
+    def test_us_ssn_valid(self):
+        from faker.providers.ssn.en_US import Provider
+
+        provider = Provider(None)
+        for i in range(1000):
+            ssn = provider.ssn()
+            self.assertEqual(len(ssn), 11)
+            self.assertNotEqual(ssn[0], '9')
+            self.assertNotEqual(ssn[0:3], '666')
+            self.assertNotEqual(ssn[0:3], '000')
+            self.assertNotEqual(ssn[4:6], '00')
+            self.assertNotEqual(ssn[7:11], '0000')
+
 
 class GeneratorTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Certain numbers are invalid for U.S. SSNs. The area (first 3 digits)
cannot be 666 or 900-999. The group number (middle digits) cannot be 00.
The id (last 4 digits) cannot be 0000.

See http://www.socialsecurity.gov/employer/randomizationfaqs.html#a0=5
for details.

Fixes #260 