### PR TITLE
Handle unexpected length in ean()

### DIFF
--- a/faker/providers/barcode/__init__.py
+++ b/faker/providers/barcode/__init__.py
@@ -10,7 +10,7 @@ class Provider(BaseProvider):
         code = [self.random_digit() for i in range(length - 1)]
 
         if length not in (8, 13):
-            length = 13
+            raise AssertionError("length can only be 8 or 13")
 
         if length == 8:
             weights = [3,1,3,1,3,1,3]

--- a/faker/providers/barcode/__init__.py
+++ b/faker/providers/barcode/__init__.py
@@ -9,6 +9,9 @@ class Provider(BaseProvider):
     def ean(self, length=13):
         code = [self.random_digit() for i in range(length - 1)]
 
+        if length not in (8, 13):
+            length = 13
+
         if length == 8:
             weights = [3,1,3,1,3,1,3]
         elif length == 13:


### PR DESCRIPTION
I didn't realise ean lengths could only be 8 or 13 digits and tried to use `faker.ean(length=20)` and got `UnboundLocalError: local variable 'weights' referenced before assignment`.

Adding this so that it defaults to 13 digits....