### PR TITLE
Add possibility to order artifical ssn numbers

### DIFF
--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -7,7 +7,7 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self, min_age=0, max_age=105):
+    def ssn(self, min_age=0, max_age=105, artificial=False):
         """
         Returns 11 character Finnish personal identity code (Henkilötunnus,
         HETU, Swedish: Personbeteckning). This function assigns random
@@ -33,7 +33,8 @@ class Provider(SsnProvider):
         birthday = datetime.date.today() - age
         hetu_date = "%02d%02d%s" % (
             birthday.day, birthday.month, str(birthday.year)[-2:])
-        suffix = str(self.generator.random.randrange(2, 899)).zfill(3)
+        range = (900, 999) if artificial is True else (2, 899)
+        suffix = str(self.generator.random.randrange(*range)).zfill(3)
         checksum = _checksum(hetu_date + suffix)
         separator = self._get_century_code(birthday.year)
         hetu = "".join([hetu_date, separator, suffix, checksum])

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -54,6 +54,16 @@ class TestFiFI(unittest.TestCase):
     def test_ssn_sanity(self):
         for age in range(100):
             self.factory.ssn(min_age=age, max_age=age+1)
+    
+    def test_valid_ssn(self):
+        ssn = self.factory.ssn(artificial=False)
+        individual_number = int(ssn[7:10])
+        self.assertLessEqual(individual_number, 899)
+
+    def test_artifical_ssn(self):
+        ssn = self.factory.ssn(artificial=True)
+        individual_number = int(ssn[7:10])
+        self.assertGreaterEqual(individual_number, 900)
 
 
 class TestHrHR(unittest.TestCase):


### PR DESCRIPTION
Ref: #725

Adding a new optional parameter (artifical) for FI_fi ssn provider. Default functionality
was not changed, it will provide valid Finnish SSN numbers. If set to true, it will generate
artifical ssn numbers with individual number starting with 9.
