### PR TITLE
Fix randomly produced language codes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changelog
 * Allow generation of IPv4 and IPv6 network address with valid CIDR. Thanks @kdeldycke.
 * Unittest IPv4 and IPv6 address and network generation. Thanks @kdeldycke.
 * Add a new provider to generate random binary blob. Thanks @kdeldycke.
+* Check that randomly produced language codes are parseable as locale by the
+  factory constructor. Thanks @kdeldycke.
 
 `0.5.3 - 21-September-2015 <http://github.com/joke2k/faker/compare/v0.5.2...v0.5.3>`__
 --------------------------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changelog
 * Add a new provider to generate random binary blob. Thanks @kdeldycke.
 * Check that randomly produced language codes are parseable as locale by the
   factory constructor. Thanks @kdeldycke.
+* Fix chinese random language code. Thanks @kdeldycke.
 
 `0.5.3 - 21-September-2015 <http://github.com/joke2k/faker/compare/v0.5.2...v0.5.3>`__
 --------------------------------------------------------------------------------------

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -13,7 +13,7 @@ from .. import BaseProvider
 
 
 class Provider(BaseProvider):
-    language_codes = ('cn', 'de', 'el', 'en', 'es', 'fr', 'it', 'pt', 'ru')
+    language_codes = ('zh', 'de', 'el', 'en', 'es', 'fr', 'it', 'pt', 'ru')
 
     @classmethod
     def boolean(cls, chance_of_getting_true=50):

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -471,6 +471,14 @@ class FactoryTestCase(unittest.TestCase):
             self.assertTrue(isinstance(binary, six.binary_type))
             self.assertTrue(len(binary) == length)
 
+    def test_language_code(self):
+        from faker.providers.misc import Provider
+
+        for _ in range(99):
+            language_code = Provider.language_code()
+            self.assertTrue(isinstance(language_code, string_types))
+            Factory.create(locale=language_code)
+
     def test_password(self):
         from faker.providers.misc import Provider
 


### PR DESCRIPTION
First commit shows that the `cn` language code is not recognised by the `Factory` constructor.

Second commit replace `cn` by `zh`, the former being the Chinese TLD, not Chinese's language code.