### PR TITLE
Fix no_NO postcodes.

### DIFF
--- a/faker/providers/address/no_NO/__init__.py
+++ b/faker/providers/address/no_NO/__init__.py
@@ -27,10 +27,3 @@ class Provider(AddressProvider):
     address_formats = ('{{street_address}}, {{postcode}} {{city}}',)
     building_number_formats = ('#', '#', '#', '#?', '##', '##', '##?')
     postcode_formats = ('####',)
-
-    @classmethod
-    def postcode(cls):
-        """
-        :example 0234
-        """
-        return cls.random_element(cls.postcode_formats)

--- a/faker/tests/no_NO/__init__.py
+++ b/faker/tests/no_NO/__init__.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+
+
+class no_NO_FactoryTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = Factory.create('no_NO')
+
+    def test_en_GB_postcode(self):
+        for i in range(100):
+            self.assertTrue(re.match(r'^[0-9]{4}$', self.factory.postcode()))


### PR DESCRIPTION
Current implementation of postal codes for `no_NO` locale returns the schema instead of the value:
```python
>>> import faker
>>> faker.VERSION
'0.7.6'
>>> faker.Faker(locale='no_NO').postcode()
u'####'
```

This PR fix this issue.