### PR TITLE
Refactored RGB color methods

### DIFF
--- a/faker/providers/color/__init__.py
+++ b/faker/providers/color/__init__.py
@@ -175,18 +175,9 @@ class Provider(BaseProvider):
         return "#{0}{0}{1}{1}{2}{2}".format(*color)
 
     @classmethod
-    def rgb_color_list(cls):
-        color = cls.hex_color()
-        return (
-            int(color[1:3], 16),
-            int(color[3:5], 16),
-            int(color[5:7], 16),
-        )
-
-    @classmethod
     def rgb_color(cls):
-        return ','.join(map(str, cls.rgb_color_list()))
+        return ','.join(map(str, (cls.random_int(0, 255) for _ in range(3))))
 
     @classmethod
     def rgb_css_color(cls):
-        return 'rgb(%s)' % ','.join(map(str, cls.rgb_color_list()))
+        return 'rgb(%s)' % ','.join(map(str, (cls.random_int(0, 255) for _ in range(3))))


### PR DESCRIPTION
Simplified RGB color generation a little. Previously rgb_color piggybacked off of hex_color, where it then parsed rgb ints from the hex color string, casted them as ints, then formatted them into rgb string. This just generates ints between 0-255 and formats them into a string.

Checked with the color-tests branch and it still passes the unit tests added there. :)