### PR TITLE
#569, fix issues in addition to the AttributeError with cx_Freeze.

### DIFF
--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -7,7 +7,10 @@ import pkgutil
 def get_path(module):
     if getattr(sys, 'frozen', False):
         # frozen
-        path = os.path.dirname(sys.executable)
+        base_dir = os.path.dirname(sys.executable)
+        lib_dir = os.path.join(base_dir, "lib")
+        module_to_rel_path = os.path.join(*module.__package__.split("."))
+        path = os.path.join(lib_dir, module_to_rel_path)
     else:
         # unfrozen
         path = os.path.dirname(os.path.realpath(module.__file__))


### PR DESCRIPTION
### What does this change

The directory to the providers and locales are determined based on the cx_Freeze executable by creating a path to the lib directory, which was created by cx_Freeze. This is the path, where all libraries reside in.

### What was wrong

The path to the module directories was determined by the directory of the cx_Freeze executable only. Therefore the providers and locales could not be found.

### How this fixes it

Fixes #569

The problem was, that cx_Freeze does dismiss \_\_file\_\_ variables. There was a commit c8ca8be3443942a73a21fc22474ee51f38e59eb6, which tried to fix the issue, but the origin problem was not fixed, because the directory of each module was determined by the directory where the cx_Freeze executable resides in. No determination of the real paths to the modules were done.
