### PR TITLE
Implement support for start_datetime in unix_time()

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1172,13 +1172,15 @@ class Provider(BaseProvider):
 
     regex = re.compile(timedelta_pattern)
 
-    def unix_time(self, end_datetime=None):
+    def unix_time(self, start_datetime=None, end_datetime=None):
         """
-        Get a timestamp between January 1, 1970 and now
+        Get a timestamp between January 1, 1970 and now, unless passed
+        explicit start_datetime and end_datetimes
         :example 1061306726
         """
+        start_datetime = self._parse_start_datetime(start_datetime)
         end_datetime = self._parse_end_datetime(end_datetime)
-        return self.generator.random.randint(0, end_datetime)
+        return self.generator.random.randint(start_datetime, end_datetime)
 
     def time_delta(self, end_datetime=None):
         """
@@ -1256,6 +1258,13 @@ class Provider(BaseProvider):
         :example datetime.time(15, 56, 56, 772876)
         """
         return self.date_time(end_datetime=end_datetime).time()
+
+    @classmethod
+    def _parse_start_datetime(cls, value):
+        if value is None:
+            return 0
+
+        return cls._parse_date_time(value)
 
     @classmethod
     def _parse_end_datetime(cls, value):

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -55,6 +55,7 @@ class TestDateTime(unittest.TestCase):
 
     def setUp(self):
         self.factory = Faker()
+        self.factory.seed(0)
 
     def assertBetween(self, date, start_date, end_date):
         self.assertTrue(date <= end_date)
@@ -365,6 +366,44 @@ class TestDateTime(unittest.TestCase):
         series = [i for i in self.factory.time_series(start_date=start, end_date=end, tzinfo=start.tzinfo)]
         self.assertEqual(series[0][0], start)
 
+    def test_unix_time(self):
+        for _ in range(100):
+            now=datetime.now()
+            epoch_start=datetime(1970,1,1)
+
+            # Include a buffer of one day in either direction to account for rounding and time zone peculiarities
+            buffer = 86400
+
+            # Ensure doubly-constrained unix_times are generated correctly
+            start_datetime=datetime(2001, 1, 1)
+            end_datetime=datetime(2001, 1, 2)
+
+            constrained_unix_time = self.factory.unix_time(start_datetime=start_datetime, end_datetime=end_datetime)
+
+            self.assertIsInstance(constrained_unix_time, int)
+            self.assertBetween(constrained_unix_time, start_datetime.timestamp()-buffer, end_datetime.timestamp()+buffer)
+
+            # Ensure relative unix_times partially-constrained by a start time are generated correctly
+            one_day_ago = datetime.today()-timedelta(days=1)
+            
+            recent_unix_time = self.factory.unix_time(start_datetime="-1d")
+
+            self.assertIsInstance(recent_unix_time, int)
+            self.assertBetween(recent_unix_time, one_day_ago.timestamp()-buffer, now.timestamp()+buffer)
+
+            # Ensure relative unix_times partially-constrained by an end time are generated correctly
+            one_day_after_epoch_start = datetime(1970,1,2)
+
+            distant_unix_time = self.factory.unix_time(end_datetime=one_day_after_epoch_start)
+            
+            self.assertIsInstance(distant_unix_time, int)
+            self.assertBetween(distant_unix_time, epoch_start.timestamp()-buffer, one_day_after_epoch_start.timestamp()+buffer)
+
+            # Ensure wide-open unix_times are generated correctly
+            random_unix_time = self.factory.unix_time()
+
+            self.assertIsInstance(constrained_unix_time, int)
+            self.assertBetween(constrained_unix_time, 0-buffer, now.timestamp()+buffer)
 
 class TestPlPL(unittest.TestCase):
 

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -369,7 +369,7 @@ class TestDateTime(unittest.TestCase):
     def test_unix_time(self):
         from faker.providers.date_time import datetime_to_timestamp
 
-        for _ in range(100000):
+        for _ in range(100):
             now = datetime.now(utc).replace(microsecond=0)
             epoch_start = datetime(1970,1,1,tzinfo=utc)
 

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -367,21 +367,20 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(series[0][0], start)
 
     def test_unix_time(self):
-        for _ in range(100):
-            now=datetime.now()
-            epoch_start=datetime(1970,1,1)
+        from faker.providers.date_time import datetime_to_timestamp
 
-            # Include a buffer of one day in either direction to account for rounding and time zone peculiarities
-            buffer = 86400
+        for _ in range(100000):
+            now = datetime.now(utc).replace(microsecond=0)
+            epoch_start = datetime(1970,1,1,tzinfo=utc)
 
             # Ensure doubly-constrained unix_times are generated correctly
-            start_datetime=datetime(2001, 1, 1)
-            end_datetime=datetime(2001, 1, 2)
+            start_datetime = datetime(2001, 1, 1, tzinfo=utc)
+            end_datetime = datetime(2001, 1, 2, tzinfo=utc)
 
             constrained_unix_time = self.factory.unix_time(start_datetime=start_datetime, end_datetime=end_datetime)
 
             self.assertIsInstance(constrained_unix_time, int)
-            self.assertBetween(constrained_unix_time, start_datetime.timestamp()-buffer, end_datetime.timestamp()+buffer)
+            self.assertBetween(constrained_unix_time, datetime_to_timestamp(start_datetime), datetime_to_timestamp(end_datetime))
 
             # Ensure relative unix_times partially-constrained by a start time are generated correctly
             one_day_ago = datetime.today()-timedelta(days=1)
@@ -389,21 +388,21 @@ class TestDateTime(unittest.TestCase):
             recent_unix_time = self.factory.unix_time(start_datetime="-1d")
 
             self.assertIsInstance(recent_unix_time, int)
-            self.assertBetween(recent_unix_time, one_day_ago.timestamp()-buffer, now.timestamp()+buffer)
+            self.assertBetween(recent_unix_time, datetime_to_timestamp(one_day_ago), datetime_to_timestamp(now))
 
             # Ensure relative unix_times partially-constrained by an end time are generated correctly
-            one_day_after_epoch_start = datetime(1970,1,2)
+            one_day_after_epoch_start = datetime(1970, 1, 2, tzinfo=utc)
 
             distant_unix_time = self.factory.unix_time(end_datetime=one_day_after_epoch_start)
             
             self.assertIsInstance(distant_unix_time, int)
-            self.assertBetween(distant_unix_time, epoch_start.timestamp()-buffer, one_day_after_epoch_start.timestamp()+buffer)
+            self.assertBetween(distant_unix_time, datetime_to_timestamp(epoch_start), datetime_to_timestamp(one_day_after_epoch_start))
 
             # Ensure wide-open unix_times are generated correctly
             random_unix_time = self.factory.unix_time()
 
             self.assertIsInstance(constrained_unix_time, int)
-            self.assertBetween(constrained_unix_time, 0-buffer, now.timestamp()+buffer)
+            self.assertBetween(constrained_unix_time, 0, datetime_to_timestamp(now))
 
 class TestPlPL(unittest.TestCase):
 


### PR DESCRIPTION
### What does this change

Implements support for start_datetime in unix_time() and creates tests for this function.

### What was wrong

unix_time() supported the ability to explicitly declare an end_datetime parameter (to aid in deterministic testing) but didn't support start_datetime. This is necessary if there's a need to generate unix epoch values within certain ranges.

### How this fixes it

* Implement tests for all permutations of unix_time() parameters
* Defaults to previous behavior if start_datetime is omitted
* Make TestDateTime unit tests deterministic

Closes #765 
