### PR TITLE
Remove support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
     - master
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
-
 Changelog
 =========
+
+UNRELEASED
+----------
+
+* Remove support for Python 3.3.
 
 `0.8.8 - 19-December-2017 <https://github.com/joke2k/faker/compare/v0.8.7...v0.8.8>`__
 --------------------------------------------------------------------------------------
@@ -437,4 +441,3 @@ Changelog
 -----------------
 
 * First release
-

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,333,344,350,36,py250,py3240}
+envlist=py{27,344,350,36,py250,py3240}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 3.3 is EOL. It is no longer receiving bug fixes, including for security issues. It has been EOL since 2017-09-29.

https://devguide.python.org/#status-of-python-branches

Reduces test load.
