### PR TITLE
Add date handling for datetime functions

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -17,7 +17,7 @@ from .. import BaseProvider
 
 
 def datetime_to_timestamp(dt):
-    if dt.tzinfo is not None:
+    if getattr(dt, 'tzinfo', None) is not None:
         dt = dt.astimezone(tzlocal())
     return mktime(dt.timetuple())
 

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -327,6 +327,12 @@ class FactoryTestCase(unittest.TestCase):
         now_back = datetime.datetime.fromtimestamp(timestamp, utc)
         self.assertEqual(now, now_back)
 
+        today = datetime.date.today()
+        timestamp = datetime_to_timestamp(today)
+        today_as_dt = datetime.datetime.combine(today, datetime.time.min)
+        today_back = datetime.datetime.fromtimestamp(timestamp)
+        self.assertEqual(today_as_dt, today_back)
+
     def test_datetime_safe(self):
         from faker.utils import datetime_safe
         # test using example provided in module


### PR DESCRIPTION
faker v0.5.4 introduced timezone handling to datetime functions. This however broke compatibility when using dates instead of datetimes. eg, `date_time_between_dates`.