### PR TITLE
Add `faker-wifi-essid` to the list of community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -16,6 +16,9 @@ Here's a list of Providers written by the community:
 |               | generic or specialized   |                                  +
 |               | by cloud.                |                                  +
 +---------------+--------------------------+----------------------------------+
+| Wi-Fi ESSID   | Fake Wi-Fi ESSIDs.       | `faker_wifi_essid`_              +
++---------------+--------------------------+----------------------------------+
 
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_cloud: https://pypi.org/project/faker-cloud/
+.. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/


### PR DESCRIPTION
Hello there,

This PR aims to add a Faker provider I have developed to the list of community providers. This new provider generates fake Wi-Fi ESSIDs. I use it for development and demo purposes in [one of my projects](https://github.com/SkypLabs/probequest).

Cheers.