### PR TITLE
Close #667. Allow past dates within a second

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1342,7 +1342,10 @@ class Provider(BaseProvider):
         """
         start_date = self._parse_date_time(start_date, tzinfo=tzinfo)
         end_date = self._parse_date_time(end_date, tzinfo=tzinfo)
-        ts = self.generator.random.randint(start_date, end_date)
+        if end_date - start_date <= 1:
+            ts = start_date + self.generator.random.random()
+        else:
+            ts = self.generator.random.randint(start_date, end_date)
         return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
 
     def date_between(self, start_date='-30y', end_date='today'):

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -191,6 +191,10 @@ class TestDateTime(unittest.TestCase):
         self.assertTrue(datetime_start <= random_date)
         self.assertTrue(datetime_end >= random_date)
 
+    def test_past_datetime_within_second(self):
+        # Should not raise a ``ValueError``
+        self.factory.past_datetime(start_date='+1s')
+
     def test_date_between_dates(self):
         date_end = date.today()
         date_start = date_end - timedelta(days=10)


### PR DESCRIPTION
### What does this changes

We test for the difference between `start_date` and `end_date` in `date_time_between`. If it's `<= 1`,  we generate a random number between `0.0` and `1.0` by using `random.random()` instead of using `random.randint()`

### What was wrong

When the difference between `start_date` and `end_date` in `date_time_between` is <= 1 second, the call to `random.randomint` fails with a `ValueError`

### How this fixes it

`random.random()` won't raise `ValueError` when the difference is `<= 1`

Fixes #667

  
  