### PR TITLE
issue #700: Added the ability to specify the min and max age for some…

### DIFF
--- a/faker/providers/ssn/et_EE/__init__.py
+++ b/faker/providers/ssn/et_EE/__init__.py
@@ -29,12 +29,10 @@ def checksum(digits):
 
 
 class Provider(SsnProvider):
-    min_age = 16 * 365
-    max_age = 90 * 365
     scale1 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 1)
     scale2 = (3, 4, 5, 6, 7, 8, 9, 1, 2, 3)
 
-    def ssn(self):
+    def ssn(self, min_age=16, max_age=90):
         """
         Returns 11 character Estonian personal identity code (isikukood, IK).
 
@@ -51,7 +49,7 @@ class Provider(SsnProvider):
         """
         age = datetime.timedelta(
             days=self.generator.random.randrange(
-                self.min_age, self.max_age))
+                min_age * 365, max_age * 365))
         birthday = datetime.date.today() - age
         if birthday.year < 2000:
             ik = self.generator.random.choice(('3', '4'))

--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -7,7 +7,7 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self):
+    def ssn(self, min_age=18, max_age=90):
         """
         Returns 11 character Finnish personal identity code (Henkilötunnus,
         HETU, Swedish: Personbeteckning). Age of person is between 18 and 90
@@ -29,10 +29,8 @@ class Provider(SsnProvider):
             checksum_characters = "0123456789ABCDEFHJKLMNPRSTUVWXY"
             return checksum_characters[int(hetu) % 31]
 
-        min_age = 18 * 365
-        max_age = 90 * 365
         age = datetime.timedelta(
-            days=self.generator.random.randrange(min_age, max_age))
+            days=self.generator.random.randrange(min_age * 365, max_age * 365))
         birthday = datetime.date.today() - age
         hetu_date = "%02d%02d%s" % (
             birthday.day, birthday.month, str(birthday.year)[-2:])

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -7,7 +7,7 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self):
+    def ssn(self, min_age=18, max_age=90):
         """
         Returns a 10 digit Swedish SSN, "Personnummer".
 
@@ -33,10 +33,8 @@ class Provider(SsnProvider):
             check_digit = _luhn_checksum(int(partial_number) * 10)
             return check_digit if check_digit == 0 else 10 - check_digit
 
-        min_age = 18 * 365
-        max_age = 90 * 365
         age = datetime.timedelta(
-            days=self.generator.random.randrange(min_age, max_age))
+            days=self.generator.random.randrange(min_age * 365, max_age * 365))
         birthday = datetime.datetime.now() - age
         pnr_date = birthday.strftime('%y%m%d')
         suffix = str(self.generator.random.randrange(0, 999)).zfill(3)

--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -511,13 +511,12 @@ class Provider(SsnProvider):
         "659003", "659004", "710000", "810000", "820000",
     ]
 
-    def ssn(self):
+    def ssn(self, min_age=18, max_age=90):
         def checksum(s):
             return str((1 - 2 * int(s, 13)) % 11).replace('10', 'X')
 
-        min_age = 18 * 365
-        max_age = 90 * 365
-        age = datetime.timedelta(days=self.random_int(min_age, max_age))
+        age = datetime.timedelta(days=self.random_int(
+            min_age * 365, max_age * 365))
         birthday = datetime.date.today() - age
         birthday_str = birthday.strftime('%Y%m%d')
 


### PR DESCRIPTION
### What does this changes

It will be possible to specify the min and max age when generating a ssn number (for those locales that directly supports it).

### What was wrong

Could not generate ssn numbers for people with an age less than 16/18 or olrder than 90.

### How this fixes it

Added two optional parameters for the min and max age.

Fixes #700 
