### PR TITLE
Add MSISDN provider to pt_br locale

### DIFF
--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -71,3 +71,18 @@ class Provider(PhoneNumberProvider):
         '#### ####',
         '####-####',
     )
+    msisdn_formats = (
+        '5511#########',
+        '5521#########',
+        '5531#########',
+        '5541#########',
+        '5551#########',
+        '5561#########',
+        '5571#########',
+        '5581#########',
+    )
+
+    @classmethod
+    def msisdn(cls):
+        """ https://en.wikipedia.org/wiki/MSISDN """
+        return cls.numerify(cls.random_element(cls.msisdn_formats))

--- a/tests/providers/phone_number.py
+++ b/tests/providers/phone_number.py
@@ -35,3 +35,21 @@ class TestJaJP(unittest.TestCase):
             assert len(second) == 4
             assert len(third) == 4
             assert first in formats
+
+
+
+class TestMSISDN(unittest.TestCase):
+    """ Tests MSISDN in the pt_br locale """
+
+    def setUp(self):
+        self.factory = Factory.create('pt_br')
+
+    def test_msisdn(self):
+        msisdn = self.factory.msisdn()
+        formats = ('5511', '5521', '5531', '5541', '5551', '5561', '5571', '5581')
+
+        assert msisdn is not None
+        assert isinstance(msisdn, string_types)
+        assert len(msisdn) == 13
+        assert msisdn.isdigit()
+        assert msisdn[0:4] in formats


### PR DESCRIPTION
Pull request for issue #595 .

Example:
```python
fake = Factory.create('pt_BR')
fake.msisdn()  # 552113241587
```
Reference:
* https://en.wikipedia.org/wiki/MSISDN