### PR TITLE
Fixed checksum for CPF (brazillian ssn)

### DIFF
--- a/faker/providers/ssn/pt_BR/__init__.py
+++ b/faker/providers/ssn/pt_BR/__init__.py
@@ -13,7 +13,7 @@ def checksum(digits):
 
     reminder = s % 11
     if reminder == 0 or reminder == 1:
-        return 1
+        return 0
     else:
         return 11 - reminder
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -119,7 +119,7 @@ class TestPtBR(unittest.TestCase):
 
     def test_pt_BR_ssn_checksum(self):
         self.assertEqual(pt_checksum([8, 8, 2, 8, 2, 1, 6, 5, 2]), 2)
-        self.assertEqual(pt_checksum([8, 8, 2, 8, 2, 1, 6, 5, 2, 2]), 1)
+        self.assertEqual(pt_checksum([8, 8, 2, 8, 2, 1, 6, 5, 2, 2]), 0)
 
     def test_pt_BR_ssn(self):
         for _ in range(100):


### PR DESCRIPTION
### What does this changes

This MR fixes the checksum code used by CPF (brazillian ssn).

References:
https://pt.wikipedia.org/wiki/Cadastro_de_pessoas_f%C3%ADsicas#Algoritmo
https://metacpan.org/source/MAMAWE/Algorithm-CheckDigits-v1.3.0/lib/Algorithm/CheckDigits/M11_004.pm

### What was wrong

When the "reminder" sum was 0 or 1, the checksum returned was 1.

### How this fixes it

When the "reminder" sum was 0 or 1, the checksum returned must be 0.

Fixes #758 
