### PR TITLE
Command improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ When installed, you can invoke faker from the command-line:
           [-l {bg_BG,cs_CZ,...,zh_CN,zh_TW}]
           [-r REPEAT] [-s SEP]
           [-i {module.containing.custom_provider othermodule.containing.custom_provider}]
-          [fake [fake ...]]
+          [fake] [fake argument [fake argument ...]]
 
 Where:
 
@@ -197,9 +197,7 @@ Where:
 -  ``fake``: is the name of the fake to generate an output for, such as
    ``name``, ``address``, or ``text``
 
--  ``[fake ...]``: is an optional comma-separated list of field names to
-   pass to the fake, such as ``ssn,birthday`` when the ``profile`` fake
-   is used
+-  ``[fake argument ...]``: optional arguments to pass to the fake (e.g. the profile fake takes an optional list of comma separated field names as the first argument)
 
 Examples:
 

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -144,13 +144,26 @@ class Command(object):
 
         parser.add_argument('-l', '--lang',
                             choices=AVAILABLE_LOCALES,
-                            default=default_locale)
+                            default=default_locale,
+                            help="specify the language for a localized "
+                            "provider (e.g. de_DE)")
         parser.add_argument('-r', '--repeat',
-                            default=1, type=int)
+                            default=1,
+                            type=int,
+                            help="generate the specified number of outputs")
         parser.add_argument('-s', '--sep',
-                            default='\n')
+                            default='\n',
+                            help="use the specified separator after each "
+                            "output")
 
-        parser.add_argument('-i', '--include', default=META_PROVIDERS_MODULES, nargs='*')
+        parser.add_argument('-i',
+                            '--include',
+                            default=META_PROVIDERS_MODULES,
+                            nargs='*',
+                            help="list of additional custom providers to "
+                            "user, given as the import path of the module "
+                            "containing your Provider class (not the provider "
+                            "class itself)")
 
         parser.add_argument('fake',
                             action='store',

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -152,23 +152,34 @@ class Command(object):
 
         parser.add_argument('-i', '--include', default=META_PROVIDERS_MODULES, nargs='*')
 
-        parser.add_argument('fake', action='store', nargs='*')
+        parser.add_argument('fake',
+                            action='store',
+                            nargs='?',
+                            help="name of the fake to generate output for "
+                                 "(e.g. profile)")
+
+        parser.add_argument('fake_args',
+                            metavar="fake argument",
+                            action='store',
+                            nargs='*',
+                            help="optional arguments to pass to the fake "
+                                 "(e.g. the profile fake takes an optional "
+                                 "list of comma separated field names as the "
+                                 "first argument)")
 
         arguments = parser.parse_args(self.argv[1:])
 
         for i in range(arguments.repeat):
 
-            fake = arguments.fake[0] if len(arguments.fake) else None
-
-            print_doc(fake,
-                      arguments.fake[1:],
+            print_doc(arguments.fake,
+                      arguments.fake_args,
                       lang=arguments.lang,
                       output=arguments.o,
                       includes=arguments.include
                       )
             print(arguments.sep, file=arguments.o)
 
-            if not fake:
+            if not arguments.fake:
                 # repeat not supported for all docs
                 break
 


### PR DESCRIPTION
Thanks for writing fake-factory (or faker, still a little confused about the name) and releasing it as free software, I am using it for several projects.

While writing a man page for faker, as part of packaging it for Debian, I noticed that the help given when passing --help was a little lacking. While attempting to improve this, I also noticed that the fake argument was oddly structured, so I changed that also.