### PR TITLE
Remove incorrect phone number formats

### DIFF
--- a/faker/providers/phone_number/en_US/__init__.py
+++ b/faker/providers/phone_number/en_US/__init__.py
@@ -15,9 +15,6 @@ class Provider(PhoneNumberProvider):
         # Non-standard 10-digit phone number format
         '###.###.####',
         '###.###.####',
-        # Standard 11-digit phone number format
-        '1-###-###-####',
-        '1-###-###-####',
         # Standard 10-digit phone number format with extensions
         '###-###-####x###',
         '###-###-####x####',
@@ -30,8 +27,14 @@ class Provider(PhoneNumberProvider):
         '###.###.####x###',
         '###.###.####x####',
         '###.###.####x#####',
+        # Standard 11-digit phone number format
+        '+1-###-###-####',
+        '001-###-###-####',
         # Standard 11-digit phone number format with extensions
-        '1-###-###-####x###',
-        '1-###-###-####x####',
-        '1-###-###-####x#####',
+        '+1-###-###-####x###',
+        '+1-###-###-####x####',
+        '+1-###-###-####x#####',
+        '001-###-###-####x###',
+        '001-###-###-####x####',
+        '001-###-###-####x#####',
     )

--- a/faker/providers/phone_number/en_US/__init__.py
+++ b/faker/providers/phone_number/en_US/__init__.py
@@ -12,13 +12,13 @@ class Provider(PhoneNumberProvider):
         # Optional 10-digit local phone number format
         '(###)###-####',
         '(###)###-####',
-        # Non-standard 10-digit phone number formats
+        # Non-standard 10-digit phone number format
         '###.###.####',
         '###.###.####',
-        # Standard 11-digit international format
+        # Standard 11-digit phone number format
         '1-###-###-####',
         '1-###-###-####',
-        # Standard 10-digit phone number formats with extensions
+        # Standard 10-digit phone number format with extensions
         '###-###-####x###',
         '###-###-####x####',
         '###-###-####x#####',
@@ -26,11 +26,11 @@ class Provider(PhoneNumberProvider):
         '(###)###-####x###',
         '(###)###-####x####',
         '(###)###-####x#####',
-        # Non-standard 10-digit phone number formats with extensions
+        # Non-standard 10-digit phone number format with extensions
         '###.###.####x###',
         '###.###.####x####',
         '###.###.####x#####',
-        # Standard 11-digit international format with extensions
+        # Standard 11-digit phone number format with extensions
         '1-###-###-####x###',
         '1-###-###-####x####',
         '1-###-###-####x#####',

--- a/faker/providers/phone_number/en_US/__init__.py
+++ b/faker/providers/phone_number/en_US/__init__.py
@@ -4,28 +4,34 @@ from .. import Provider as PhoneNumberProvider
 
 class Provider(PhoneNumberProvider):
     formats = (
-        '+##(#)##########',
-        '+##(#)##########',
-        '0##########',
-        '0##########',
+        # Standard 10-digit phone number formats
+        '##########',
+        '##########',
         '###-###-####',
-        '(###)###-####',
-        '1-###-###-####',
-        '###.###.####',
         '###-###-####',
+        # Optional 10-digit local phone number format
         '(###)###-####',
-        '1-###-###-####',
+        '(###)###-####',
+        # Non-standard 10-digit phone number formats
         '###.###.####',
+        '###.###.####',
+        # Standard 11-digit international format
+        '1-###-###-####',
+        '1-###-###-####',
+        # Standard 10-digit phone number formats with extensions
         '###-###-####x###',
-        '(###)###-####x###',
-        '1-###-###-####x###',
-        '###.###.####x###',
         '###-###-####x####',
-        '(###)###-####x####',
-        '1-###-###-####x####',
-        '###.###.####x####',
         '###-###-####x#####',
+        # Optional 10-digit local phone number format with extensions
+        '(###)###-####x###',
+        '(###)###-####x####',
         '(###)###-####x#####',
-        '1-###-###-####x#####',
+        # Non-standard 10-digit phone number formats with extensions
+        '###.###.####x###',
+        '###.###.####x####',
         '###.###.####x#####',
+        # Standard 11-digit international format with extensions
+        '1-###-###-####x###',
+        '1-###-###-####x####',
+        '1-###-###-####x#####',
     )


### PR DESCRIPTION
- Remove the +##(#)########## and 0########## phone number formats from the
  en_US locale as they are not valid NANP formats - see wikipedia article
  https://en.wikipedia.org/wiki/North_American_Numbering_Plan for more info
- Sort and organize all remaining en_US phone number formats for future
  enhancements and arguments to be added to the provider

This is in relation to issues #170 and #162 and will resolve them
