### PR TITLE
Adds en_AU provider, adapted from PHP Faker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,7 @@ Included localized providers:
 -  `de\_DE <http://fake-factory.readthedocs.org/en/master/locales/de_DE.html>`__ - German
 -  `dk\_DK <http://fake-factory.readthedocs.org/en/master/locales/dk_DK.html>`__ - Danish
 -  `el\_GR <http://fake-factory.readthedocs.org/en/master/locales/el_GR.html>`__ - Greek
+-  `en\_AU <http://fake-factory.readthedocs.org/en/master/locales/en_AU.html>`__ - English (Australia)
 -  `en\_CA <http://fake-factory.readthedocs.org/en/master/locales/en_CA.html>`__ - English (Canada)
 -  `en\_GB <http://fake-factory.readthedocs.org/en/master/locales/en_GB.html>`__ - English (Great Britain)
 -  `en\_US <http://fake-factory.readthedocs.org/en/master/locales/en_US.html>`__ - English (United States)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,6 +134,7 @@ Included localized providers:
 -  `de\_DE <http://fake-factory.readthedocs.org/en/master/locales/de_DE.html>`__ - German
 -  `dk\_DK <http://fake-factory.readthedocs.org/en/master/locales/dk_DK.html>`__ - Danish
 -  `el\_GR <http://fake-factory.readthedocs.org/en/master/locales/el_GR.html>`__ - Greek
+-  `en\_AU <http://fake-factory.readthedocs.org/en/master/locales/en_AU.html>`__ - English (Australia)
 -  `en\_CA <http://fake-factory.readthedocs.org/en/master/locales/en_CA.html>`__ - English (Canada)
 -  `en\_GB <http://fake-factory.readthedocs.org/en/master/locales/en_GB.html>`__ - English (Great Britain)
 -  `en\_US <http://fake-factory.readthedocs.org/en/master/locales/en_US.html>`__ - English (United States)

--- a/faker/providers/address/en_AU/__init__.py
+++ b/faker/providers/address/en_AU/__init__.py
@@ -1,0 +1,109 @@
+from __future__ import unicode_literals
+
+from ..en import Provider as AddressProvider
+from faker.generator import random
+
+class Provider(AddressProvider):
+
+    city_prefixes = ('North', 'East', 'West', 'South', 'New', 'Lake', 'Port', 'St.')
+
+    city_suffixes = (
+        'town', 'ton', 'land', 'ville', 'berg', 'burgh', 'borough', 'bury', 'view', 'port', 'mouth', 'stad', 'furt',
+        'chester', 'mouth', 'fort', 'haven', 'side', 'shire')
+
+    building_number_formats = ('###', '##', '#')
+
+    street_suffixes = (
+        'Access', 'Alley', 'Alleyway', 'Amble', 'Anchorage', 'Approach', 'Arcade', 'Artery', 'Avenue', 'Basin',
+        'Beach', 'Bend', 'Block', 'Boulevard', 'Brace', 'Brae', 'Break', 'Bridge', 'Broadway', 'Brow', 'Bypass',
+        'Byway', 'Causeway', 'Centre', 'Centreway', 'Chase', 'Circle', 'Circlet', 'Circuit', 'Circus', 'Close',
+        'Colonnade', 'Common', 'Concourse', 'Copse', 'Corner', 'Corso', 'Court', 'Courtyard', 'Cove', 'Crescent',
+        'Crest', 'Cross', 'Crossing', 'Crossroad', 'Crossway', 'Cruiseway', 'Cul-de-sac', 'Cutting', 'Dale', 'Dell',
+        'Deviation', 'Dip', 'Distributor', 'Drive', 'Driveway', 'Edge', 'Elbow', 'End', 'Entrance', 'Esplanade',
+        'Estate', 'Expressway', 'Extension', 'Fairway', 'Fire Track', 'Firetrail', 'Flat', 'Follow', 'Footway',
+        'Foreshore', 'Formation', 'Freeway', 'Front', 'Frontage', 'Gap', 'Garden', 'Gardens', 'Gate', 'Gates',
+        'Glade', 'Glen', 'Grange', 'Green', 'Ground', 'Grove', 'Gully', 'Heights', 'Highroad', 'Highway', 'Hill',
+        'Interchange', 'Intersection', 'Junction', 'Key', 'Landing', 'Lane', 'Laneway', 'Lees', 'Line', 'Link',
+        'Little', 'Lookout', 'Loop', 'Lower', 'Mall', 'Meander', 'Mew', 'Mews', 'Motorway', 'Mount', 'Nook', 'Outlook',
+        'Parade', 'Park', 'Parklands', 'Parkway', 'Part', 'Pass', 'Path', 'Pathway', 'Piazza', 'Place', 'Plateau',
+        'Plaza', 'Pocket', 'Point', 'Port', 'Promenade', 'Quad', 'Quadrangle', 'Quadrant', 'Quay', 'Quays', 'Ramble',
+        'Ramp', 'Range', 'Reach', 'Reserve', 'Rest', 'Retreat', 'Ride', 'Ridge', 'Ridgeway', 'Right Of Way', 'Ring',
+        'Rise', 'River', 'Riverway', 'Riviera', 'Road', 'Roads', 'Roadside', 'Roadway', 'Ronde', 'Rosebowl', 'Rotary',
+        'Round', 'Route', 'Row', 'Rue', 'Run', 'Service Way', 'Siding', 'Slope', 'Sound', 'Spur', 'Square', 'Stairs',
+        'State Highway', 'Steps', 'Strand', 'Street', 'Strip', 'Subway', 'Tarn', 'Terrace', 'Thoroughfare', 'Tollway',
+        'Top', 'Tor', 'Towers', 'Track', 'Trail', 'Trailer', 'Triangle', 'Trunkway', 'Turn', 'Underpass', 'Upper',
+        'Vale', 'Viaduct', 'View', 'Villas', 'Vista', 'Wade', 'Walk', 'Walkway', 'Way', 'Wynd')
+
+    postcode_formats = (
+        # as per https://en.wikipedia.org/wiki/Postcodes_in_Australia
+        # NSW
+        '1###',
+        '20##', '21##', '22##', '23##', '24##', '25##',
+        '2619', '262#', '263#', '264#', '265#', '266#', '267#', '268#', '269#', '27##', '28##',
+        '292#', '293#', '294#', '295#', '296#', '297#', '298#', '299#',
+        # ACT
+        '02##',
+        '260#', '261#',
+        '290#', '291#', '2920',
+        # VIC
+        '3###',
+        '8###',
+        # QLD
+        '4###',
+        '9###',
+        # SA
+        '5###',
+        # WA
+        '6###',
+        # TAS
+        '7###',
+        # NT
+        '08##',
+        '09##',
+    )
+
+    states = (
+        'Australian Capital Territory', 'New South Wales', 'Northern Territory', 'Queensland', 'South Australia',
+        'Tasmania', 'Victoria', 'Western Australia')
+
+    states_abbr = (
+        'ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA')
+
+    city_formats = (
+        '{{city_prefix}} {{first_name}}{{city_suffix}}',
+        '{{city_prefix}} {{first_name}}',
+        '{{first_name}}{{city_suffix}}',
+        '{{last_name}}{{city_suffix}}',
+    )
+
+    street_name_formats = (
+        '{{first_name}} {{street_suffix}}',
+        '{{last_name}} {{street_suffix}}'
+    )
+
+    street_address_formats = (
+        '{{building_number}} {{street_name}}',
+        '{{secondary_address}}\n {{building_number}} {{street_name}}',
+    )
+
+    address_formats = (
+        "{{street_address}}\n{{city}}, {{state_abbr}}, {{postcode}}",
+    )
+
+    secondary_address_formats = ('Apt. ###', 'Flat ##', 'Suite ###', 'Unit ##', 'Level #', '### /', '## /', '# /')
+
+    @classmethod
+    def city_prefix(cls):
+        return cls.random_element(cls.city_prefixes)
+
+    @classmethod
+    def secondary_address(cls):
+        return cls.numerify(cls.random_element(cls.secondary_address_formats))
+
+    @classmethod
+    def state(cls):
+        return cls.random_element(cls.states)
+
+    @classmethod
+    def state_abbr(cls):
+        return cls.random_element(cls.states_abbr)

