### PR TITLE
Allow left/right_digits=0 for pyfloat (see issue #401)

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -40,11 +40,14 @@ class Provider(BaseProvider):
 
     @classmethod
     def pyfloat(cls, left_digits=None, right_digits=None, positive=False):
-        if left_digits is not None and left_digits <= 0:
-            raise ValueError('A float number cannot have less than 1 digit in '
+        if left_digits is not None and left_digits < 0:
+            raise ValueError('A float number cannot have less than 0 digits in its '
                              'integer part')
-        if right_digits is not None and right_digits <= 0:
-            raise ValueError('A float number should have fractional part')
+        if right_digits is not None and right_digits < 0:
+            raise ValueError('A float number cannot have less than 0 digits in its '
+                             'fractional part')
+        if left_digits == 0 and right_digits == 0:
+            raise ValueError('A float number cannot have less than 0 digits in total')
 
         left_digits = left_digits if left_digits is not None else (
             cls.random_int(1, sys.float_info.dig))

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -535,14 +535,13 @@ class FactoryTestCase(unittest.TestCase):
         provider = Provider(None)
 
         self.assertTrue(0 <= abs(provider.pyfloat(left_digits=1)) < 10)
+        self.assertTrue(0 <= abs(provider.pyfloat(left_digits=0)) < 1)
+        x=abs(provider.pyfloat(right_digits=0))
+        self.assertTrue(x-int(x) == 0)
         with self.assertRaises(ValueError,
-                               msg='A float number cannot have less than 1 '
-                               'digit in integer part'):
-            provider.pyfloat(left_digits=0)
-        with self.assertRaises(ValueError,
-                               msg='A float number should have fractional '
-                               'part'):
-            provider.pyfloat(right_digits=0)
+                               msg='A float number cannot have 0 digits '
+                               'in total'):
+            provider.pyfloat(left_digits=0, right_digits=0)
 
     def test_us_ssn_valid(self):
         from faker.providers.ssn.en_US import Provider


### PR DESCRIPTION
Setting `left_digits=0` results in purely fractional numbers, allowing to
create e.g. random percentage values for test cases.

Setting `right_digits=0` results in integer values (represented as
floats), allowing to test if they are handled correctly or maybe
rounding is a problem for the use case under test.

Also see discussion for this [commit](https://github.com/illia-v/faker/commit/348a312e1a8378b9a168c7bf22fce8b5be500aad)