### PR TITLE
Increase lower bound on AD date generation

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1209,7 +1209,7 @@ class Provider(BaseProvider):
         :return datetime
         """
         end_datetime = self._parse_end_datetime(end_datetime)
-        ts = self.generator.random.randint(-62135600400, end_datetime)
+        ts = self.generator.random.randint(-62135596800, end_datetime)
         # NOTE: using datetime.fromtimestamp(ts) directly will raise
         #       a "ValueError: timestamp out of range for platform time_t"
         #       on some platforms due to system C functions;


### PR DESCRIPTION
### What does this changes

Increases the lower bound on AD date generation by one hour.

### What was wrong

The lower bound was one hour too far, which meant that it was possible to pick dates logically as far as one hour into BCE. This led to an OverflowError.

### How this fixes it

As far as the lowest possible value for `ts` now, this does not generate an `OverflowError` for underflow into BCE.

Fixes #696 