### PR TITLE
Revert name change of faker.generator.random

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,13 +296,17 @@ used to generate the values:
     fake.random
     fake.random.getstate()
 
+By default all generators share the same instance of ``random.Random``, which
+can be accessed with ``from faker.generator import random``. Using this may
+be useful for plugins that want to affect all faker instances.
+
 Seeding the Generator
 ---------------------
 
 When using Faker for unit testing, you will often want to generate the same
 data set. For convenience, the generator also provide a ``seed()`` method, which
-seeds the random number generator. Calling the same script twice with the same
-seed produces the same results.
+seeds the shared random number generator. Calling the same methods with the
+same version of faker and seed produces the same results.
 
 .. code:: python
 
@@ -313,13 +317,15 @@ seed produces the same results.
     print(fake.name())
     > Margaret Boehm
 
-The code above is equivalent to the following:
+Each generator can also be switched to its own instance of ``random.Random``,
+separate to the shared one, by using the ``seed_instance()`` method, which acts
+the same way. For example:
 
-.. code:: python
+.. code-block:: python
 
     from faker import Faker
     fake = Faker()
-    fake.random.seed(4321)
+    fake.seed_instance(4321)
 
     print(fake.name())
     > Margaret Boehm

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -277,13 +277,17 @@ used to generate the values:
     fake.random
     fake.random.getstate()
 
+By default all generators share the same instance of ``random.Random``, which
+can be accessed with ``from faker.generator import random``. Using this may
+be useful for plugins that want to affect all faker instances.
+
 Seeding the Generator
 ---------------------
 
 When using Faker for unit testing, you will often want to generate the same
 data set. For convenience, the generator also provide a ``seed()`` method, which
-seeds the random number generator. Calling the same script twice with the same
-seed produces the same results.
+seeds the shared random number generator. Calling the same methods with the
+same version of faker and seed produces the same results.
 
 .. code:: python
 
@@ -291,18 +295,20 @@ seed produces the same results.
     fake = Faker()
     fake.seed(4321)
 
-    print fake.name()
+    print(fake.name())
     > Margaret Boehm
 
-The code above is equivalent to the following:
+Each generator can also be switched to its own instance of ``random.Random``,
+separate to the shared one, by using the ``seed_instance()`` method, which acts
+the same way. For example:
 
-.. code:: python
+.. code-block:: python
 
     from faker import Faker
     fake = Faker()
-    fake.random.seed(4321)
+    fake.seed_instance(4321)
 
-    print fake.name()
+    print(fake.name())
     > Margaret Boehm
 
 Tests

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -3,11 +3,12 @@
 from __future__ import unicode_literals
 
 import re
-import random
+import random as random_module
 
 
 _re_token = re.compile(r'\{\{(\s?)(\w+)(\s?)\}\}')
-mod_random = random.Random()
+random = random_module.Random()
+mod_random = random  # compat with name released in 0.8
 
 
 class Generator(object):
@@ -18,7 +19,7 @@ class Generator(object):
         self.providers = []
         self.__config = dict(
             list(self.__config.items()) + list(config.items()))
-        self.__random = mod_random
+        self.__random = random
 
     def add_provider(self, provider):
 
@@ -57,14 +58,14 @@ class Generator(object):
 
     def seed_instance(self, seed=None):
         """Calls random.seed"""
-        if self.__random == mod_random:
+        if self.__random == random:
             # create per-instance random obj when first time seed_instance() is called
-            self.__random = random.Random()
+            self.__random = random_module.Random()
         self.__random.seed(seed)
 
     @classmethod
     def seed(cls, seed=None):
-        mod_random.seed(seed)
+        random.seed(seed)
 
     def format(self, formatter, *args, **kwargs):
         """

--- a/faker/utils/distribution.py
+++ b/faker/utils/distribution.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 
 import bisect
-from faker.generator import mod_random
+from faker.generator import random as mod_random
+
 
 def random_sample(random=None):
     if random is None:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import re
 import unittest
 import string
-import six
 import sys
 
 try:
@@ -14,7 +13,7 @@ except ImportError:  # pragma: no cover
     from io import StringIO
 
 from faker import Generator, Factory
-from faker.generator import mod_random as random
+from faker.generator import random
 from faker.utils import text, decorators
 from . import string_types
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,7 +2,7 @@ from faker.utils.loading import find_available_locales
 from faker.utils.distribution import choice_distribution
 from faker.utils.datasets import add_dicts
 from faker.config import PROVIDERS
-from faker.generator import mod_random
+from faker.generator import random
 from faker.utils.loading import find_available_providers
 from faker.config import META_PROVIDERS_MODULES
 from importlib import import_module
@@ -25,7 +25,7 @@ class UtilsTestCase(unittest.TestCase):
             random_state = json.load(fh)
         random_state[1] = tuple(random_state[1])
 
-        mod_random.setstate(random_state)
+        random.setstate(random_state)
         samples = [choice_distribution(a, p) for i in range(100)]
         a_pop = len([i for i in samples if i == 'a'])
         b_pop = len([i for i in samples if i == 'b'])


### PR DESCRIPTION
Fixes #591. This makes third party code that re-seeds the global faker library work again, after ea4f189bbff1925d7a7e2d7cbc6e91e2e8a9a3f3 changed the name and made attempts to reseed silently fail by affecting the standard random module instead.