### PR TITLE
fixed female name format typo (issue #541)

### DIFF
--- a/faker/providers/person/hu_HU/__init__.py
+++ b/faker/providers/person/hu_HU/__init__.py
@@ -41,7 +41,7 @@ class Provider(PersonProvider):
     formats_female = OrderedDict((
         ('{{last_name}} {{first_name_female}}', 0.1),
         ('{{last_name}} {{last_name}} {{first_name_female}}', 0.1),
-        ('{{last_name})} {{first_name_female}} {{first_name_female}}', 0.1),
+        ('{{last_name}} {{first_name_female}} {{first_name_female}}', 0.1),
         ('{{first_name_female_abbreviated}} {{last_name}} {{first_name_female}}', 0.1),
         ('{{last_name}} {{first_name_female_abbreviated}} {{first_name_female}}', 0.1),
         ('{{prefix}} {{last_name}} {{first_name_female}}', 0.05),


### PR DESCRIPTION
fixed typo that could result in `{{last_name})}` appearing in a random female names.

Fix for issue #541 