### PR TITLE
Move logo further down the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,3 @@
-::
-
-    _|_|_|_|          _|
-    _|        _|_|_|  _|  _|      _|_|    _|  _|_|
-    _|_|_|  _|    _|  _|_|      _|_|_|_|  _|_|
-    _|      _|    _|  _|  _|    _|        _|
-    _|        _|_|_|  _|    _|    _|_|_|  _|
-
 *Faker* is a Python package that generates fake data for you. Whether
 you need to bootstrap your database, create good-looking XML documents,
 fill-in your persistence to stress test it, or anonymize data taken from
@@ -14,6 +6,14 @@ a production service, Faker is for you.
 Faker is heavily inspired by `PHP Faker`_, `Perl Faker`_, and by `Ruby Faker`_.
 
 ----
+
+::
+
+    _|_|_|_|          _|
+    _|        _|_|_|  _|  _|      _|_|    _|  _|_|
+    _|_|_|  _|    _|  _|_|      _|_|_|_|  _|_|
+    _|      _|    _|  _|  _|    _|        _|
+    _|        _|_|_|  _|    _|    _|_|_|  _|
 
 |pypi| |unix_build| |windows_build| |coverage| |license|
 


### PR DESCRIPTION
Google mangles the ASCII logo when displaying README in search results.

Refs #474 