### PR TITLE
Resolves #324. Add characters classmethod to lorem provider

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -6,20 +6,6 @@ from .. import BaseProvider
 
 class Provider(BaseProvider):
     @classmethod
-    def characters(cls, max_nb=255, variable_case=True):
-        """
-        Generate a random character string
-        :param max_nb number of characters the string should consist of
-        :param variable_case set to False to exclude uppercase characters
-        :example 'pmGYPlciRq'
-        """
-        characters = "".join(cls.random_letter() for i in range(max_nb))
-        if not variable_case:
-            return characters.lower()
-        else:
-            return characters
-
-    @classmethod
     def word(cls):
         """
         Generate a random word

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -6,9 +6,24 @@ from .. import BaseProvider
 
 class Provider(BaseProvider):
     @classmethod
+    def characters(cls, max_nb=255, variable_case=True):
+        """
+        Generate a random character string
+        :param max_nb number of characters the string should consist of
+        :param variable_case set to False to exclude uppercase characters
+        :example 'pmGYPlciRq'
+        """
+        characters = "".join(cls.random_letter() for i in range(max_nb))
+        if not variable_case:
+            return characters.lower()
+        else:
+            return characters
+
+    @classmethod
     def word(cls):
         """
-        :example 'Lorem'
+        Generate a random word
+        :example 'lorem'
         """
         return cls.random_element(cls.word_list)
 

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -25,7 +25,7 @@ class Provider(BaseProvider):
 
     @classmethod
     def pystr(cls, max_chars=20):
-        return Lorem.text(max_chars)
+        return "".join(cls.random_letter() for i in range(max_chars))
 
     @classmethod
     def pyfloat(cls, left_digits=None, right_digits=None, positive=False):

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -499,6 +499,30 @@ class FactoryTestCase(unittest.TestCase):
         sentence = provider.sentence(0)
         self.assertEqual(sentence, '')
 
+    def test_lowercase_only_characters(self):
+        from faker.providers.lorem import Provider
+
+        provider = Provider(None)
+
+        characters = provider.characters(variable_case=False)
+        for char in characters:
+            self.assertTrue(char in string.ascii_lowercase)
+
+    def test_max_nb_characters(self):
+        from faker.providers.lorem import Provider
+
+        provider = Provider(None)
+
+        characters = provider.characters()
+        self.assertEqual(len(characters), 255)
+        characters = provider.characters(max_nb=10)
+        self.assertEqual(len(characters), 10)
+        characters = provider.characters(max_nb=0)
+        self.assertEqual(characters, '')
+        characters = provider.characters(max_nb=-10)
+        self.assertEqual(characters, '')
+
+
     def test_us_ssn_valid(self):
         from faker.providers.ssn.en_US import Provider
 

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -499,27 +499,17 @@ class FactoryTestCase(unittest.TestCase):
         sentence = provider.sentence(0)
         self.assertEqual(sentence, '')
 
-    def test_lowercase_only_characters(self):
-        from faker.providers.lorem import Provider
-
+    def test_random_pystr_characters(self):
+        from faker.providers.python import Provider
         provider = Provider(None)
 
-        characters = provider.characters(variable_case=False)
-        for char in characters:
-            self.assertTrue(char in string.ascii_lowercase)
-
-    def test_max_nb_characters(self):
-        from faker.providers.lorem import Provider
-
-        provider = Provider(None)
-
-        characters = provider.characters()
+        characters = provider.pystr()
+        self.assertEqual(len(characters), 20)
+        characters = provider.pystr(max_chars=255)
         self.assertEqual(len(characters), 255)
-        characters = provider.characters(max_nb=10)
-        self.assertEqual(len(characters), 10)
-        characters = provider.characters(max_nb=0)
+        characters = provider.pystr(max_chars=0)
         self.assertEqual(characters, '')
-        characters = provider.characters(max_nb=-10)
+        characters = provider.pystr(max_chars=-10)
         self.assertEqual(characters, '')
 
 


### PR DESCRIPTION
Sometimes I want to generate a string of characters of a specific length
without any punctuation or capitalization. Adding a characters() method
allows for this. It defaults to a 255-character, mixed case string but
the method can also be called with params that specify length and
whether to exclude uppercase characters.