### PR TITLE
Fixed condition for None in geo_coordinate

### DIFF
--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -90,7 +90,7 @@ class Provider(BaseProvider):
         """
         Optionally center the coord and pick a point within radius.
         """
-        if not center:
+        if center is None:
             return Decimal(str(random.randint(-180000000, 180000000) / 1000000.0)).quantize(Decimal('.000001'))
         else:
             center = float(center)


### PR DESCRIPTION
The original check to see if nothing was supplied as a center was for falseness, which would cause random results if they intended to supply a center of 0.