### PR TITLE
Removed potentially offensive phrases

### DIFF
--- a/faker/providers/person/de_DE/__init__.py
+++ b/faker/providers/person/de_DE/__init__.py
@@ -401,7 +401,7 @@ class Provider(PersonProvider):
         'Siering', 'Söding', 'Sölzer', 'Sontag', 'Sorgatz', 'Speer', 'Spieß',
         'Stadelmann', 'Stahr', 'Staude', 'Steckel', 'Steinberg', 'Stey',
         'Stiebitz', 'Stiffel', 'Stoll', 'Stolze', 'Striebitz', 'Stroh',
-        'Stumpf', 'Sucker', 'Süßebier', 'Täsche', 'Textor', 'Thanel', 'Thies',
+        'Stumpf', 'Süßebier', 'Täsche', 'Textor', 'Thanel', 'Thies',
         'Tintzmann', 'Tlustek', 'Trapp', 'Trommler', 'Tröst', 'Trub', 'Trüb',
         'Trubin', 'Trupp', 'Tschentscher', 'Ullmann', 'Ullrich',
         'van der Dussen', 'Vogt', 'Vollbrecht', 'Wagenknecht', 'Wagner', 'Wähner',


### PR DESCRIPTION
Removing 'Sucker' from the list of surnames to avoid any concerns when results are exposed to public.

This is exactly same situation as with PR #379 and it's main intention is to make it safe for developers to use the results of this library in a publicly facing context.

I understand that this project could benefit from having some names that expose [Scunthorpe Problem](https://en.wikipedia.org/wiki/Scunthorpe_problem), but this may as well be a purpose for a completely separate library.