### PR TITLE
Generate proper dates before 1970

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -360,7 +360,7 @@ class Provider(BaseProvider):
         start_date = cls._parse_date_time(start_date, tzinfo=tzinfo)
         end_date = cls._parse_date_time(end_date, tzinfo=tzinfo)
         timestamp = random.randint(start_date, end_date)
-        return datetime(1970, 1, 1) + timedelta(seconds=timestamp)
+        return datetime(1970, 1, 1,tzinfo=tzinfo) + timedelta(seconds=timestamp)
 
     @classmethod
     def future_datetime(cls, end_date='+30d', tzinfo=None):

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -360,7 +360,7 @@ class Provider(BaseProvider):
         start_date = cls._parse_date_time(start_date, tzinfo=tzinfo)
         end_date = cls._parse_date_time(end_date, tzinfo=tzinfo)
         timestamp = random.randint(start_date, end_date)
-        return datetime.fromtimestamp(timestamp, tzinfo)
+        return datetime(1970, 1, 1) + timedelta(seconds=timestamp)
 
     @classmethod
     def future_datetime(cls, end_date='+30d', tzinfo=None):


### PR DESCRIPTION
Using timestamp doesn't allow you to generate a date before 1970. In fact, you can even put in (-100y,-90y) as parameters and get a runtime error.