### PR TITLE
added iban provider

### DIFF
--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+
+from .. import BaseProvider
+
+import string
+from string import ascii_uppercase
+import re
+
+localized = True
+
+class Provider(BaseProvider):
+    
+    ALPHA = {c: str(ord(c) % 55) for c in string.ascii_uppercase}
+
+     # see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+    bban_format = '????#############'
+    country_code = 'GB'
+
+    def bank_country(self):
+        return self.country_code
+
+    def bban(self):
+        temp = re.sub(r'\?',
+            lambda x: self.random_element(ascii_uppercase), 
+            self.bban_format)
+        return self.numerify(temp)
+
+    def iban(self):
+        bban = self.bban()
+
+        check = bban + self.country_code + '00'
+        check = int(''.join(self.ALPHA.get(c, c) for c in check))
+        check = 98 - (check % 97)
+        check = str(check).zfill(2)
+
+        return self.country_code + check + bban

--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -1,12 +1,12 @@
 # coding=utf-8
 
-from .. import BaseProvider
+localized = True
+default_locale = 'en_GB'
 
+from .. import BaseProvider
 import string
 from string import ascii_uppercase
 import re
-
-localized = True
 
 class Provider(BaseProvider):
     """
@@ -17,7 +17,7 @@ class Provider(BaseProvider):
     
     ALPHA = {c: str(ord(c) % 55) for c in string.ascii_uppercase}
 
-     # see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+    # see https://en.wikipedia.org/wiki/International_Bank_Account_Number
     bban_format = '????#############'
     country_code = 'GB'
 

--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -9,6 +9,11 @@ import re
 localized = True
 
 class Provider(BaseProvider):
+    """
+    Provider for IBAN/BBAN: it generates valid (valid length, valid checksum)
+    IBAN/BBANs for the given country. But the ids of the banks are random and
+    not valid banks! Same for account numbers.
+    """
     
     ALPHA = {c: str(ord(c) % 55) for c in string.ascii_uppercase}
 

--- a/faker/providers/bank/de_AT/__init__.py
+++ b/faker/providers/bank/de_AT/__init__.py
@@ -1,0 +1,6 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    bban_format = '################'
+    country_code = 'AT'

--- a/faker/providers/bank/de_AT/__init__.py
+++ b/faker/providers/bank/de_AT/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BankProvider
 
-
 class Provider(BankProvider):
     bban_format = '################'
     country_code = 'AT'

--- a/faker/providers/bank/de_DE/__init__.py
+++ b/faker/providers/bank/de_DE/__init__.py
@@ -1,0 +1,6 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    bban_format = '##################'
+    country_code = 'DE'

--- a/faker/providers/bank/de_DE/__init__.py
+++ b/faker/providers/bank/de_DE/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BankProvider
 
-
 class Provider(BankProvider):
     bban_format = '##################'
     country_code = 'DE'

--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -1,0 +1,6 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    bban_format = '????#############'
+    country_code = 'GB'

--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BankProvider
 
-
 class Provider(BankProvider):
     bban_format = '????#############'
     country_code = 'GB'

--- a/faker/providers/bank/en_US/__init__.py
+++ b/faker/providers/bank/en_US/__init__.py
@@ -1,0 +1,7 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    # no IBAN in en_US! but need to provide a class for the tests!
+    bban_format = '??##'
+    country_code = 'US'

--- a/faker/providers/bank/en_US/__init__.py
+++ b/faker/providers/bank/en_US/__init__.py
@@ -1,7 +1,0 @@
-from .. import Provider as BankProvider
-
-
-class Provider(BankProvider):
-    # no IBAN in en_US! but need to provide a class for the tests!
-    bban_format = '??##'
-    country_code = 'US'

--- a/faker/providers/bank/fr_FR/__init__.py
+++ b/faker/providers/bank/fr_FR/__init__.py
@@ -1,0 +1,6 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    bban_format = '########################'
+    country_code = 'FR'

--- a/faker/providers/bank/fr_FR/__init__.py
+++ b/faker/providers/bank/fr_FR/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BankProvider
 
-
 class Provider(BankProvider):
     bban_format = '########################'
     country_code = 'FR'

--- a/faker/providers/bank/it_IT/__init__.py
+++ b/faker/providers/bank/it_IT/__init__.py
@@ -1,0 +1,6 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    bban_format = '?######################'
+    country_code = 'IT'

--- a/faker/providers/bank/it_IT/__init__.py
+++ b/faker/providers/bank/it_IT/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BankProvider
 
-
 class Provider(BankProvider):
     bban_format = '?######################'
     country_code = 'IT'

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -61,6 +61,7 @@ class UtilsTestCase(unittest.TestCase):
         expected_providers = list(map(str, [
             'faker.providers.address',
             'faker.providers.automotive',
+            'faker.providers.bank',
             'faker.providers.barcode',
             'faker.providers.color',
             'faker.providers.company',


### PR DESCRIPTION
### What does this changes

see #643 
added a provider for fake iban/bban data.
the iban/bban codes are valid in term of checksum, but they do not hold valid bank identifiers or account numbers.
IBAN format was taken from wikipedia https://en.wikipedia.org/wiki/International_Bank_Account_Number

country support is far from complete, but can be extended easily
