### PR TITLE
Australian unit tests

### DIFF
--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -93,7 +93,11 @@ class TestEnAU(unittest.TestCase):
         state = self.factory.state()
         assert isinstance(state, string_types)
         assert state in EnAuProvider.states
-        
+
+    def test_city_prefix(self):
+        city_prefix = self.factory.city_prefix()
+        assert isinstance(city_prefix, string_types)
+        assert city_prefix in EnAuProvider.city_prefixes
 
 
 class TestEnGB(unittest.TestCase):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -78,6 +78,7 @@ class TestElGR(unittest.TestCase):
         assert isinstance(latitude, Decimal)
         assert isinstance(longitude, Decimal)
 
+
 class TestEnAU(unittest.TestCase):
     """ Tests addresses in the en_AU locale """
 
@@ -104,6 +105,7 @@ class TestEnAU(unittest.TestCase):
         assert isinstance(state_abbr, string_types)
         assert state_abbr in EnAuProvider.states_abbr
         self.assertTrue(state_abbr.isupper())
+
 
 class TestEnGB(unittest.TestCase):
     """ Tests addresses in the en_GB locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -99,6 +99,11 @@ class TestEnAU(unittest.TestCase):
         assert isinstance(city_prefix, string_types)
         assert city_prefix in EnAuProvider.city_prefixes
 
+    def test_state_abbr(self):
+        state_abbr = self.factory.state_abbr()
+        assert isinstance(state_abbr, string_types)
+        assert state_abbr in EnAuProvider.states_abbr
+        self.assertTrue(state_abbr.isupper())
 
 class TestEnGB(unittest.TestCase):
     """ Tests addresses in the en_GB locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -11,7 +11,7 @@ from ukpostcodeparser.parser import parse_uk_postcode
 from faker import Factory
 from faker.providers.address.de_DE import Provider as DeProvider
 from faker.providers.address.el_GR import Provider as GrProvider
-from faker.providers.address.en_AU import Provider as AuProvider
+from faker.providers.address.en_AU import Provider as EnAuProvider
 from faker.providers.address.hu_HU import Provider as HuProvider
 from faker.providers.address.ja_JP import Provider as JaProvider
 from faker.providers.address.ne_NP import Provider as NeProvider
@@ -88,6 +88,12 @@ class TestEnAU(unittest.TestCase):
         for _ in range(100):
             postcode = self.factory.postcode()
             assert re.match("\d{4}", postcode)
+
+    def test_state(self):
+        state = self.factory.state()
+        assert isinstance(state, string_types)
+        assert state in EnAuProvider.states
+        
 
 
 class TestEnGB(unittest.TestCase):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -77,6 +77,12 @@ class TestElGR(unittest.TestCase):
         assert isinstance(latitude, Decimal)
         assert isinstance(longitude, Decimal)
 
+class TestEnAU(unittest.TestCase):
+    """ Tests addresses in the en_AU locale """
+
+    def setup(self):
+        self.factory = Factory.create('en_AU')
+
 
 class TestEnGB(unittest.TestCase):
     """ Tests addresses in the en_GB locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -11,6 +11,7 @@ from ukpostcodeparser.parser import parse_uk_postcode
 from faker import Factory
 from faker.providers.address.de_DE import Provider as DeProvider
 from faker.providers.address.el_GR import Provider as GrProvider
+from faker.providers.address.en_AU import Provider as AuProvider
 from faker.providers.address.hu_HU import Provider as HuProvider
 from faker.providers.address.ja_JP import Provider as JaProvider
 from faker.providers.address.ne_NP import Provider as NeProvider
@@ -80,8 +81,13 @@ class TestElGR(unittest.TestCase):
 class TestEnAU(unittest.TestCase):
     """ Tests addresses in the en_AU locale """
 
-    def setup(self):
+    def setUp(self):
         self.factory = Factory.create('en_AU')
+
+    def test_postcode(self):
+        for _ in range(100):
+            postcode = self.factory.postcode()
+            assert re.match("\d{4}", postcode)
 
 
 class TestEnGB(unittest.TestCase):


### PR DESCRIPTION
Hi. 

Looks like ```EnAU``` locale was missing unit tests in the address module. These tests have been now implemented. 

Unit tests ran locally - all green.

Thank you. 