### PR TITLE
start deprecating `Factory.create`

### DIFF
--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -3,4 +3,5 @@ VERSION = '0.8.4'
 from faker.generator import Generator
 from faker.factory import Factory
 
-Faker = Factory.create
+
+Faker = Factory._create

--- a/faker/factory.py
+++ b/faker/factory.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 from importlib import import_module
 import locale as pylocale
+import warnings
 
 from faker import Generator
 from faker.config import DEFAULT_LOCALE, PROVIDERS, AVAILABLE_LOCALES
@@ -14,7 +15,16 @@ from faker.utils.loading import list_module
 class Factory(object):
 
     @classmethod
-    def create(cls, locale=None, providers=None, generator=None, includes=None, **config):
+    def create(cls, *args, **kwargs):
+        if cls.__name__ == 'Factory':
+            warnings.warn(
+                '`Factory.create()` is being deprecated. Use `Faker()` instead.',
+                PendingDeprecationWarning,
+            )
+        return cls._create(*args, **kwargs)
+
+    @classmethod
+    def _create(cls, locale=None, providers=None, generator=None, includes=None, **config):
         if includes is None:
             includes = []
 


### PR DESCRIPTION
ref #453 

This PR will make `Factory.create` raise a warning, so we can give users some time to update their code.

I'm thinking about a 3 months long period. Then we can release `v1.0.0` where we actually deprecate `Factory`.