### PR TITLE
Added company provider to hu_HU locale

### DIFF
--- a/faker/providers/company/hu_HU/__init__.py
+++ b/faker/providers/company/hu_HU/__init__.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as CompanyProvider
+
+
+class Provider(CompanyProvider):
+    formats = (
+        '{{last_name}} {{company_suffix}}',
+        '{{last_name}} {{last_name}} {{company_suffix}}',
+        '{{last_name}}'
+    )
+
+    company_suffixes = (
+        'Kft',
+        'és Tsa',
+        'Kht',
+        'ZRT',
+        'NyRT',
+        'BT'
+    )
+
+    @classmethod
+    def company_suffix(cls):
+        return cls.random_element(cls.company_suffixes)

--- a/tests/providers/company.py
+++ b/tests/providers/company.py
@@ -6,6 +6,7 @@ import unittest
 import re
 
 from faker import Factory
+from faker.providers.company.hu_HU import Provider as HuProvider
 from faker.providers.company.ja_JP import Provider as JaProvider
 from faker.providers.company.pt_BR import Provider as PtProvider, company_id_checksum
 from .. import string_types
@@ -48,3 +49,19 @@ class TestPtBR(unittest.TestCase):
         for _ in range(100):
             cnpj = PtProvider.cnpj()
             self.assertTrue(re.search(r'\d{2}\.\d{3}\.\d{3}/0001-\d{2}', cnpj))
+
+class TestHuHU(unittest.TestCase):
+    """ Tests company in the hu_HU locale """
+
+    def setUp(self):
+        self.factory = Factory.create('hu_HU')
+
+    def test_company_suffix(self):
+        suffixes = HuProvider.company_suffixes
+        suffix = self.factory.company_suffix()
+        assert isinstance(suffix, string_types)
+        assert suffix in suffixes
+
+    def test_company(self):
+        company = self.factory.company()
+        assert isinstance(company, string_types)


### PR DESCRIPTION
Related to issue #490. 

Looks like ```hu_HU``` locale was missing the company localisation. As a consequence, ```fake.company_suffix()``` was returning English results. 

This has now been fixed with unit tests.

```python setup.py test``` executed locally. All green.

Thank you. 