### PR TITLE
Added ValueError unit test for lorem

### DIFF
--- a/tests/factory.py
+++ b/tests/factory.py
@@ -407,6 +407,10 @@ class FactoryTestCase(unittest.TestCase):
         paragraph = provider.paragraph(0)
         self.assertEqual(paragraph, '')
 
+    def test_words_valueerror(self):
+        f = Factory.create()
+        self.assertRaises(ValueError, f.text, max_nb_chars=4)
+
     def test_no_words_paragraph(self):
         from faker.providers.lorem import Provider
 


### PR DESCRIPTION
Hi.

File faker/providers/lorem/__init__.py had a missing unit test for checking that if ```max_nb_chars``` is below 5, ```ValueError``` is raised. 

This unit test has been now added and coverage improved. 

```python setup.py test``` executed locally - all green.

Thank you.