### PR TITLE
Fix for issue #513 in test test_date_time_between_dates_with_tzinfo

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -4,11 +4,11 @@ from __future__ import unicode_literals
 
 from datetime import timedelta
 import re
-from time import time, mktime
+from time import time
 from calendar import timegm
 
 from dateutil import relativedelta
-from dateutil.tz import tzlocal
+from dateutil.tz import tzutc
 
 from faker.generator import random
 from faker.utils.datetime_safe import date, datetime, real_date, real_datetime
@@ -21,10 +21,8 @@ localized = True
 
 def datetime_to_timestamp(dt):
     if getattr(dt, 'tzinfo', None) is not None:
-        if getattr(dt, 'tzinfo', 'UTC'):
-            return timegm(dt.timetuple())
-        dt = dt.astimezone(tzlocal())
-    return mktime(dt.timetuple())
+        dt = dt.astimezone(tzutc())
+    return timegm(dt.timetuple())
 
 
 timedelta_pattern = r''

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 import re
 from time import time, mktime
+from calendar import timegm
 
 from dateutil import relativedelta
 from dateutil.tz import tzlocal
@@ -20,6 +21,8 @@ localized = True
 
 def datetime_to_timestamp(dt):
     if getattr(dt, 'tzinfo', None) is not None:
+        if getattr(dt, 'tzinfo', 'UTC'):
+            return timegm(dt.timetuple())
         dt = dt.astimezone(tzlocal())
     return mktime(dt.timetuple())
 


### PR DESCRIPTION
Problem was in function datetime_to_timestamp from `faker/providers/date_time/__init__.py`.
`time.mktime()` assumes that the passed tuple is in local time and `calendar.timegm()` assumes it's in UTC.
 After fix in this commit there are no such issue.