### PR TITLE
NEW: Added Norwegian no_NO bank provider

### DIFF
--- a/faker/providers/bank/no_NO/__init__.py
+++ b/faker/providers/bank/no_NO/__init__.py
@@ -2,4 +2,4 @@ from .. import Provider as BankProvider
 
 class Provider(BankProvider):
     bban_format = '###########'
-country_code = 'NO'
+    country_code = 'NO'

--- a/faker/providers/bank/no_NO/__init__.py
+++ b/faker/providers/bank/no_NO/__init__.py
@@ -1,0 +1,5 @@
+from .. import Provider as BankProvider
+
+class Provider(BankProvider):
+    bban_format = '###########'
+country_code = 'NO'

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+
+import re
+import unittest
+
+from faker import Faker
+
+class TestNoNO(unittest.TestCase):
+    """ Tests the street address in no_NO locale """
+
+    def setUp(self):
+        self.factory = Faker('no_NO')
+
+    def test_bban(self):
+        bban = self.factory.bban()
+        assert re.match("\d{11}", bban)

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -6,7 +6,7 @@ import unittest
 from faker import Faker
 
 class TestNoNO(unittest.TestCase):
-    """ Tests the street address in no_NO locale """
+    """ Tests the bban in no_NO locale """
 
     def setUp(self):
         self.factory = Faker('no_NO')


### PR DESCRIPTION
11 digits. 

### What does this changes

Norwegian bank accounts have 11 digits: https://www.ecbs.org/iban/norway-bank-account-number.html

1-4: Bank identifier
5-10: Account identifier
11: Control digit

### What was wrong

Even with no_NO locale, calls to fake.bban() returned en_GB account numbers.

### How this fixes it

Returns 11 digits. No check for bank identifier (first 4 digits) or control digit (last digit).
