### PR TITLE
Fix infinite loop random sample unique

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+from collections import Counter
 import re
 import string
 
@@ -120,7 +121,10 @@ class BaseProvider(object):
     def random_sample_unique(self, elements=('a', 'b', 'c'), length=None):
         """
         Returns a `set` of random unique elements for the specified length.
+        Multiple occurances of the same value increase its probabilty to be in the output.
         """
+        if not isinstance(elements, dict):
+            elements = Counter(elements)
         if length is None:
             length = self.generator.random.randint(1, len(elements))
 

--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -130,8 +130,10 @@ class BaseProvider(object):
         if length > len(elements):
             raise ValueError("Sample length cannot be longer than the number of unique elements to pick from.")
         sample = set()
-        while len(sample) < length:
-            sample.add(self.random_element(elements))
+        for _ in range(length):
+            element = self.random_element(elements)
+            sample.add(element)
+            elements.pop(element)
         return sample
 
     def randomize_nb_elements(self, number=10, le=False, ge=False, min=None, max=None):

--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -123,13 +123,12 @@ class BaseProvider(object):
         Returns a `set` of random unique elements for the specified length.
         Multiple occurances of the same value increase its probabilty to be in the output.
         """
-        if not isinstance(elements, dict):
-            elements = Counter(elements)
+        elements = Counter(elements)
         if length is None:
             length = self.generator.random.randint(1, len(elements))
 
         if length > len(elements):
-            raise ValueError("Sample length cannot be longer than the number of elements to pick from.")
+            raise ValueError("Sample length cannot be longer than the number of unique elements to pick from.")
         sample = set()
         while len(sample) < length:
             sample.add(self.random_element(elements))

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -390,7 +390,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.providers import BaseProvider
         provider = BaseProvider(self.generator)
 
-        # To many items requested
+        # Too many items requested
         with self.assertRaises(ValueError):
             provider.random_sample_unique('abcde', 6)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -390,13 +390,25 @@ class FactoryTestCase(unittest.TestCase):
         from faker.providers import BaseProvider
         provider = BaseProvider(self.generator)
 
+        # To many items requested
+        with self.assertRaises(ValueError):
+            provider.random_sample_unique('abcde', 6)
+
+        # Duplicate inputs reduced to unique set
+        with self.assertRaises(ValueError):
+            provider.random_sample_unique('aabcd', 5)
+
+        # Same length
+        sample = provider.random_sample_unique('aabcd', 4)
+        self.assertEqual(sample, set('abcd'))
+
+        sample = provider.random_sample_unique('abcde', 5)
+        self.assertEqual(sample, set('abcde'))
+
+        # Length = 3
         sample = provider.random_sample_unique('abcde', 3)
         self.assertEqual(len(sample), 3)
         self.assertTrue(sample.issubset(set('abcde')))
-
-        # Same length
-        sample = provider.random_sample_unique('abcde', 5)
-        self.assertEqual(sample, set('abcde'))
 
         # Length = 1
         sample = provider.random_sample_unique('abcde', 1)
@@ -406,10 +418,6 @@ class FactoryTestCase(unittest.TestCase):
         # Length = 0
         sample = provider.random_sample_unique('abcde', 0)
         self.assertEqual(sample, set())
-
-        # Length = 0
-        with self.assertRaises(ValueError):
-            provider.random_sample_unique('abcde', 6)
 
     def test_random_number(self):
         from faker.providers import BaseProvider


### PR DESCRIPTION
This is fixed by using `collections.Counter` on the elements (if not already a dict). Duplicate values are then removed so the length of the elements should be the number of unique elements. Using `collections.Counter` counts the occurrence of elements to maintain the higher probability for those values to be in the final sample.

Before this change the following would result in an infinite loop:
```python
from faker import Generator
from faker.providers import BaseProvider
provider = BaseProvider(Generator())
provider.random_sample_unique('aabcd', 5)
```
Because the sample will never be 5 values long because there are only 4 unique values (`'abcd'`) in the provided elements.