### PR TITLE
Remove extras_require for unsupported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,11 +74,5 @@ setup(
         ':python_version=="2.7"': [
             'ipaddress',
         ],
-        ':python_version=="3.0"': [
-            'importlib',
-        ],
-        ':python_version=="3.2"': [
-            'ipaddress',
-        ],
     }
 )


### PR DESCRIPTION
Python 3.0 and 3.2 are not tested, nor supported. Drop the reference in `extras_require`.