--- a/faker/providers/internet/en_AU/__init__.py
+++ b/faker/providers/internet/en_AU/__init__.py
@@ -1,0 +1,12 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from .. import Provider as InternetProvider
+
+
+class Provider(InternetProvider):
+
+    free_email_domains = (
+        'gmail.com', 'yahoo.com', 'hotmail.com', 'yahoo.com.au', 'hotmail.com.au',
+    )
+
+    tlds = ('com', 'com.au', 'org', 'org.au', 'net', 'net.au', 'biz', 'info', 'edu', 'edu.au')

--- a/faker/providers/phone_number/en_AU/__init__.py
+++ b/faker/providers/phone_number/en_AU/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+from .. import Provider as PhoneNumberProvider
+
+
+class Provider(PhoneNumberProvider):
+    formats = (
+        # Local calls
+        '#### ####',
+        '####-####',
+        '####.####',  # domain registrars apparently use this
+        '########',
+        # National dialing
+        '0{{area_code}} #### ####',
+        '0{{area_code}}-####-####',
+        '0{{area_code}}.####.####',
+        '0{{area_code}}########',
+        # Optional parenthesis
+        '(0{{area_code}}) #### ####',
+        '(0{{area_code}})-####-####',
+        '(0{{area_code}}).####.####',
+        '(0{{area_code}})########',
+        # International drops the 0
+        '+61 {{area_code}} #### ####',
+        '+61-{{area_code}}-####-####',
+        '+61.{{area_code}}.####.####',
+        '+61{{area_code}}########',
+        # 04 Mobile telephones (Australia-wide) mostly commonly written 4 - 3 - 3 instead of 2 - 4 - 4
+        '04## ### ###',
+        '04##-###-###',
+        '04##.###.###',
+        '+61 4## ### ###',
+        '+61-4##-###-###',
+        '+61.4##.###.###',
+    )
+
+    @classmethod
+    def area_code(cls):
+        return cls.numerify(cls.random_element(
+            ['2',
+             '3',
+             '7',
+             '8']))
+
+    def phone_number(self):
+        pattern = self.random_element(self.formats)
+        return self.numerify(self.generator.parse(pattern))


### PR DESCRIPTION
Hello,

I've submitted a few accepted patches for the en_AU provider for the PHP Faker implementation recently; as a 'native' Python developer it only makes sense to contribute a provider back to this library.

Let me know if OK.

Reference implementation this is based from at https://github.com/fzaninotto/Faker/tree/master/src/Faker/Provider/en_AU