### PR TITLE
Implement schema selection for internet url provider

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -46,10 +46,8 @@ class Provider(BaseProvider):
         '{{user_name}}@{{free_email_domain}}',
     )
     url_formats = (
-        'http://www.{{domain_name}}/',
-        'http://{{domain_name}}/',
-        'https://www.{{domain_name}}/',
-        'https://{{domain_name}}/',
+        '://www.{{domain_name}}/',
+        '://{{domain_name}}/',
     )
     uri_formats = (
         '{{url}}',
@@ -165,22 +163,12 @@ class Provider(BaseProvider):
     def tld(self):
         return self.random_element(self.tlds)
 
-    def _filter_url_formats(self, exclude_scheme):
-        if not isinstance(exclude_scheme, str):
-            raise ValueError('exclude_scheme param should be a string')
-        if exclude_scheme.lower() not in ['https', 'http']:
-            raise ValueError('exclude_scheme param should either `http` or `https`')
+    def url(self, schemes=None):
+        if not schemes:
+            schemes = ['http', 'https']
 
-        pattern = '{}://'.format(exclude_scheme)
-        return filter(lambda f: not f.startswith(pattern), self.url_formats)
+        pattern = '{}{}'.format(self.random_element(schemes), self.random_element(self.url_formats))
 
-    def url(self, exclude_scheme=None):
-        formats_allowed = self.url_formats
-
-        if exclude_scheme:
-            formats_allowed = self._filter_url_formats(exclude_scheme)
-
-        pattern = self.random_element(formats_allowed)
         return self.generator.parse(pattern)
 
     def ipv4(self, network=False):

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -165,8 +165,22 @@ class Provider(BaseProvider):
     def tld(self):
         return self.random_element(self.tlds)
 
-    def url(self):
-        pattern = self.random_element(self.url_formats)
+    def _filter_url_formats(self, exclude_scheme):
+        if not isinstance(exclude_scheme, str):
+            raise ValueError('exclude_scheme param should be a string')
+        if exclude_scheme.lower() not in ['https', 'http']:
+            raise ValueError('exclude_scheme param should either `http` or `https`')
+
+        pattern = '{}://'.format(exclude_scheme)
+        return filter(lambda f: not f.startswith(pattern), self.url_formats)
+
+    def url(self, exclude_scheme=None):
+        formats_allowed = self.url_formats
+
+        if exclude_scheme:
+            formats_allowed = self._filter_url_formats(exclude_scheme)
+
+        pattern = self.random_element(formats_allowed)
         return self.generator.parse(pattern)
 
     def ipv4(self, network=False):

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -46,8 +46,8 @@ class Provider(BaseProvider):
         '{{user_name}}@{{free_email_domain}}',
     )
     url_formats = (
-        '://www.{{domain_name}}/',
-        '://{{domain_name}}/',
+        'www.{{domain_name}}/',
+        '{{domain_name}}/',
     )
     uri_formats = (
         '{{url}}',
@@ -164,10 +164,20 @@ class Provider(BaseProvider):
         return self.random_element(self.tlds)
 
     def url(self, schemes=None):
-        if not schemes:
+        """
+        :param schemes: a list of strings to use as schemes, one will chosen randomly.
+        If None, it will generate http and https urls.
+        Passing an empty list will result in schemeless url generation like "://domain.com".
+
+        :returns: a random url string.
+        """
+        if schemes is None:
             schemes = ['http', 'https']
 
-        pattern = '{}{}'.format(self.random_element(schemes), self.random_element(self.url_formats))
+        pattern = '{}://{}'.format(
+            self.random_element(schemes) if schemes else "",
+            self.random_element(self.url_formats)
+        )
 
         return self.generator.parse(pattern)
 

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from itertools import cycle
+
 import unittest
 
 import mock
@@ -32,28 +34,23 @@ class TestInternetProviderUrl(unittest.TestCase):
         self.factory = Faker()
 
     @staticmethod
-    def is_http(url):
-        return url.startswith('http://')
+    def is_correct_scheme(url, schemes):
+        return any(url.startswith('{}://'.format(scheme)) for scheme in schemes)
 
-    @staticmethod
-    def is_https(url):
-        return url.startswith('https://')
+    def test_url_default_schemes(self):
+        for _ in range(100):
+            url = self.factory.url()
+            self.assertTrue(self.is_correct_scheme(url, ['http', 'https']))
 
-    def test_url(self):
-        urls = [self.factory.url() for i in range(100)]
-        self.assertTrue(all(self.is_http(url) or self.is_https(url) for url in urls))
-
-    def test_url_only_http(self):
-        urls = [self.factory.url(exclude_scheme='https') for i in range(100)]
-        self.assertTrue(all(self.is_http(url) for url in urls))
-
-    def test_url_only_https(self):
-        urls = [self.factory.url(exclude_scheme='http') for i in range(100)]
-        self.assertTrue(all(self.is_https(url) for url in urls))
-
-    def test_url_raises_error(self):
-        with self.assertRaises(ValueError):
-            self.factory.url(exclude_scheme=['http', 'https'])
+    def test_url_custom_schemes(self):
+        schemes_sets = [
+            ['usb'],
+            ['ftp', 'file'],
+            ['usb', 'telnet', 'http'],
+        ]
+        for _, schemes in zip(range(100), cycle(schemes_sets)):
+            url = self.factory.url(schemes=schemes)
+            self.assertTrue(self.is_correct_scheme(url, schemes))
 
 
 class TestJaJP(unittest.TestCase):

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -25,6 +25,36 @@ class TestInternetProvider(unittest.TestCase):
         self.assertEqual(email.split('@')[1], 'example.com')
 
 
+class TestInternetProviderUrl(unittest.TestCase):
+    """ Test internet url generation """
+
+    def setUp(self):
+        self.factory = Faker()
+
+    @staticmethod
+    def is_http(url):
+        return url.startswith('http://')
+
+    @staticmethod
+    def is_https(url):
+        return url.startswith('https://')
+
+    def test_url(self):
+        urls = [self.factory.url() for i in range(100)]
+        self.assertTrue(all(self.is_http(url) or self.is_https(url) for url in urls))
+
+    def test_url_only_http(self):
+        urls = [self.factory.url(https=False) for i in range(100)]
+        self.assertTrue(all(self.is_http(url) for url in urls))
+
+    def test_url_only_https(self):
+        urls = [self.factory.url(http=False) for i in range(100)]
+        self.assertTrue(all(self.is_https(url) for url in urls))
+
+    def test_url_raises_error(self):
+        self.assertRaises(ValueError, self.factory.url(http=False, https=False))
+
+
 class TestJaJP(unittest.TestCase):
     """ Tests internet in the ja_JP locale """
 

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -52,6 +52,12 @@ class TestInternetProviderUrl(unittest.TestCase):
             url = self.factory.url(schemes=schemes)
             self.assertTrue(self.is_correct_scheme(url, schemes))
 
+    def test_url_empty_schemes_list_generate_schemeless_urls(self):
+        for _ in range(100):
+            url = self.factory.url(schemes=[])
+            self.assertFalse(url.startswith('http'))
+            self.assertTrue(url.startswith('://'))
+
 
 class TestJaJP(unittest.TestCase):
     """ Tests internet in the ja_JP locale """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -44,15 +44,16 @@ class TestInternetProviderUrl(unittest.TestCase):
         self.assertTrue(all(self.is_http(url) or self.is_https(url) for url in urls))
 
     def test_url_only_http(self):
-        urls = [self.factory.url(https=False) for i in range(100)]
+        urls = [self.factory.url(exclude_scheme='https') for i in range(100)]
         self.assertTrue(all(self.is_http(url) for url in urls))
 
     def test_url_only_https(self):
-        urls = [self.factory.url(http=False) for i in range(100)]
+        urls = [self.factory.url(exclude_scheme='http') for i in range(100)]
         self.assertTrue(all(self.is_https(url) for url in urls))
 
     def test_url_raises_error(self):
-        self.assertRaises(ValueError, self.factory.url(http=False, https=False))
+        with self.assertRaises(ValueError):
+            self.factory.url(exclude_scheme=['http', 'https'])
 
 
 class TestJaJP(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Adds the ability to generate url with control over the scheme.

### What was wrong

It is currently not possible. A random `http` or `https` url is generated.
Related to: https://github.com/joke2k/faker/issues/692

### How this fixes it

Adding optional parameter to internet provider `url` method.

The actual signature change is my proposal, i don't know if it's reasonable or good enough.
I'll do better test cases (and implementation?) if this change in behavior will be accepted.

