### PR TITLE
Update ja_JP for username and domain

### DIFF
--- a/faker/providers/internet/ja_JP/__init__.py
+++ b/faker/providers/internet/ja_JP/__init__.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from .. import Provider as InternetProvider
+from faker.utils.decorators import slugify
+
+
+class Provider(InternetProvider):
+    user_name_formats = (
+        '{{last_romanized_name}}.{{first_romanized_name}}',
+        '{{first_romanized_name}}.{{last_romanized_name}}',
+        '{{first_romanized_name}}##',
+        '?{{last_romanized_name}}',
+    )
+    tlds = ('com', 'com', 'com', 'net', 'org', 'jp', 'jp', 'jp')
+
+    @slugify
+    def domain_word(self):
+        return self.generator.format('last_romanized_name')

--- a/faker/providers/person/ja_JP/__init__.py
+++ b/faker/providers/person/ja_JP/__init__.py
@@ -81,6 +81,49 @@ class Provider(PersonProvider):
         'ワカマツ', 'ワタナベ',
     )
 
+    romanized_formats = (
+        '{{first_romanized_name_female}} {{last_romanized_name}}',
+        '{{first_romanized_name_male}} {{last_romanized_name}}',
+    )
+
+    first_romanized_names_female = (
+        'Akira', 'Akemi', 'Asuka',
+        'Kaori', 'Kana', 'Kumiko',
+        'Sayuri',
+        'Chiyo', 'Tsubasa', 'Tomomi',
+        'Naoko', 'Nanaka',
+        'Hanako', 'Haruka',
+        'Maaya', 'Mai', 'Miki', 'Momoko',
+        'Yui', 'Yoko', 'Yumiko',
+        'Rei', 'Rika',
+    )
+
+    first_romanized_names_male = (
+        'Akira', 'Atsushi', 'Osamu',
+        'Kyosuke', 'Kenichi',
+        'Jun', 'Sotaro',
+        'Taichi', 'Takuma', 'Taro', 'Tsubasa', 'Tomoya',
+        'Naoki', 'Naoto'
+        'Hideki', 'Hiroshi',
+        'Manabu', 'Mituru', 'Minoru', 'Hiroki',
+        'Yuta', 'Yasuhiro', 'Yoichi', 'Yosuke',
+        'Ryosuke', 'Ryohei',
+    )
+
+    first_romanized_names = first_romanized_names_male + first_romanized_names_female
+
+    last_romanized_names = (
+        'Aota', 'Aoyama', 'Ishida', 'Idaka', 'Ito', 'Uno', 'Ekoda', 'Ogaki',
+        'Kato', 'Kano', 'Kijima', 'Kimura', 'Kiriyama', 'Kudo', 'Koizumi', 'Kobayashi', 'Kondo',
+        'Saito', 'Sakamoto', 'Sasaki', 'Sato', 'Sasada', 'Suzuki', 'Sugiyama',
+        'Takahashi', 'Tanaka', 'Tanabe', 'Tsuda', 'Tsuchiya',
+        'Nakajima', 'Nakamura', 'Nagisa', 'Nakatsugawa', 'Nishinosono', 'Nomura',
+        'Harada', 'Hamada', 'Hirokawa', 'Fujimoto',
+        'Matsumoto', 'Miyake', 'Miyagawa', 'Murayama',
+        'Yamagishi', 'Yamaguchi', 'Yamada', 'Yamamoto', 'Yoshida', 'Yoshimoto',
+        'Wakamatsu', 'Watanabe',
+    )
+
     def kana_name(self):
         '''
         @example 'アオタ アキラ'
@@ -109,3 +152,32 @@ class Provider(PersonProvider):
         @example 'アオタ'
         '''
         return cls.random_element(cls.last_kana_names)
+
+    def romanized_name(self):
+        '''
+        @example 'Akira Aota'
+        '''
+        pattern = self.random_element(self.romanized_formats)
+        return self.generator.parse(pattern)
+
+    @classmethod
+    def first_romanized_name(cls):
+        '''
+        @example 'Akira'
+        '''
+        return cls.random_element(cls.first_romanized_names)
+
+    @classmethod
+    def first_romanized_name_female(cls):
+        return cls.random_element(cls.first_romanized_names_female)
+
+    @classmethod
+    def first_romanized_name_male(cls):
+        return cls.random_element(cls.first_romanized_names_male)
+
+    @classmethod
+    def last_romanized_name(cls):
+        '''
+        @example 'Aota'
+        '''
+        return cls.random_element(cls.last_romanized_names)

--- a/faker/tests/ja_JP/__init__.py
+++ b/faker/tests/ja_JP/__init__.py
@@ -6,6 +6,7 @@ import unittest
 import re
 
 from faker import Factory
+from faker.utils import text
 from .. import string_types
 
 
@@ -83,6 +84,23 @@ class ja_JP_FactoryTestCase(unittest.TestCase):
         assert isinstance(company, string_types)
         assert any(prefix in company for prefix in prefixes)
         assert any(company.startswith(prefix) for prefix in prefixes)
+
+    def test_ja_JP_internet(self):
+        from faker.providers.person.ja_JP import Provider
+        last_romanized_names = Provider.last_romanized_names
+
+        domain_word = self.factory.domain_word()
+        assert domain_word
+        assert isinstance(domain_word, string_types)
+        assert any(domain_word == text.slugify(last_romanized_name) for last_romanized_name in last_romanized_names)
+
+        user_name = self.factory.user_name()
+        assert user_name
+        assert isinstance(user_name, string_types)
+
+        tld = self.factory.tld()
+        assert tld
+        assert isinstance(tld, string_types)
 
     def test_ja_JP_person(self):
         name = self.factory.name()

--- a/faker/tests/ja_JP/__init__.py
+++ b/faker/tests/ja_JP/__init__.py
@@ -117,6 +117,26 @@ class ja_JP_FactoryTestCase(unittest.TestCase):
         assert last_kana_name
         assert isinstance(last_kana_name, string_types)
 
+        romanized_name = self.factory.romanized_name()
+        assert romanized_name
+        assert isinstance(romanized_name, string_types)
+
+        first_romanized_name = self.factory.first_romanized_name()
+        assert first_romanized_name
+        assert isinstance(first_romanized_name, string_types)
+
+        first_romanized_name_male = self.factory.first_romanized_name_male()
+        assert first_romanized_name_male
+        assert isinstance(first_romanized_name_male, string_types)
+
+        first_romanized_name_female = self.factory.first_romanized_name_female()
+        assert first_romanized_name_female
+        assert isinstance(first_romanized_name_female, string_types)
+
+        last_romanized_name = self.factory.last_romanized_name()
+        assert last_romanized_name
+        assert isinstance(last_romanized_name, string_types)
+
     def test_ja_JP_phone_number(self):
         pn = self.factory.phone_number()
         formats = (


### PR DESCRIPTION
In order to get username and domain in ja_JP
・Add [Romanized Japanese](https://en.wikipedia.org/wiki/Romanization_of_Japanese) person name
・Add internet provider for ja_JP


