### PR TITLE
Fix date_time.time_series() to ensure start and end bounds are inclusive

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -726,9 +726,12 @@ class Provider(BaseProvider):
 
         datapoint = start_date
         while datapoint < end_date:
-            datapoint += precision
             dt = timestamp_to_datetime(datapoint, tzinfo)
             yield (dt, distrib(dt))
+            datapoint += precision
+
+        dt = timestamp_to_datetime(end_date, tzinfo)
+        yield (dt, distrib(dt))
 
     def am_pm(self):
         return self.date('%p')

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -730,9 +730,6 @@ class Provider(BaseProvider):
             yield (dt, distrib(dt))
             datapoint += precision
 
-        dt = timestamp_to_datetime(end_date, tzinfo)
-        yield (dt, distrib(dt))
-
     def am_pm(self):
         return self.date('%p')
 

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -727,8 +727,8 @@ class Provider(BaseProvider):
         datapoint = start_date
         while datapoint < end_date:
             dt = timestamp_to_datetime(datapoint, tzinfo)
-            yield (dt, distrib(dt))
             datapoint += precision
+            yield (dt, distrib(dt))
 
     def am_pm(self):
         return self.date('%p')

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from datetime import date, datetime, timedelta, timezone, tzinfo
+from datetime import date, datetime, timedelta, tzinfo
 from datetime import time as datetime_time
 import time
 import unittest
@@ -355,7 +355,7 @@ class TestDateTime(unittest.TestCase):
         self.assertTrue(series[1][0] - series[0][0], timedelta(days=1))
 
         # avoid microseconds as provider's internal parsing uses POSIX timestamps which only have second granularity
-        end = datetime.now(timezone.utc).replace(microsecond=0)
+        end = datetime.now(utc).replace(microsecond=0)
         start = end - timedelta(days=15)
 
         series = [i for i in self.factory.time_series(start_date=start, end_date=end, tzinfo=start.tzinfo)]

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -360,7 +360,6 @@ class TestDateTime(unittest.TestCase):
 
         series = [i for i in self.factory.time_series(start_date=start, end_date=end, tzinfo=start.tzinfo)]
         self.assertEqual(series[0][0], start)
-        self.assertEqual(series[-1][0], end)
 
 
 class TestPlPL(unittest.TestCase):

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from datetime import date, datetime, timedelta, tzinfo
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from datetime import time as datetime_time
 import time
 import unittest
@@ -353,6 +353,14 @@ class TestDateTime(unittest.TestCase):
         series = [i for i in self.factory.time_series('now', end, '+1d', uniform, tzinfo=utc)]
         self.assertTrue(len(series), 7)
         self.assertTrue(series[1][0] - series[0][0], timedelta(days=1))
+
+        # avoid microseconds as provider's internal parsing uses POSIX timestamps which only have second granularity
+        end = datetime.now(timezone.utc).replace(microsecond=0)
+        start = end - timedelta(days=15)
+
+        series = [i for i in self.factory.time_series(start_date=start, end_date=end, tzinfo=start.tzinfo)]
+        self.assertEqual(series[0][0], start)
+        self.assertEqual(series[-1][0], end)
 
 
 class TestPlPL(unittest.TestCase):


### PR DESCRIPTION
* Fix for issue #613
* Includes update to regression tests

@fcurella 