### PR TITLE
Support for non-ascii fake data while maintaining readability for english speakers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ Included localized providers:
 -  `ko\_KR <https://faker.readthedocs.io/en/master/locales/ko_KR.html>`__ - Korean
 -  `lt\_LT <https://faker.readthedocs.io/en/master/locales/lt_LT.html>`__ - Lithuanian
 -  `lv\_LV <https://faker.readthedocs.io/en/master/locales/lv_LV.html>`__ - Latvian
+-  `ma\_MA <https://faker.readthedocs.io/en/master/locales/ma_MA.html>`__ - Martian (Mars)
 -  `ne\_NP <https://faker.readthedocs.io/en/master/locales/ne_NP.html>`__ - Nepali
 -  `nl\_NL <https://faker.readthedocs.io/en/master/locales/nl_NL.html>`__ - Dutch (Netherlands)
 -  `no\_NO <https://faker.readthedocs.io/en/master/locales/no_NO.html>`__ - Norwegian

--- a/faker/providers/address/ma_MA/__init__.py
+++ b/faker/providers/address/ma_MA/__init__.py
@@ -1,0 +1,10 @@
+from ..en_US import Provider as AddressProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('city_prefixes', 'city_suffixes', 'street_suffixes', 'states',
+            'states_abbr', 'military_state_abbr', 'military_ship_prefix',
+            'military_apo_format', 'military_dpo_format',
+            'secondary_address_formats')
+class Provider(AddressProvider):
+    pass

--- a/faker/providers/color/ma_MA/__init__.py
+++ b/faker/providers/color/ma_MA/__init__.py
@@ -1,0 +1,11 @@
+from collections import OrderedDict
+
+from deasciiify import deasciiify
+
+from ..en_US import Provider as ColorProvider
+
+
+class Provider(ColorProvider):
+    all_colors = OrderedDict((deasciiify(name), code)
+                             for name, code
+                             in ColorProvider.all_colors.iteritems())

--- a/faker/providers/company/ma_MA/__init__.py
+++ b/faker/providers/company/ma_MA/__init__.py
@@ -1,0 +1,7 @@
+from ..en_US import Provider as CompanyProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('catch_phrase_words', 'bsWords', 'company_suffixes')
+class Provider(CompanyProvider):
+    pass

--- a/faker/providers/internet/ma_MA/__init__.py
+++ b/faker/providers/internet/ma_MA/__init__.py
@@ -1,0 +1,8 @@
+from ..en_US import Provider as InternetProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('free_email_domains', 'tlds', 'uri_pages', 'uri_paths',
+            'uri_extensions')
+class Provider(InternetProvider):
+    pass

--- a/faker/providers/job/ma_MA/__init__.py
+++ b/faker/providers/job/ma_MA/__init__.py
@@ -1,0 +1,7 @@
+from ..en_US import Provider as JobProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('jobs')
+class Provider(JobProvider):
+    pass

--- a/faker/providers/lorem/ma_MA/__init__.py
+++ b/faker/providers/lorem/ma_MA/__init__.py
@@ -1,0 +1,7 @@
+from ..la import Provider as LoremProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('word_list')
+class Provider(LoremProvider):
+    pass

--- a/faker/providers/person/ma_MA/__init__.py
+++ b/faker/providers/person/ma_MA/__init__.py
@@ -1,0 +1,9 @@
+from ..en_US import Provider as PersonProvider
+from faker.utils.decorators import martianify
+
+
+@martianify('first_names_female', 'first_names_male', 'first_names',
+            'last_names', 'prefixes_female', 'prefixes_male',
+            'suffixes_female', 'suffixes_male')
+class Provider(PersonProvider):
+    pass

--- a/faker/tests/__init__.py
+++ b/faker/tests/__init__.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 __loader__ = None
 
+import collections
 import datetime
 import json
 import os
@@ -272,6 +273,51 @@ class FactoryTestCase(unittest.TestCase):
 
         slug = fn("a'b/.cé")
         self.assertEqual(slug, 'abcé')
