### PR TITLE
A configurable lorem provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,38 @@ How to create a Provider
     fake.foo()
     > 'bar'
 
+
+How to customize Lorem
+------------------------
+You can provide your own sets of words if you don't want to use the
+default lorem ipsum one. i.e. with a list of words picked from `cakeipsum <http://www.cupcakeipsum.com/>`__.
+.. code:: python
+
+    from faker import Factory
+    fake = Factory.create()
+
+    my_word_list = [
+    'danish',
+    'cheesecake',
+    'sugar',
+    'Lollipop',
+    'wafer',
+    'Gummies',
+    'sesame',
+    'Jelly',
+    'beans',
+    'pie',
+    'bar',
+    'Ice',
+    'oat'
+    ]
+
+    fake.sentence()
+    #'Expedita at beatae voluptatibus nulla omnis.'
+
+    fake.sentence(ext_word_list=my_word_list)
+    # 'Oat beans oat Lollipop bar cheesecake.'
+
 How to use with Factory Boy
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -248,7 +248,7 @@ How to customize the Lorem Provider
 -----------------------------------
 
 You can provide your own sets of words if you don't want to use the
-default lorem ipsum one. i.e. with a list of words picked from `cakeipsum <http://www.cupcakeipsum.com/>`__ :
+default lorem ipsum one. The following example shows how to do it with a list of words picked from `cakeipsum <http://www.cupcakeipsum.com/>`__ :
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -244,37 +244,29 @@ How to create a Provider
     fake.foo()
     > 'bar'
 
+How to customize the Lorem Provider
+-----------------------------------
 
-How to customize Lorem
-------------------------
 You can provide your own sets of words if you don't want to use the
-default lorem ipsum one. i.e. with a list of words picked from `cakeipsum <http://www.cupcakeipsum.com/>`__.
+default lorem ipsum one. i.e. with a list of words picked from `cakeipsum <http://www.cupcakeipsum.com/>`__ :
+
 .. code:: python
 
     from faker import Factory
     fake = Factory.create()
 
     my_word_list = [
-    'danish',
-    'cheesecake',
-    'sugar',
-    'Lollipop',
-    'wafer',
-    'Gummies',
-    'sesame',
-    'Jelly',
-    'beans',
-    'pie',
-    'bar',
-    'Ice',
-    'oat'
-    ]
+    'danish','cheesecake','sugar',
+    'Lollipop','wafer','Gummies',
+    'sesame','Jelly','beans',
+    'pie','bar','Ice','oat' ]
 
     fake.sentence()
     #'Expedita at beatae voluptatibus nulla omnis.'
 
     fake.sentence(ext_word_list=my_word_list)
     # 'Oat beans oat Lollipop bar cheesecake.'
+
 
 How to use with Factory Boy
 ---------------------------

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -1,8 +1,6 @@
 localized = True
 #default_locale is 'en_US' in the previous State of this application
 default_locale = 'la' 
-#external provider
-external_provider = ''
 
 from .. import BaseProvider
 
@@ -42,9 +40,7 @@ class Provider(BaseProvider):
         'ext_word_list' --- a list of word you would like to have 
                  instead of 'Lorem ipsum'
         """
-        if ext_word_list:
-            return [cls.word(ext_word_list) for _ in range(0, nb)]
-        return [cls.word() for _ in range(0, nb)]
+        return [cls.word(ext_word_list) for _ in range(0, nb)]
 
     @classmethod
     def sentence(cls, nb_words=6, variable_nb_words=True, ext_word_list=None):
@@ -65,10 +61,7 @@ class Provider(BaseProvider):
         if variable_nb_words:
             nb_words = cls.randomize_nb_elements(nb_words)
 
-        if ext_word_list:
-            words = cls.words(nb_words, ext_word_list)
-        else:
-            words = cls.words(nb_words)
+        words = cls.words(nb=nb_words, ext_world_list=ext_world_list)
         words[0] = words[0].title()
 
         return cls.word_connector.join(words) + cls.sentence_punctuation

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -94,9 +94,7 @@ class Provider(BaseProvider):
 
         :return list
         """
-        if ext_word_list:
-            return [cls.sentence(ext_word_list=ext_word_list) for _ in range(0, nb)]
-        return [cls.sentence() for _ in range(0, nb)]
+        return [cls.sentence(ext_word_list=ext_word_list) for _ in range(0, nb)]
 
     @classmethod
     def paragraph(cls, nb_sentences=3, variable_nb_sentences=True, ext_word_list=None):

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -24,6 +24,8 @@ class Provider(BaseProvider):
         Keyword arguments:
         'ext_word_list' --- a list of word you would like to have 
                  instead of 'Lorem ipsum'
