### PR TITLE
Improved hu_HU accuracy

### DIFF
--- a/faker/providers/internet/hu_HU/__init__.py
+++ b/faker/providers/internet/hu_HU/__init__.py
@@ -1,0 +1,33 @@
+# coding=utf8
+from __future__ import unicode_literals
+from .. import Provider as InternetProvider
+
+class Provider(InternetProvider):
+
+    free_email_domains = (
+        'gmail.com',
+        'hotmail.com',
+        'yahoo.com'
+    )
+
+    tlds = (
+        'hu',
+        'com',
+        'com.hu',
+        'info',
+        'org',
+        'net',
+        'biz'
+    )
+
+    replacements = (
+        ('ö', 'o'),
+        ('ü', 'u'),
+        ('á', 'a'),
+        ('é', 'e'),
+        ('í', 'i'),
+        ('ó', 'i'),
+        ('ő', 'o'),
+        ('ú', 'u'),
+        ('ű', 'u')
+    )

--- a/tests/providers/internet.py
+++ b/tests/providers/internet.py
@@ -47,3 +47,18 @@ class TestZhCN(unittest.TestCase):
     def test_email(self):
         email = self.factory.email()
         validate_email(email, check_deliverability=False)
+
+
+class testHuHU(unittest.TestCase):
+    """ Tests internet module in the hu_HU locale. """
+
+    def setUp(self):
+        self.factory = Factory.create('hu')
+
+    def test_internet(self):
+        domain_name = self.factory.domain_name()
+        assert isinstance(domain_name, string_types)
+        tld = self.factory.tld()
+        assert isinstance(tld, string_types)
+        email = self.factory.email()
+        assert isinstance(email, string_types)


### PR DESCRIPTION
Hello.

This is related to issue #490.

Domains and e-mail addresses used to contain accents. These accents have now been removed. 

Unit tests added and ```python setup.py test``` ran locally. All green.

Thank you.