+
+    def test_martianify(self):
+        @decorators.martianify('item_list', 'item_tuple', 'item_dict',
+                               'item_set', 'item_ordered_dict',
+                               'item_tuple_of_tuples', 'item_list_of_dicts')
+        class TestProvider(object):
+            item_list = ['first', 'second', 'third']
+            item_tuple = ('first', 'second', 'third')
+            item_dict = {'first': 1, 'second': 2, 'third': 3}
+            item_set = {'first', 'second', 'third'}
+            item_ordered_dict = collections.OrderedDict((
+                ('first', 1),
+                ('second', 2),
+                ('third', 3)
+            ))
+            item_tuple_of_tuples = (
+                ('first', 1),
+                ('second', 2),
+                ('third', 3)
+            )
+            item_list_of_dicts = [
+                {'first': 1},
+                {'second': 2},
+                {'third': 3}
+            ]
+
+        mars_first, mars_second, mars_third = 'ḟīṝṧṯ', 'ŝêċóᵰɖ', 'ᵵɦíṝɖ'
+        mars_items = (mars_first, mars_second, mars_third)
+
+        self.assertListEqual(list(mars_items), TestProvider.item_list)
+        self.assertTupleEqual(mars_items, TestProvider.item_tuple)
+        self.assertDictEqual({mars_first: 1, mars_second: 2, mars_third: 3},
+                             TestProvider.item_dict)
+        self.assertSetEqual(set(mars_items), TestProvider.item_set)
+        self.assertTrue(isinstance(TestProvider.item_ordered_dict,
+                                   collections.OrderedDict))
+        self.assertDictEqual({mars_first: 1, mars_second: 2, mars_third: 3},
+                             TestProvider.item_ordered_dict)
+        self.assertTupleEqual(((mars_first, 1), (mars_second, 2),
+                               (mars_third, 3)),
+                              TestProvider.item_tuple_of_tuples)
+        self.assertTrue(isinstance(TestProvider.item_list_of_dicts, list))
+        for d, item, i in zip(TestProvider.item_list_of_dicts,
+                              mars_items, range(1, 4)):
+            self.assertDictEqual({item: i}, d)
 
     def test_random_element(self):
         from faker.providers import BaseProvider

--- a/faker/utils/decorators.py
+++ b/faker/utils/decorators.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 
+import collections
 from functools import wraps
+
+from deasciiify import deasciiify
 
 from faker.utils import text
 
@@ -24,3 +27,45 @@ def slugify_unicode(fn):
     def wrapper(*args, **kwargs):
         return text.slugify(fn(*args, **kwargs), allow_unicode=True)
     return wrapper
+
+
+def martianify(*fields):
+    """Returns a class decorator that "martianifies" the specified fields.
+
+    The act of martianifying a string involves replacing the ASCII letters in
+    the string with non-ASCII characters that look similar to the original
+    character. This is very useful for adding non-ASCII characters to your test
+    suite while maintaining the readability of the strings.
+
+    For example, a string like "cooperative", when "martianified" looks like
+    "ḉȍöᶈᶒṙẳʈḯṿę"; yet useful for testing, yet readable.
+
+    :param fields: list of fields to be "martianified", represented as a list
+        of strings. Each of these strings must be the name of a field
+        containing a list of strings.
+    """
+    def transform(item):
+        if isinstance(item, basestring):
+            return deasciiify(item)
+        elif isinstance(item, collections.OrderedDict):
+            return collections.OrderedDict((transform(key), transform(value))
+                                           for key, value in item.iteritems())
+        elif isinstance(item, dict):
+            return {transform(key): transform(value)
+                    for key, value in item.iteritems()}
+        elif isinstance(item, collections.Iterable):
+            return item.__class__(transform(x) for x in item)
+        else:
+            return item
+
+    def decorator(cls):
+        for field in fields:
+            try:
+                value = getattr(cls, field)
+            except AttributeError:
+                raise KeyError('%s is not a field on %s' % (field,
+                                                            cls.__name__))
+            setattr(cls, field, transform(value))
+        return cls
+
+    return decorator

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     install_requires=[
         "python-dateutil>=2.4",
         "six",
+        "deasciiify",
     ],
     extras_require={
         ':python_version=="2.7"': [


### PR DESCRIPTION
**tl;dr;** I'd like to be able to run my test suite with non-ascii test data, while not using characters that most devs in the team can't read and words that most can't pronounce. The objective is to detect encoding errors in the code, while maintaining readability.

In the Bitbucket test suite, we use a [similar library](https://bitbucket.org/bitbucket/fakedata) (to faker) to generate the fake data. At the time I wrote that library, I wasn't aware of faker. One feature of that library I really find useful is its ability to optionally obfuscate strings. So the library can generate strings like "ợɼȧɳɠé", which are quite readable.

I thought it would be cool to add such a feature to faker and then move our test suite to faker (and deprecate fakedata). I'm not sure if you would be open to integrating my changes, given that this is an esoteric feature, but I'd appreciate it if you did.

To better illustrate this change, I'm pasting this Python session:

```python
>>> from faker import Factory
>>> fake = Factory.create('ma_MA')
>>> print fake.address()
50088 Ƙạṙᶖ Ṁîℓľ Ȧƥƫ. 590
Łḁǩễ Ṙȏἠἀŀɖ, ȘČ 49183-6904
>>> print fake.state()
Ӥȇᶀṙàŝķἇ
>>> print fake.name()
Ƌṛ. Ťȭñȳ 𝕄ŏřᵷåɲ
>>> print fake.url()
http://ṙổᵬɨἤşồή-ĵȭḫǹṧőἡ.óṛģ/
>>> print fake.job()
ℌáếḿầţǒɭǭǧïᵴṯ
>>> print fake.sentence()
Ċổᵯṁṏɖĩ άǖȶ ʠửåᶊ ὴơṥṱŗựḿ.
>>> print fake.bs()
ḟαɕïļȋţāŧé ᵬŗïçʞṧ-ἅňᶁ-ȼƚĩ¢ǩš ᵱᶅḁťƒöṝᶆȿ
```

Thank you for your time.