+
+        :return string
         """
         if ext_word_list:
             return cls.random_element(ext_word_list)
@@ -39,6 +41,8 @@ class Provider(BaseProvider):
         nb --- how many words to return
         'ext_word_list' --- a list of word you would like to have 
                  instead of 'Lorem ipsum'
+
+        :return list
         """
         return [cls.word(ext_word_list) for _ in range(0, nb)]
 
@@ -54,6 +58,8 @@ class Provider(BaseProvider):
             otherwise $nbWords may vary by +/-40% with a minimum of 1
         :param 'ext_word_list' --- a list of word you would like to have 
                  instead of 'Lorem ipsum'
+
+        :return string
         """
         if nb_words <= 0:
             return ''
@@ -118,6 +124,7 @@ class Provider(BaseProvider):
         :param nb how many paragraphs to return
         :param 'ext_word_list' a list of word you would like to have 
                  instead of 'Lorem ipsum'
+                 
         :return list
         """
 

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -5,13 +5,6 @@ from .. import BaseProvider
 
 
 class Provider(BaseProvider):
-    '''
-    factory.create will enter this class and will and will list all the
-    methods then will go to 'la.__init__'
-
-    Why does it goes to 'la' as soon as it finish to read this class
-    '''
-    #import pytest; pytest.set_trace()
     word_connector = ' '
     sentence_punctuation = '.'
     @classmethod
@@ -123,7 +116,7 @@ class Provider(BaseProvider):
         :param nb how many paragraphs to return
         :param 'ext_word_list' a list of word you would like to have 
                  instead of 'Lorem ipsum'
-                 
+
         :return list
         """
 

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -1,5 +1,4 @@
 localized = True
-#default_locale is 'en_US' in the previous State of this application
 default_locale = 'la' 
 
 from .. import BaseProvider

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -1,37 +1,63 @@
 localized = True
-default_locale = 'la'
+#default_locale is 'en_US' in the previous State of this application
+default_locale = 'la' 
+#external provider
+external_provider = ''
 
 from .. import BaseProvider
 
 
 class Provider(BaseProvider):
+    '''
+    factory.create will enter this class and will and will list all the
+    methods then will go to 'la.__init__'
+
+    Why does it goes to 'la' as soon as it finish to read this class
+    '''
+    #import pytest; pytest.set_trace()
     word_connector = ' '
     sentence_punctuation = '.'
     @classmethod
-    def word(cls):
+    def word(cls, ext_word_list=None):
         """
         Generate a random word
         :example 'lorem'
+
+        Keyword arguments:
+        'ext_word_list' --- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
         """
+        if ext_word_list:
+            return cls.random_element(ext_word_list)
         return cls.random_element(cls.word_list)
 
     @classmethod
-    def words(cls, nb=3):
+    def words(cls, nb=3, ext_word_list=None):
         """
         Generate an array of random words
         :example array('Lorem', 'ipsum', 'dolor')
-        :param nb how many words to return
+
+        Keyword arguments:
+        nb --- how many words to return
+        'ext_word_list' --- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
         """
+        if ext_word_list:
+            return [cls.word(ext_word_list) for _ in range(0, nb)]
         return [cls.word() for _ in range(0, nb)]
 
     @classmethod
-    def sentence(cls, nb_words=6, variable_nb_words=True):
+    def sentence(cls, nb_words=6, variable_nb_words=True, ext_word_list=None):
         """
         Generate a random sentence
         :example 'Lorem ipsum dolor sit amet.'
-        :param nb_words around how many words the sentence should contain
-        :param variable_nb_words set to false if you want exactly $nbWords returned,
+
+        Keyword arguments:
+        :param 'nb_words' --- around how many words the sentence should contain
+        :param 'variable_nb_words' --- set to false if you want exactly $nbWords returned,
             otherwise $nbWords may vary by +/-40% with a minimum of 1
+        :param 'ext_word_list' --- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
         """
         if nb_words <= 0:
             return ''
@@ -39,29 +65,44 @@ class Provider(BaseProvider):
         if variable_nb_words:
             nb_words = cls.randomize_nb_elements(nb_words)
 
-        words = cls.words(nb_words)
+        if ext_word_list:
+            words = cls.words(nb_words, ext_word_list)
+        else:
+            words = cls.words(nb_words)
         words[0] = words[0].title()
 
         return cls.word_connector.join(words) + cls.sentence_punctuation
 
     @classmethod
-    def sentences(cls, nb=3):
+    def sentences(cls, nb=3, ext_word_list=None):
         """
         Generate an array of sentences
         :example array('Lorem ipsum dolor sit amet.', 'Consectetur adipisicing eli.')
