### PR TITLE
IPv4 and IPv6 network generators.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ Changelog
 * Add Maestro credit card. Thanks @anthonylauzon.
 * Add ``hr_HR`` localization. Thanks @mislavcimpersak.
 * Update ``de_DE`` first names. Thanks @WarrenFaith and @mschoebel.
-* Allow generation of IPv4 and IPv6 network address with valid CIDR.
-* Unittest IPv4 and IPv6 address and network generation.
+* Allow generation of IPv4 and IPv6 network address with valid CIDR. Thanks @kdeldycke.
+* Unittest IPv4 and IPv6 address and network generation. Thanks @kdeldycke.
 
 `0.5.3 - 21-September-2015 <http://github.com/joke2k/faker/compare/v0.5.2...v0.5.3>`__
 --------------------------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Changelog
 * Add Maestro credit card. Thanks @anthonylauzon.
 * Add ``hr_HR`` localization. Thanks @mislavcimpersak.
 * Update ``de_DE`` first names. Thanks @WarrenFaith and @mschoebel.
+* Allow generation of IPv4 and IPv6 network address with valid CIDR.
+* Unittest IPv4 and IPv6 address and network generation.
 
 `0.5.3 - 21-September-2015 <http://github.com/joke2k/faker/compare/v0.5.2...v0.5.3>`__
 --------------------------------------------------------------------------------------

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -9,11 +9,6 @@ from faker.generator import random
 from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import slugify, slugify_unicode
 
-try:
-    unicode
-except NameError:  # pragma: no cover
-    unicode = str  # pylint: disable=W0622,C0103
-
 
 localized = True
 

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import unicode_literals
 from .. import BaseProvider
 
+from ipaddress import ip_address, ip_network, IPV4LENGTH, IPV6LENGTH
+
 from faker.generator import random
 from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import slugify, slugify_unicode
@@ -50,9 +52,6 @@ class Provider(BaseProvider):
      )
 
     replacements = tuple()
-
-    IPV4LENGTH = 32
-    IPV6LENGTH = 128
 
     def _to_ascii(self, string):
         for search, replace in self.replacements:
@@ -103,38 +102,22 @@ class Provider(BaseProvider):
         return self.generator.parse(pattern)
 
     def ipv4(self, network=False):
-        """ Produce a random IPv4 address or network with a valid CIDR.
-
-        IP code generation inspired by ipaddress module: https://github.com/phihag/ipaddress
-        """
-        ip_int = random.randint(0, (2 ** self.IPV4LENGTH) - 1)
+        """ Produce a random IPv4 address or network with a valid CIDR. """
+        address = str(ip_address(random.randint(
+            0, (2 ** IPV4LENGTH) - 1)))
         if network:
-            prefixlen = random.randint(0, self.IPV4LENGTH)
-            ALL_ONES = (2 ** self.IPV4LENGTH) - 1
-            netmask = ALL_ONES ^ (ALL_ONES >> prefixlen)
-            ip_int = int(ip_int) & int(netmask)
-        ip_str = '.'.join([str(ip_int >> n & 0xFF) for n in [24, 16, 8, 0]])
-        if network:
-            ip_str += '/' + str(prefixlen)
-        return ip_str
+            address += '/' + str(random.randint(0, IPV4LENGTH))
+            address = str(ip_network(unicode(address), strict=False))
+        return address
 
     def ipv6(self, network=False):
-        """ Produce a random IPv6 address or network with a valid CIDR.
-
-        IP code generation inspired by ipaddress module: https://github.com/phihag/ipaddress
-        """
-        ip_int = random.randint(2 ** self.IPV4LENGTH, (2 ** self.IPV6LENGTH) - 1)
+        """ Produce a random IPv6 address or network with a valid CIDR. """
+        address = str(ip_address(random.randint(
+            2 ** IPV4LENGTH, (2 ** IPV6LENGTH) - 1)))
         if network:
