### PR TITLE
More command line improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,12 +218,9 @@ Examples:
     {'ssn': u'628-10-1085', 'birthdate': '2008-03-29'}
 
     $ faker -r=3 -s=";" name
-    Willam Kertzmann
-    ;
-    Josiah Maggio
-    ;
-    Gayla Schmitt
-    ;
+    Willam Kertzmann;
+    Josiah Maggio;
+    Gayla Schmitt;
 
 How to create a Provider
 ------------------------

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -145,6 +145,7 @@ class Command(object):
         parser.add_argument('-l', '--lang',
                             choices=AVAILABLE_LOCALES,
                             default=default_locale,
+                            metavar='LOCALE',
                             help="specify the language for a localized "
                             "provider (e.g. de_DE)")
         parser.add_argument('-r', '--repeat',

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -128,10 +128,20 @@ class Command(object):
         if default_locale not in AVAILABLE_LOCALES:
             default_locale = DEFAULT_LOCALE
 
+        epilog = """supported locales:
+
+  {0}
+
+  faker can take a locale as an argument, to return localized data. If no
+  localized provider is found, the factory falls back to the default en_US
+  locale.
+""".format(', '.join(sorted(AVAILABLE_LOCALES)))
+
         formatter_class = argparse.RawDescriptionHelpFormatter
         parser = argparse.ArgumentParser(
             prog=self.prog_name,
             description='{0} version {1}'.format(self.prog_name, VERSION),
+            epilog=epilog,
             formatter_class=formatter_class)
 
         parser.add_argument("--version", action="version",

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -150,11 +150,9 @@ examples:
   {{'ssn': u'628-10-1085', 'birthdate': '2008-03-29'}}
 
   $ faker -r=3 -s=";" name
-  Willam Kertzmann
-  ;
-  Josiah Maggio
-  ;
-  Gayla Schmitt
+  Willam Kertzmann;
+  Josiah Maggio;
+  Gayla Schmitt;
 
 """.format(', '.join(sorted(AVAILABLE_LOCALES)))
 

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -135,6 +135,27 @@ class Command(object):
   faker can take a locale as an argument, to return localized data. If no
   localized provider is found, the factory falls back to the default en_US
   locale.
+
+examples:
+
+  $ faker address
+  968 Bahringer Garden Apt. 722
+  Kristinaland, NJ 09890
+
+  $ faker -l de_DE address
+  Samira-Niemeier-Allee 56
+  94812 Biedenkopf
+
+  $ faker profile ssn,birthdate
+  {{'ssn': u'628-10-1085', 'birthdate': '2008-03-29'}}
+
+  $ faker -r=3 -s=";" name
+  Willam Kertzmann
+  ;
+  Josiah Maggio
+  ;
+  Gayla Schmitt
+
 """.format(', '.join(sorted(AVAILABLE_LOCALES)))
 
         formatter_class = argparse.RawDescriptionHelpFormatter


### PR DESCRIPTION
Print the available locales in a separate section to make the help output easier to read. Also, include the examples given in the README in the help output.