-        :param nb how many sentences to return
+
+        Keyword arguments:
+        :param 'nb'--- how many sentences to return
+        :param 'ext_word_list'--- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
+
         :return list
         """
+        if ext_word_list:
+            return [cls.sentence(ext_word_list=ext_word_list) for _ in range(0, nb)]
         return [cls.sentence() for _ in range(0, nb)]
 
     @classmethod
-    def paragraph(cls, nb_sentences=3, variable_nb_sentences=True):
+    def paragraph(cls, nb_sentences=3, variable_nb_sentences=True, ext_word_list=None):
         """
         Generate a single paragraph
         :example 'Sapiente sunt omnis. Ut pariatur ad autem ducimus et. Voluptas rem voluptas sint modi dolorem amet.'
-        :param nb_sentences around how many sentences the paragraph should contain
-        :param variable_nb_sentences set to false if you want exactly $nbSentences returned,
+
+        Keyword arguments:
+        :param 'nb_sentences' --- around how many sentences the paragraph should contain
+        :param 'variable_nb_sentences' --- set to false if you want exactly $nbSentences returned,
             otherwise $nbSentences may vary by +/-40% with a minimum of 1
+        :param 'ext_word_list' --- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
+
         :return string
         """
         if nb_sentences <= 0:
@@ -70,25 +111,40 @@ class Provider(BaseProvider):
         if variable_nb_sentences:
             nb_sentences = cls.randomize_nb_elements(nb_sentences)
 
+        if ext_word_list:
+            return cls.word_connector.join(cls.sentences(
+                nb_sentences, ext_word_list=ext_word_list)
+                )
+
         return cls.word_connector.join(cls.sentences(nb_sentences))
 
     @classmethod
-    def paragraphs(cls, nb=3):
+    def paragraphs(cls, nb=3, ext_word_list=None):
         """
         Generate an array of paragraphs
         :example array($paragraph1, $paragraph2, $paragraph3)
         :param nb how many paragraphs to return
+        :param 'ext_word_list' a list of word you would like to have 
+                 instead of 'Lorem ipsum'
         :return array
         """
+        if ext_word_list:
+            return [cls.paragraph(ext_word_list=ext_word_list) for _ in range(0, nb)]
+
         return [cls.paragraph() for _ in range(0, nb)]
 
     @classmethod
-    def text(cls, max_nb_chars=200):
+    def text(cls, max_nb_chars=200, ext_word_list=None):
         """
         Generate a text string.
         Depending on the $maxNbChars, returns a string made of words, sentences, or paragraphs.
         :example 'Sapiente sunt omnis. Ut pariatur ad autem ducimus et. Voluptas rem voluptas sint modi dolorem amet.'
-        :param max_nb_chars Maximum number of characters the text should contain (minimum 5)
+
+        Keyword arguments:
+        :param 'max_nb_chars' --- Maximum number of characters the text should contain (minimum 5)
+        :param 'ext_word_list' --- a list of word you would like to have 
+                 instead of 'Lorem ipsum'
+
         :return string
         """
         text = []
@@ -101,7 +157,10 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many words are needed to reach the $max_nb_chars once;
                 while size < max_nb_chars:
-                    word = (cls.word_connector if size else '') + cls.word()
+                    if ext_word_list:
+                        word = (cls.word_connector if size else '') + cls.word(ext_word_list=ext_word_list)
+                    else:
+                        word = (cls.word_connector if size else '') + cls.word()
                     text.append(word)
                     size += len(word)
                 text.pop()
@@ -114,7 +173,10 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many sentences are needed to reach the $max_nb_chars once
                 while size < max_nb_chars:
-                    sentence = (cls.word_connector if size else '') + cls.sentence()
+                    if ext_word_list:
+                        sentence = (cls.word_connector if size else '') + cls.sentence(ext_word_list=ext_word_list)
+                    else:
+                        sentence = (cls.word_connector if size else '') + cls.sentence()
                     text.append(sentence)
                     size += len(sentence)
                 text.pop()
@@ -124,7 +186,10 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many paragraphs are needed to reach the $max_nb_chars once
                 while size < max_nb_chars:
-                    paragraph = ('\n' if size else '') + cls.paragraph()
+                    if ext_word_list:
+                        paragraph = ('\n' if size else '') + cls.paragraph(ext_word_list=ext_word_list)
+                    else:
+                        paragraph = ('\n' if size else '') + cls.paragraph()
                     text.append(paragraph)
                     size += len(paragraph)
                 text.pop()

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -1,12 +1,29 @@
 localized = True
+#'Latin' is the default locale
 default_locale = 'la' 
 
 from .. import BaseProvider
 
 
 class Provider(BaseProvider):
+    """Will provide methods to retrieve lorem content
+    
+    Attributes:
+        sentence_punctuation (str): End of sentence punctuation
+        word_connector (str): Default connector between words
+
+    Methods:
+        word: Generate a random word
+        words: Generate a list containing random words
+        sentence: Generate a random sentence
+        sentences: Generate a list containing sentences
+        paragraph: Generate a single paragraph
+        paragraphs: Generate many paragraphs
+        text: Generate a text string.
+    """
     word_connector = ' '
     sentence_punctuation = '.'
+
     @classmethod
     def word(cls, ext_word_list=None):
         """

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -61,7 +61,7 @@ class Provider(BaseProvider):
         if variable_nb_words:
             nb_words = cls.randomize_nb_elements(nb_words)
 
