### PR TITLE
fix incorrect value for that seed value

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -299,7 +299,7 @@ same version of faker and seed produces the same results.
     fake.seed(4321)
 
     print(fake.name())
-    > Margaret Boehm
+    > Jason Brown
 
 Each generator can also be switched to its own instance of ``random.Random``,
 separate to the shared one, by using the ``seed_instance()`` method, which acts


### PR DESCRIPTION
### What does this changes
The name on the front page of the documentation for the section with the seeds

### What was wrong
The name for the given seed. Probably because the underlying data changed since that section was written/updated

### How this fixes it

Trivial
