### PR TITLE
Use isounidecode over other ports of Text::Unidecode

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-from text_unidecode import unidecode
+from isounidecode import unidecode
 
 from .. import BaseProvider
 
@@ -69,7 +69,8 @@ class Provider(BaseProvider):
         for search, replace in self.replacements:
             string = string.replace(search, replace)
 
-        string = unidecode(string)
+        # isounidecode returns bytes, so decode to str/unicode
+        string = unidecode(string).decode("ascii")
         return string
 
     @lowercase

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     install_requires=[
         "python-dateutil>=2.4",
         "six",
-        "text-unidecode",
+        "isounidecode",
     ],
     tests_require=[
         "email_validator>=1.0.0,<1.1.0",


### PR DESCRIPTION
### What does this change

Swaps out `text-unidecode` for `isounidecode`

### What was wrong

`text-unidecode` is released under the Artistic License v1.0, which has some clauses which make it more restrictive than Faker's current license.

`text-unidecode` itself replaced `unidecode` as that package was released under the terms of the GPL, which again is more restrictive than Faker's current license.

### How this fixes it

This library is released under a BSD license
(https://github.com/redvasily/isounidecode/blob/master/LICENSE.txt)
which has none of the problems associated with the GPL or Artistic License that unidecode and
text-unidecode are released under.

Tests pass locally on Python 2.7 and 3.6

Fixes #727