-            prefixlen = random.randint(0, self.IPV6LENGTH)
-            ALL_ONES = (2 ** self.IPV6LENGTH) - 1
-            netmask = ALL_ONES ^ (ALL_ONES >> prefixlen)
-            ip_int = int(ip_int) & int(netmask)
-        hex_str = '%032x' % ip_int
-        hextets = ['%x' % int(hex_str[x:x + 4], 16) for x in range(0, 32, 4)]
-        ip_str = ':'.join([h.zfill(4) for h in hextets])
-        if network:
-            ip_str += '/' + str(prefixlen)
-        return ip_str
+            address += '/' + str(random.randint(0, IPV6LENGTH))
+            address = str(ip_network(unicode(address), strict=False))
+        return address
 
     def mac_address(self):
         mac = [random.randint(0x00, 0xff) for i in range(0, 6)]

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -113,7 +113,7 @@ class Provider(BaseProvider):
             0, (2 ** IPV4LENGTH) - 1)))
         if network:
             address += '/' + str(random.randint(0, IPV4LENGTH))
-            address = str(ip_network(unicode(address), strict=False))
+            address = str(ip_network(address, strict=False))
         return address
 
     def ipv6(self, network=False):
@@ -122,7 +122,7 @@ class Provider(BaseProvider):
             2 ** IPV4LENGTH, (2 ** IPV6LENGTH) - 1)))
         if network:
             address += '/' + str(random.randint(0, IPV6LENGTH))
-            address = str(ip_network(unicode(address), strict=False))
+            address = str(ip_network(address, strict=False))
         return address
 
     def mac_address(self):

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -9,6 +9,12 @@ from faker.generator import random
 from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import slugify, slugify_unicode
 
+try:
+    unicode
+except NameError:  # pragma: no cover
+    unicode = str  # pylint: disable=W0622,C0103
+
+
 localized = True
 
 

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -562,16 +562,17 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(999):
             address = provider.ipv6()
-            self.assertEqual(len(address), 39)
+            self.assertTrue(len(address) >= 3)  # ::1
+            self.assertTrue(len(address) <= 39)
             self.assertTrue(
-                re.compile(r'^([0-9a-f]{4}:){7}[0-9a-f]{4}$').search(address))
+                re.compile(r'^([0-9a-f]{0,4}:){2,7}[0-9a-f]{1,4}$').search(address))
 
         for _ in range(999):
             address = provider.ipv6(network=True)
