### PR TITLE
use `r'...'` to avoid deprecated syntax

### DIFF
--- a/faker/utils/text.py
+++ b/faker/utils/text.py
@@ -8,9 +8,9 @@ import six
 import unicodedata
 
 
-_re_pattern = re.compile('[^\w\s-]', flags=re.U)
-_re_pattern_allow_dots = re.compile('[^\.\w\s-]', flags=re.U)
-_re_spaces = re.compile('[-\s]+', flags=re.U)
+_re_pattern = re.compile(r'[^\w\s-]', flags=re.U)
+_re_pattern_allow_dots = re.compile(r'[^\.\w\s-]', flags=re.U)
+_re_spaces = re.compile(r'[-\s]+', flags=re.U)
 
 
 _PROTECTED_TYPES = six.integer_types + (

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -12,7 +12,7 @@ class TestPtBR(unittest.TestCase):
 
     def setUp(self):
         self.factory = Faker('pt_BR')
-        self.format = re.compile('[\w]{3}-[\d]{4}')
+        self.format = re.compile(r'[\w]{3}-[\d]{4}')
 
     def test_plate_has_been_generated(self):
         plate = self.factory.license_plate()


### PR DESCRIPTION
Before this changer (with faker `pip install -e .`'d in a fresh venv):

```
$PYTHONWARNINGS="error::DeprecationWarning" python -c "from faker.providers import BaseProvider"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/davidchudzicki/faker/faker/__init__.py", line 4, in <module>
    from faker.factory import Factory
  File "/Users/davidchudzicki/faker/faker/factory.py", line 10, in <module>
    from faker.config import DEFAULT_LOCALE, PROVIDERS, AVAILABLE_LOCALES
  File "/Users/davidchudzicki/faker/faker/config.py", line 14, in <module>
    AVAILABLE_LOCALES = find_available_locales(PROVIDERS)
  File "/Users/davidchudzicki/faker/faker/utils/loading.py", line 32, in find_available_locales
    provider_module = import_module(provider_path)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/davidchudzicki/faker/faker/providers/internet/__init__.py", line 12, in <module>
    from faker.utils.decorators import lowercase, slugify, slugify_unicode
  File "/Users/davidchudzicki/faker/faker/utils/decorators.py", line 5, in <module>
    from faker.utils import text
  File "/Users/davidchudzicki/faker/faker/utils/text.py", line 11
    _re_pattern = re.compile('[^\w\s-]', flags=re.U)
                            ^
SyntaxError: invalid escape sequence \w
```

After this change, all is well:

```
$PYTHONWARNINGS="error::DeprecationWarning" python -c "from faker.providers import BaseProvider"
<no problems>
```

Using the `r'...'` form is consistent with what's used most other places in this repo already. This change just finishes it up.