### PR TITLE
Generate blob

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -5,6 +5,7 @@ import hashlib
 import string
 import uuid
 import os
+import sys
 
 from faker.generator import random
 from faker.providers.date_time import Provider as DatetimeProvider
@@ -91,7 +92,8 @@ class Provider(BaseProvider):
 
         Default blob size is 1 Mb.
         """
-        return bytes([random.randrange(256) for o in range(length)])
+        blob = [random.randrange(256) for o in range(length)]
+        return bytes(blob) if sys.version_info[0] >= 3 else bytearray(blob)
 
     @classmethod
     def md5(cls, raw_output=False):

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -91,7 +91,7 @@ class Provider(BaseProvider):
 
         Default blob size is 1 Mb.
         """
-        return os.urandom(length)
+        return bytes([random.randrange(256) for o in range(length)])
 
     @classmethod
     def md5(cls, raw_output=False):


### PR DESCRIPTION
Fixes #488 and #530

Test cases fail due to 
six.binary_type
Type for representing binary data. This is str in Python 2 and bytes in Python 3.

Where python 2 uses str. which is technically correct, but not in this case. Could use isinstance(binary,bytearray) or isinstance(binary,bytes) instead. Could possible do a try decode on it.

try
binary.decode(errors='ignore')