-            self.assertTrue(len(address) >= 41)
-            self.assertTrue(len(address) <= 43)
+            self.assertTrue(len(address) >= 4)  # ::/8
+            self.assertTrue(len(address) <= 39 + 4)
             self.assertTrue(
-                re.compile(r'^([0-9a-f]{4}:){7}[0-9a-f]{4}/\d{1,3}$').search(
+                re.compile(r'^([0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}/\d{1,3}$').search(
                     address))
 
 

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -7,6 +7,7 @@ __loader__ = None
 import datetime
 import json
 import os
+import re
 import time
 import unittest
 import string
@@ -542,15 +543,17 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(999):
             address = provider.ipv4()
-            self.assertGreaterEqual(len(address), 7)
-            self.assertLessEqual(len(address), 15)
-            self.assertRegexpMatches(address, '^(\d{1,3}\.){3}\d{1,3}$')
+            self.assertTrue(len(address) >= 7)
+            self.assertTrue(len(address) <= 15)
+            self.assertTrue(
+                re.compile(r'^(\d{1,3}\.){3}\d{1,3}$').search(address))
 
         for _ in range(999):
             address = provider.ipv4(network=True)
-            self.assertGreaterEqual(len(address), 9)
-            self.assertLessEqual(len(address), 18)
-            self.assertRegexpMatches(address, '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$')
+            self.assertTrue(len(address) >= 9)
+            self.assertTrue(len(address) <= 18)
+            self.assertTrue(
+                re.compile(r'^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$').search(address))
 
     def test_ipv6(self):
         from faker.providers.internet import Provider
@@ -560,13 +563,16 @@ class FactoryTestCase(unittest.TestCase):
         for _ in range(999):
             address = provider.ipv6()
             self.assertEqual(len(address), 39)
-            self.assertRegexpMatches(address, '^([0-9a-f]{4}:){7}[0-9a-f]{4}$')
+            self.assertTrue(
+                re.compile(r'^([0-9a-f]{4}:){7}[0-9a-f]{4}$').search(address))
 
         for _ in range(999):
             address = provider.ipv6(network=True)
-            self.assertGreaterEqual(len(address), 41)
-            self.assertLessEqual(len(address), 43)
-            self.assertRegexpMatches(address, '^([0-9a-f]{4}:){7}[0-9a-f]{4}/\d{1,3}$')
+            self.assertTrue(len(address) >= 41)
+            self.assertTrue(len(address) <= 43)
+            self.assertTrue(
+                re.compile(r'^([0-9a-f]{4}:){7}[0-9a-f]{4}/\d{1,3}$').search(
+                    address))
 
 
 class GeneratorTestCase(unittest.TestCase):

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -535,6 +535,39 @@ class FactoryTestCase(unittest.TestCase):
             email = factory.email()
             self.assertTrue('@' in email)
 
+    def test_ipv4(self):
+        from faker.providers.internet import Provider
+
+        provider = Provider(None)
+
+        for _ in range(999):
+            address = provider.ipv4()
+            self.assertGreaterEqual(len(address), 7)
+            self.assertLessEqual(len(address), 15)
+            self.assertRegexpMatches(address, '^(\d{1,3}\.){3}\d{1,3}$')
+
+        for _ in range(999):
+            address = provider.ipv4(network=True)
+            self.assertGreaterEqual(len(address), 9)
+            self.assertLessEqual(len(address), 18)
+            self.assertRegexpMatches(address, '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$')
+
+    def test_ipv6(self):
+        from faker.providers.internet import Provider
+
+        provider = Provider(None)
+
+        for _ in range(999):
+            address = provider.ipv6()
+            self.assertEqual(len(address), 39)
+            self.assertRegexpMatches(address, '^([0-9a-f]{4}:){7}[0-9a-f]{4}$')
+
+        for _ in range(999):
+            address = provider.ipv6(network=True)
+            self.assertGreaterEqual(len(address), 41)
+            self.assertLessEqual(len(address), 43)
+            self.assertRegexpMatches(address, '^([0-9a-f]{4}:){7}[0-9a-f]{4}/\d{1,3}$')
+
 
 class GeneratorTestCase(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -62,13 +62,12 @@ setup(
     extras_require={
         ':python_version=="2.6"': [
             'importlib',
-            'ipaddress',
-        ],
-        ':python_version=="2.7"': [
-            'ipaddress',
         ],
         ':python_version=="3.0"': [
-            'importlib'
+            'importlib',
+        ],
+        ':python_version=="3.2"': [
+            'ipaddress',
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         ':python_version=="3.0"': [
             'importlib',
         ],
-        ':python_version=="3.2"': [
+        ':python_version=<"3.3"': [
             'ipaddress',
         ],
     }

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         ':python_version=="3.0"': [
             'importlib',
         ],
-        ':python_version=<"3.3"': [
+        ':python_version<="3.3"': [
             'ipaddress',
         ],
     }

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
@@ -58,7 +60,15 @@ setup(
         "six",
     ],
     extras_require={
-        ':python_version=="2.6"': ['importlib'],
-        ':python_version=="3.0"': ['importlib'],
+        ':python_version=="2.6"': [
+            'importlib',
+            'ipaddress',
+        ],
+        ':python_version=="2.7"': [
+            'ipaddress',
+        ],
+        ':python_version=="3.0"': [
+            'importlib'
+        ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,15 @@ setup(
     extras_require={
         ':python_version=="2.6"': [
             'importlib',
+            'ipaddress',
+        ],
+        ':python_version=="2.7"': [
+            'ipaddress',
         ],
         ':python_version=="3.0"': [
             'importlib',
         ],
-        ':python_version<="3.3"': [
+        ':python_version=="3.2"': [
             'ipaddress',
         ],
     }


### PR DESCRIPTION
Adds optional IPv4 and IPv6 network address generation with valid CIDR notation.

Also add corresponding unit-tests.

Usage example:
```python
>>> from faker import Factory as FakerFactory
>>> faker = FakerFactory.create()
>>> faker.ipv4()
u'94.84.244.87'
>>> faker.ipv4(network=True)
u'105.0.0.0/10'
>>> faker.ipv4(network=True)
u'131.46.122.140/30'
>>> faker.ipv6()
u'0b9e:425c:8028:ffd1:88a1:9d54:a4a0:cafb'
>>> faker.ipv6(network=True)
u'1e1b:0791:da18:0000:0000:0000:0000:0000/45'
>>> faker.ipv6(network=True)
u'79c1:84fc:53b8:c9a8:23ca:7407:a775:0180/121'
```