### PR TITLE
Use exact dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,10 @@ setup(
     test_suite='tests',
     zip_safe=zip_safe,
     install_requires=[
-        "email_validator>=1.0.2",
+        "email_validator==1.0.2",
         "python-dateutil>=2.4",
         "six",
-        "ukpostcodeparser>=1.1.1",
+        "ukpostcodeparser==1.1.1",
     ],
     extras_require={
         ':python_version=="2.7"': [

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 mock==1.0.1
-UkPostcodeParser>=1.1.1
-email_validator>=1.0.2
+UkPostcodeParser==1.1.1
+email_validator==1.0.2


### PR DESCRIPTION
This helps downstream projects which use `pip install --require-hashes`, because of the error:

> In --require-hashes mode, all requirements must have their versions pinned with ==.
> These do not.