### PR TITLE
Fail if a plain dict is passed to random_element

### DIFF
--- a/faker/generator.py
+++ b/faker/generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 import re
 import random
 
@@ -16,7 +17,7 @@ class Generator(object):
 
     def __init__(self, **config):
         self.providers = []
-        self.__config = dict(
+        self.__config = OrderedDict(
             list(self.__config.items()) + list(config.items()))
 
     def add_provider(self, provider):

--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -2,6 +2,7 @@
 
 import re
 import string
+from collections import OrderedDict
 
 from faker.generator import random
 from faker.utils.distribution import choice_distribution
@@ -94,10 +95,15 @@ class BaseProvider(object):
         """
         Returns a random element from a passed object.
 
-        If `elements` is a dictionary, the value will be used as
-        a weighting element. For example::
+        If `elements` is an OrderedDict, the value will be used as a weighting
+        element. For example::
 
-            random_element({"{{variable_1}}": 0.5, "{{variable_2}}": 0.2, "{{variable_3}}": 0.2, "{{variable_4}}": 0.1})
+            random_element(OrderedDict([
+                ("{{variable_1}}", 0.5),
+                ("{{variable_2}}", 0.2),
+                ("{{variable_3}}", 0.2),
+                ("{{variable_4}}": 0.1)
+            ])
 
         will have the following distribution:
             * `variable_1`: 50% probability
@@ -108,6 +114,8 @@ class BaseProvider(object):
         """
 
         if isinstance(elements, dict):
+            raise ValueError("Use OrderedDict only to avoid dependency on PYTHONHASHSEED (#363).")
+        elif isinstance(elements, OrderedDict):
             choices = elements.keys()
             probabilities = elements.values()
             return choice_distribution(list(choices), list(probabilities))

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -13,6 +13,7 @@ import unittest
 import string
 import six
 import sys
+from collections import OrderedDict
 
 try:
     from mock import patch
@@ -280,12 +281,16 @@ class FactoryTestCase(unittest.TestCase):
         pick = provider.random_element(choices)
         self.assertTrue(pick in choices)
 
-        choices = {'a': 5, 'b': 2, 'c': 2, 'd':1 }
+        # dicts not allowed because they introduce dependency on PYTHONHASHSEED
+        with self.assertRaises(ValueError):
+            provider.random_element({})
+
+        choices = OrderedDict([('a', 5), ('b', 2), ('c', 2), ('d', 1)])
         pick = provider.random_element(choices)
         self.assertTrue(pick in choices)
 
 
-        choices = {'a': 0.5, 'b': 0.2, 'c': 0.2, 'd':0.1}
+        choices = OrderedDict([('a', 0.5), ('b', 0.2), ('c', 0.2), ('d', 0.1)])
         pick = provider.random_element(choices)
         self.assertTrue(pick in choices)
 


### PR DESCRIPTION
Only allow providers to use `OrderedDict`s, to avoid any more `PYTHONHASHSEED` problems. Ref #363.
