### PR TITLE
Capital 'Ø' for last name 'Ødegård', and alphabetically at the end 

### DIFF
--- a/faker/providers/person/no_NO/__init__.py
+++ b/faker/providers/person/no_NO/__init__.py
@@ -268,7 +268,6 @@ class Provider(PersonProvider):
         'Christensen',
         'Dahl',
         'Danielsen',
-        'ødegård',
         'Edvardsen',
         'Eide',
         'Eliassen',
@@ -346,6 +345,7 @@ class Provider(PersonProvider):
         'Thorsen',
         'Tveit',
         'Vik',
+        'Ødegård',
     )
 
     prefixes = (


### PR DESCRIPTION
### What does this changes

The last name 'ødegård' was spelled with a lowercaser 'ø' and not sorted correctly alphabetically. Now spelled 'Ødegård', and placed alphabetically at the end of the list, as all three Norwegian special characters are (in Norway, at least).

### What was wrong

Lowercase 'ø' as first letter.

### How this fixes it

See above.

Fixes #...
