### PR TITLE
Fix fa_IR city generator

### DIFF
--- a/faker/providers/address/fa_IR/__init__.py
+++ b/faker/providers/address/fa_IR/__init__.py
@@ -62,7 +62,7 @@ class Provider(AddressProvider):
     )
 
     city_formats = (
-        '{{city_prefix}} {{first_name}}'
+        '{{city_prefix}} {{first_name}}',
     )
     street_name_formats = (
         '{{first_name}} {{street_suffix}}',


### PR DESCRIPTION
The city schema string is parsed as-is instead of being interpreted with generated random values:

```python
>>> import faker
>>> faker.Faker(locale='fa_IR').city()
u'}'
>>> faker.Faker(locale='fa_IR').city()
u'}'
>>> faker.Faker(locale='fa_IR').city()
u'e'
>>> faker.Faker(locale='fa_IR').city()
u's'
>>> faker.Faker(locale='fa_IR').city()
u'r'
>>> faker.Faker(locale='fa_IR').city()
u'{'
>>> faker.Faker(locale='fa_IR').city()
u'}'
>>> faker.Faker(locale='fa_IR').city()
u's'
>>> faker.Faker(locale='fa_IR').city()
u't'
>>> faker.Faker(locale='fa_IR').city()
u' '
>>> faker.Faker(locale='fa_IR').city()
u'i'
>>> faker.Faker(locale='fa_IR').city()
u'f'
>>> faker.Faker(locale='fa_IR').city()
u'{'
>>> faker.Faker(locale='fa_IR').city()
u'}'
>>> faker.Faker(locale='fa_IR').city()
u'c'
>>> faker.Faker(locale='fa_IR').city()
u'{'
```