### PR TITLE
don't exclude edgecases from Finnish SSN by default

### DIFF
--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -7,11 +7,10 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self, min_age=18, max_age=90):
+    def ssn(self, min_age=0, max_age=105):
         """
         Returns 11 character Finnish personal identity code (Henkilötunnus,
-        HETU, Swedish: Personbeteckning). Age of person is between 18 and 90
-        years, based on local computer date. This function assigns random
+        HETU, Swedish: Personbeteckning). This function assigns random
         sex to person.
 
         HETU consists of eleven characters of the form DDMMYYCZZZQ, where

--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -33,11 +33,24 @@ class Provider(SsnProvider):
         birthday = datetime.date.today() - age
         hetu_date = "%02d%02d%s" % (
             birthday.day, birthday.month, str(birthday.year)[-2:])
-        if birthday.year < 2000:
-            separator = '-'
-        else:
-            separator = 'A'
         suffix = str(self.generator.random.randrange(2, 899)).zfill(3)
         checksum = _checksum(hetu_date + suffix)
+        separator = self._get_century_code(birthday.year)
         hetu = "".join([hetu_date, separator, suffix, checksum])
         return hetu
+
+    @staticmethod
+    def _get_century_code(year):
+        """Returns the century code for a given year"""
+        if 2000 <= year < 3000:
+            separator = 'A'
+        elif 1900 <= year < 2000:
+            separator = '-'
+        elif 1800 <= year < 1900:
+            separator = '+'
+        else:
+            raise ValueError(
+                'Finnish SSN do not support people born '
+                'before the year 1800 or after the year 2999'
+            )
+        return separator

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from faker import Faker
 from faker.providers.ssn.et_EE import checksum as et_checksum
+from faker.providers.ssn.fi_FI import Provider as fi_Provider
 from faker.providers.ssn.hr_HR import checksum as hr_checksum
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
 from faker.providers.ssn.pl_PL import checksum as pl_checksum, calculate_month as pl_calculate_mouth
@@ -29,6 +30,30 @@ class TestEtEE(unittest.TestCase):
     def test_ssn(self):
         for _ in range(100):
             self.assertTrue(re.search(r'^\d{11}$', self.factory.ssn()))
+
+
+class TestFiFI(unittest.TestCase):
+    """ Tests SSN in the fi_FI locale """
+
+    def setUp(self):
+        self.factory = Faker('fi_FI')
+        self.provider = fi_Provider
+
+    def test_century_code(self):
+        self.assertEqual(self.provider._get_century_code(1900), '-')
+        self.assertEqual(self.provider._get_century_code(1999), '-')
+        self.assertEqual(self.provider._get_century_code(2000), 'A')
+        self.assertEqual(self.provider._get_century_code(2999), 'A')
+        self.assertEqual(self.provider._get_century_code(1800), '+')
+        self.assertEqual(self.provider._get_century_code(1899), '+')
+        with self.assertRaises(ValueError):
+            self.provider._get_century_code(1799)
+        with self.assertRaises(ValueError):
+            self.provider._get_century_code(3000)
+
+    def test_ssn_sanity(self):
+        for age in range(100):
+            self.factory.ssn(min_age=age, max_age=age+1)
 
 
 class TestHrHR(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Do not exclude the "edgecases" for the Finnish SSN provider by default. Where "edgecases" means people born after 2000 (who's SSN have a slightly different format in Finland)

### What was wrong

Presumably this library is used mostly for testing. Currently, by default the Finnish SSN provider was missing the was not generating precisely the class of SSNs that are most likely to cause problems for SSN parsers.

### How this fixes it

Includes SSN of people born after 2000

Fixes #...