### PR TITLE
Removed capitalisation from hu_HU address

### DIFF
--- a/faker/providers/address/hu_HU/__init__.py
+++ b/faker/providers/address/hu_HU/__init__.py
@@ -131,7 +131,7 @@ class Provider(AddressProvider):
         return cls.random_element(cls.frequent_street_names)
 
     def city(self):
-        return super(Provider, self).city().capitalize()
+        return super(Provider, self).city()
 
     @classmethod
     def postcode(cls):
@@ -140,7 +140,7 @@ class Provider(AddressProvider):
                                    super(Provider, cls).random_digit())
 
     def street_name(self):
-        return super(Provider, self).street_name().upper()
+        return super(Provider, self).street_name().title()
 
     @classmethod
     def building_number(cls):

--- a/tests/providers/address.py
+++ b/tests/providers/address.py
@@ -28,12 +28,22 @@ class TestEnGB(unittest.TestCase):
 class TestHuHU(unittest.TestCase):
     """ Tests addresses in the hu_HU locale """
 
+    def setUp(self):
+        self.factory = Factory.create('hu_HU')
+
     def test_postcode_first_digit(self):
         # Hungarian postcodes begin with 'H-' followed by 4 digits.
         # The first digit may not begin with a zero.
         for i in range(100):
             pcd = HuProvider.postcode()
             assert pcd[2] > "0"
+
+    def test_street_address(self):
+        """ Tests the street address in the hu_HU locale """
+        address = self.factory.address()
+        assert isinstance(address, string_types)
+        address_with_county = self.factory.street_address_with_county()
+        assert isinstance(address_with_county, string_types)
 
 
 class TestJaJP(unittest.TestCase):


### PR DESCRIPTION
Related to #490. 

The complete capitalization of street addresses has now been removed. 

Also added some unit tests to increase this particular coverage.

```python setup.py test``` ran locally - all green.

Thank you.