### PR TITLE
Reduce the maximum value of start timestamps

### DIFF
--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -373,7 +373,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.providers.date_time import Provider
         provider = Provider
 
-        timestamp_start = random.randint(0,10000000000)
+        timestamp_start = random.randint(0,2000000000)
         timestamp_end = timestamp_start+1
 
         datetime_start = datetime.datetime.fromtimestamp(timestamp_start)
@@ -387,7 +387,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.providers.date_time import Provider
         provider = Provider
 
-        timestamp_start = random.randint(0, 10000000000)
+        timestamp_start = random.randint(0, 2000000000)
         timestamp_end = timestamp_start+1
 
         datetime_start = datetime.datetime.fromtimestamp(timestamp_start, utc)


### PR DESCRIPTION
This fixes running the tests on systems on which CPython does not support
representations of timestamps larger than the maximum value of a 32 bit signed
integer.

I noticed that this was a problem from the Debian Reproducible Builds CI system, which failed to build faker on the i386 and armhf architectures [1]. Note that this does not affect the availability of faker from the Debian archive, as the binary package works on all architectures (arch all, rather than any), and the build takes place on a x86_64 machine.

1: https://tests.reproducible-builds.org/rb-pkg/unstable/amd64/faker.html