-        words = cls.words(nb=nb_words, ext_world_list=ext_world_list)
+        words = cls.words(nb=nb_words, ext_word_list=ext_word_list)
         words[0] = words[0].title()
 
         return cls.word_connector.join(words) + cls.sentence_punctuation
@@ -104,12 +104,11 @@ class Provider(BaseProvider):
         if variable_nb_sentences:
             nb_sentences = cls.randomize_nb_elements(nb_sentences)
 
-        if ext_word_list:
-            return cls.word_connector.join(cls.sentences(
+        para =  cls.word_connector.join(cls.sentences(
                 nb_sentences, ext_word_list=ext_word_list)
                 )
 
-        return cls.word_connector.join(cls.sentences(nb_sentences))
+        return para
 
     @classmethod
     def paragraphs(cls, nb=3, ext_word_list=None):
@@ -119,12 +118,10 @@ class Provider(BaseProvider):
         :param nb how many paragraphs to return
         :param 'ext_word_list' a list of word you would like to have 
                  instead of 'Lorem ipsum'
-        :return array
+        :return list
         """
-        if ext_word_list:
-            return [cls.paragraph(ext_word_list=ext_word_list) for _ in range(0, nb)]
 
-        return [cls.paragraph() for _ in range(0, nb)]
+        return [cls.paragraph(ext_word_list=ext_word_list) for _ in range(0, nb)]
 
     @classmethod
     def text(cls, max_nb_chars=200, ext_word_list=None):
@@ -150,10 +147,7 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many words are needed to reach the $max_nb_chars once;
                 while size < max_nb_chars:
-                    if ext_word_list:
-                        word = (cls.word_connector if size else '') + cls.word(ext_word_list=ext_word_list)
-                    else:
-                        word = (cls.word_connector if size else '') + cls.word()
+                    word = (cls.word_connector if size else '') + cls.word(ext_word_list=ext_word_list)
                     text.append(word)
                     size += len(word)
                 text.pop()
@@ -166,10 +160,7 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many sentences are needed to reach the $max_nb_chars once
                 while size < max_nb_chars:
-                    if ext_word_list:
-                        sentence = (cls.word_connector if size else '') + cls.sentence(ext_word_list=ext_word_list)
-                    else:
-                        sentence = (cls.word_connector if size else '') + cls.sentence()
+                    sentence = (cls.word_connector if size else '') + cls.sentence(ext_word_list=ext_word_list)
                     text.append(sentence)
                     size += len(sentence)
                 text.pop()
@@ -179,10 +170,7 @@ class Provider(BaseProvider):
                 size = 0
                 # determine how many paragraphs are needed to reach the $max_nb_chars once
                 while size < max_nb_chars:
-                    if ext_word_list:
-                        paragraph = ('\n' if size else '') + cls.paragraph(ext_word_list=ext_word_list)
-                    else:
-                        paragraph = ('\n' if size else '') + cls.paragraph()
+                    paragraph = ('\n' if size else '') + cls.paragraph(ext_word_list=ext_word_list)
                     text.append(paragraph)
                     size += len(paragraph)
                 text.pop()

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -425,6 +425,23 @@ class FactoryTestCase(unittest.TestCase):
         sentence = provider.sentence(0)
         self.assertEqual(sentence, '')
 
+    def test_ext_word_list(self):
+        from faker import Factory
+        fake = Factory.create()
+
+        my_word_list = [
+        'danish',
+        'cheesecake',
+        'sugar',
+        'Lollipop',
+        'wafer',
+        'Gummies',
+        'Jelly',
+        'pie',
+        ]
+        word = fake.word(ext_word_list=my_word_list)
+        self.assertIn(word, my_word_list)
+
     def test_random_pystr_characters(self):
         from faker.providers.python import Provider
         provider = Provider(None)


### PR DESCRIPTION
Following the recommendation of @fcurella, [PR#515](https://github.com/joke2k/faker/pull/515) , I am providing a way so that the user can provide it's own set of words to the **lorem** provider.  I added also a test named **test_ext_word_list** .  

In `lorem/__init__.py` I created a params call **ext_word_list** that stands for **external word list** so that the user can provide a list of words to use with the lorem provider.

As English is not my main language the maintainer can change the parameter **ext_word_list** to something else