### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Changelog
 `0.8.6 - 16-October-2017 <https://github.com/joke2k/faker/compare/v0.8.5...v0.8.6>`__
 -------------------------------------------------------------------------------------
 
-* Replace ``unidecode`` dependency in favor of ``text-unidecode``. Faker now requires `text-unidecode <https://pypi.python.org/pypi/text-unidecode>`_.
+* Replace ``unidecode`` dependency in favor of ``text-unidecode``. Faker now requires `text-unidecode <https://pypi.org/project/text-unidecode/>`_.
 
 `0.8.5 - 13-October-2017 <https://github.com/joke2k/faker/compare/v0.8.4...v0.8.5>`__
 -------------------------------------------------------------------------------------
@@ -91,7 +91,7 @@ Changelog
 * Use a proper international format for Ukrainian phone numbers. Thanks @illia-v.
 * Faker now requires Unidecode_.
 
-.. _Unidecode: https://pypi.python.org/pypi/Unidecode
+.. _Unidecode: https://pypi.org/project/Unidecode/
 
 `0.8.4 - 22-September-2017 <https://github.com/joke2k/faker/compare/v0.8.3...v0.8.4>`__
 ---------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -389,9 +389,9 @@ Credits
 .. _PHP Faker: https://github.com/fzaninotto/Faker
 .. _Perl Faker: http://search.cpan.org/~jasonk/Data-Faker-0.07/
 .. _Ruby Faker: https://github.com/stympy/faker
-.. _Distribute: https://pypi.python.org/pypi/distribute
+.. _Distribute: https://pypi.org/project/distribute/
 .. _Buildout: http://www.buildout.org/
-.. _modern-package-template: https://pypi.python.org/pypi/modern-package-template
+.. _modern-package-template: https://pypi.org/project/modern-package-template/
 .. _extended docs: https://faker.readthedocs.io/en/latest/
 .. _bundled providers: https://faker.readthedocs.io/en/latest/providers.html
 .. _community providers: https://faker.readthedocs.io/en/latest/communityproviders.html
@@ -400,7 +400,7 @@ Credits
 .. _Factory Boy: https://github.com/FactoryBoy/factory_boy
 
 .. |pypi| image:: https://img.shields.io/pypi/v/Faker.svg?style=flat-square&label=version
-    :target: https://pypi.python.org/pypi/Faker
+    :target: https://pypi.org/project/Faker/
     :alt: Latest version released on PyPi
 
 .. |coverage| image:: https://img.shields.io/coveralls/joke2k/faker/master.svg?style=flat-square

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -17,5 +17,5 @@ Here's a list of Providers written by the community:
 |               | by cloud.                |                                  +
 +---------------+--------------------------+----------------------------------+
 
-.. _faker_web: https://pypi.python.org/pypi/faker_web
-.. _faker_cloud: https://pypi.python.org/pypi/faker_cloud
+.. _faker_web: https://pypi.org/project/faker_web/
+.. _faker_cloud: https://pypi.org/project/faker-cloud/

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'console_scripts': ['faker=faker.cli:execute_from_command_line'],
     },
     classifiers=[
-        # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        # See https://pypi.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html