### PR TITLE
Implement support for start_datetime in unix_time()

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1172,13 +1172,15 @@ class Provider(BaseProvider):
 
     regex = re.compile(timedelta_pattern)
 
-    def unix_time(self, end_datetime=None):
+    def unix_time(self, end_datetime=None, start_datetime=None):
         """
-        Get a timestamp between January 1, 1970 and now
+        Get a timestamp between January 1, 1970 and now, unless passed
+        explicit start_datetime or end_datetime values.
         :example 1061306726
         """
+        start_datetime = self._parse_start_datetime(start_datetime)
         end_datetime = self._parse_end_datetime(end_datetime)
-        return self.generator.random.randint(0, end_datetime)
+        return self.generator.random.randint(start_datetime, end_datetime)
 
     def time_delta(self, end_datetime=None):
         """
@@ -1256,6 +1258,13 @@ class Provider(BaseProvider):
         :example datetime.time(15, 56, 56, 772876)
         """
         return self.date_time(end_datetime=end_datetime).time()
+
+    @classmethod
+    def _parse_start_datetime(cls, value):
+        if value is None:
+            return 0
+
+        return cls._parse_date_time(value)
 
     @classmethod
     def _parse_end_datetime(cls, value):

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -55,6 +55,7 @@ class TestDateTime(unittest.TestCase):
 
     def setUp(self):
         self.factory = Faker()
+        self.factory.seed(0)
 
     def assertBetween(self, date, start_date, end_date):
         self.assertTrue(date <= end_date)
@@ -365,6 +366,43 @@ class TestDateTime(unittest.TestCase):
         series = [i for i in self.factory.time_series(start_date=start, end_date=end, tzinfo=start.tzinfo)]
         self.assertEqual(series[0][0], start)
 
+    def test_unix_time(self):
+        from faker.providers.date_time import datetime_to_timestamp
+
+        for _ in range(100):
+            now = datetime.now(utc).replace(microsecond=0)
+            epoch_start = datetime(1970,1,1,tzinfo=utc)
+
+            # Ensure doubly-constrained unix_times are generated correctly
+            start_datetime = datetime(2001, 1, 1, tzinfo=utc)
+            end_datetime = datetime(2001, 1, 2, tzinfo=utc)
+
+            constrained_unix_time = self.factory.unix_time(end_datetime=end_datetime, start_datetime=start_datetime)
+
+            self.assertIsInstance(constrained_unix_time, int)
+            self.assertBetween(constrained_unix_time, datetime_to_timestamp(start_datetime), datetime_to_timestamp(end_datetime))
+
+            # Ensure relative unix_times partially-constrained by a start time are generated correctly
+            one_day_ago = datetime.today()-timedelta(days=1)
+            
+            recent_unix_time = self.factory.unix_time(start_datetime=one_day_ago)
+
+            self.assertIsInstance(recent_unix_time, int)
+            self.assertBetween(recent_unix_time, datetime_to_timestamp(one_day_ago), datetime_to_timestamp(now))
+
+            # Ensure relative unix_times partially-constrained by an end time are generated correctly
+            one_day_after_epoch_start = datetime(1970, 1, 2, tzinfo=utc)
+
+            distant_unix_time = self.factory.unix_time(end_datetime=one_day_after_epoch_start)
+            
+            self.assertIsInstance(distant_unix_time, int)
+            self.assertBetween(distant_unix_time, datetime_to_timestamp(epoch_start), datetime_to_timestamp(one_day_after_epoch_start))
+
+            # Ensure wide-open unix_times are generated correctly
+            random_unix_time = self.factory.unix_time()
+
+            self.assertIsInstance(constrained_unix_time, int)
+            self.assertBetween(constrained_unix_time, 0, datetime_to_timestamp(now))
 
 class TestPlPL(unittest.TestCase):
 


### PR DESCRIPTION
* Implement tests for all permutations of unix_time() parameters
* Defaults to previous behavior if start_datetime is omitted
* Make TestDateTime unit tests deterministic
* Address @fcurella's concerns about backwards compatibility with respect to positional arguments

Closes #765

### What does this changes

Brief summary of the changes

### What was wrong

Description of what was the root cause of the issue.

### How this fixes it

Description of how the changes fix the issue.

Fixes #...
