### PR TITLE
Fix no_NO building numbers from address provider

### DIFF
--- a/faker/providers/address/no_NO/__init__.py
+++ b/faker/providers/address/no_NO/__init__.py
@@ -25,5 +25,13 @@ class Provider(AddressProvider):
     ]
     street_address_formats = ('{{street_name}} {{building_number}}',)
     address_formats = ('{{street_address}}, {{postcode}} {{city}}',)
-    building_number_formats = ('#', '#', '#', '#?', '##', '##', '##?')
+    building_number_formats = ('%', '%', '%', '%?', '##', '##', '##?', '###',)
+    building_number_suffixes = {
+        'A': 0.2, 'B': 0.2, 'C': 0.2, 'D': 0.1, 'E': 0.1, 'F': 0.1, 'G': 0.05,
+        'H': 0.05}
     postcode_formats = ('####',)
+
+    @classmethod
+    def building_number(cls):
+        suffix = cls.random_element(cls.building_number_suffixes)
+        return cls.numerify(cls.random_element(cls.building_number_formats)).replace('?', suffix)


### PR DESCRIPTION
Fixes unparsed building number suffixes like `Drammensveien 1?`
and improves them with an ok distribution of most used suffix letters.