### PR TITLE
Close #622. Add en_GB cellphone formats

### DIFF
--- a/faker/providers/phone_number/en_GB/__init__.py
+++ b/faker/providers/phone_number/en_GB/__init__.py
@@ -3,6 +3,15 @@ from .. import Provider as PhoneNumberProvider
 
 
 class Provider(PhoneNumberProvider):
+    # Source: https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom
+
+    cellphone_formats = (
+        '+44 7### ######',
+        '+44 7#########',
+        '07### ######',
+        '07#########',
+    )
+
     formats = (
         '+44(0)##########',
         '+44(0)#### ######',
@@ -15,3 +24,7 @@ class Provider(PhoneNumberProvider):
         '(0####) ######',
         '(0####) #####',
     )
+
+    def cellphone_number(self):
+        pattern = self.random_element(self.cellphone_formats)
+        return self.numerify(self.generator.parse(pattern))


### PR DESCRIPTION
Fixes #622.

Primary source:
https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom#Mobile_telephones

***

Example:

```python
import faker

from faker import Faker
fake = Faker('en_GB')
for _ in range(10):
    print(fake.cellphone_number())
```

```
07352099948
+44 7466113027
+44 7894363975
07353912887
07151 252843
07925 440819
07179 121894
07603681069
07349589776
07849352443
```