### PR TITLE
Minor Refactoring for cli.py

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -218,7 +218,7 @@ examples:
 
         arguments = parser.parse_args()
 
-        for i in range(arguments.repeat):
+        for _ in range(arguments.repeat):
 
             print_doc(arguments.fake,
                       arguments.fake_args,

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -216,7 +216,7 @@ examples:
                                  "list of comma separated field names as the "
                                  "first argument)")
 
-        arguments = parser.parse_args()
+        arguments = parser.parse_args(self.argv[1:])
 
         for _ in range(arguments.repeat):
 

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -216,7 +216,7 @@ examples:
                                  "list of comma separated field names as the "
                                  "first argument)")
 
-        arguments = parser.parse_args(self.argv[1:])
+        arguments = parser.parse_args()
 
         for i in range(arguments.repeat):
 


### PR DESCRIPTION
### What does this changes
Use underscore for "throwaway" variable in for loop instead of variable `i`, which never gets used.

### What was wrong
Readability / simplicity

Update (Apr 11, 2018): reversed previous change made in a commit, which tried to simplify the code but ended up breaking it.