### PR TITLE
Removed potentially offensive phrases

### DIFF
--- a/faker/providers/person/de_DE/__init__.py
+++ b/faker/providers/person/de_DE/__init__.py
@@ -353,7 +353,7 @@ class Provider(PersonProvider):
         'Bloch', 'Blümel', 'Bohlander', 'Bonbach', 'Bolander', 'Bolnbach',
         'Bolzmann', 'Börner', 'Bohnbach', 'Boucsein', 'Briemer', 'Bruder',
         'Buchholz', 'Budig', 'Butte', 'Carsten', 'Caspar', 'Christoph',
-        'Cichorius', 'Conradi', 'Davids', 'Dehmel', 'Dickhard', 'Dietz',
+        'Cichorius', 'Conradi', 'Davids', 'Dehmel', 'Dietz',
         'Dippel', 'Ditschlerin', 'Dobes', 'Döhn', 'Döring', 'Dörr', 'Dörschner',
         'Dowerg', 'Drewes', 'Drub', 'Drubin', 'Dussen van', 'Eberhardt',
         'Ebert', 'Eberth', 'Eckbauer', 'Ehlert', 'Eigenwillig', 'Eimer',

--- a/faker/providers/person/en/__init__.py
+++ b/faker/providers/person/en/__init__.py
@@ -745,7 +745,7 @@ class Provider(PersonProvider):
         'Destin', 'Destry', 'Devan', 'Devante', 'Devaughn', 'Deven', 'Devin',
         'Devon', 'Devonta', 'Devontae', 'Devonte', 'Devyn', 'Deward',
         'Dewayne', 'Dewey', 'Dewitt', 'Dexter', 'Diallo', 'Diamond', 'Diane',
-        'Dick', 'Dickie', 'Diego', 'Dijon', 'Dilan', 'Dillan', 'Dillard',
+        'Dickie', 'Diego', 'Dijon', 'Dilan', 'Dillan', 'Dillard',
         'Dillion', 'Dillon', 'Dimitri', 'Dimitrios', 'Dink', 'Dino', 'Dion',
         'Dionicio', 'Dionte', 'Dirk', 'Dixon', 'Doc', 'Dock', 'Doctor', 'Doll',
         'Dolph', 'Dolphus', 'Domenic', 'Domenick', 'Domenico', 'Domingo',


### PR DESCRIPTION
Removed names that could potentially be found as offensive depending on the context.

I understand they're real names, in fact I know people having the surnames I removed in this commit. But this has caused a bit of trouble as we're assigning random names to players in our test environment.

I think those names should be removed just in case of potentially being offensive if they're used in the wrong context. Developers using this great library should not be worried about these things.