### PR TITLE
Update hu_HU jobs to be unicode literals

### DIFF
--- a/faker/providers/job/hu_HU/__init__.py
+++ b/faker/providers/job/hu_HU/__init__.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import unicode_literals
 from .. import BaseProvider
 
 


### PR DESCRIPTION
### What does this changes

Makes hu_HU locale jobs unicode

### What was wrong

When fetching jobs with the hu_HU locale, I was getting UnicodeDecodeError since these were not encoded correctly.

### How this fixes it

Correctly encodes these strings as unicode
