### PR TITLE
[Breaking changes] Refactor BaseProvider.random_* methods

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -320,7 +320,7 @@ class Provider(BaseProvider):
     def uri_path(self, deep=None):
         deep = deep if deep else self.generator.random.randint(1, 3)
         return "/".join(
-            [self.random_element(self.uri_paths) for _ in range(0, deep)]
+            self.random_elements(self.uri_paths, length=deep)
         )
 
     def uri_extension(self):

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -26,19 +26,6 @@ class Provider(BaseProvider):
     word_connector = ' '
     sentence_punctuation = '.'
 
-    def word(self, ext_word_list=None):
-        """
-        :returns: A random word, eg: 'lorem'
-
-        :param ext_word_list: a list of words you would like to have instead of
-            'Lorem ipsum'
-
-        :rtype: str
-        """
-        if ext_word_list:
-            return self.random_element(ext_word_list)
-        return self.random_element(self.word_list)
-
     def words(self, nb=3, ext_word_list=None):
         """
         :returns: An array of random words. for example: ['Lorem', 'ipsum', 'dolor']
@@ -50,7 +37,19 @@ class Provider(BaseProvider):
 
         :rtype: list
         """
-        return [self.word(ext_word_list) for _ in range(0, nb)]
+        word_list = ext_word_list if ext_word_list else self.word_list
+        return self.random_choices(word_list, length=nb)
+
+    def word(self, ext_word_list=None):
+        """
+        :returns: A random word, eg: 'lorem'
+
+        :param ext_word_list: a list of words you would like to have instead of
+            'Lorem ipsum'
+
+        :rtype: str
+        """
+        return self.words(1, ext_word_list)[0]
 
     def sentence(self, nb_words=6, variable_nb_words=True, ext_word_list=None):
         """

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -176,7 +176,7 @@ class Provider(BaseProvider):
             required_tokens) <= length, "Required length is shorter than required characters"
 
         # Generate a first version of the password
-        chars = [self.generator.random.choice(choices) for _ in range(length)]
+        chars = self.random_choices(choices, length=length)
 
         # Pick some unique locations
         random_indexes = set()

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -29,14 +29,15 @@ class Provider(BaseProvider):
         :return: String. Random of random length between min and max characters.
         """
         if min_chars is None:
-            return "".join(self.random_letter() for i in range(max_chars))
+            return "".join(self.random_letters(length=max_chars))
         else:
             assert (
                 max_chars >= min_chars), "Maximum length must be greater than or equal to minium length"
             return "".join(
-                self.random_letter() for i in range(
-                    0, self.generator.random.randint(
-                        min_chars, max_chars)))
+                self.random_letters(
+                    length=self.generator.random.randint(min_chars, max_chars),
+                )
+            )
 
     def pyfloat(self, left_digits=None, right_digits=None, positive=False):
         if left_digits is not None and left_digits < 0:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -586,32 +586,28 @@ class FactoryTestCase(unittest.TestCase):
 
         # Too many items requested
         with self.assertRaises(ValueError):
-            provider.random_sample_unique('abcde', 6)
-
-        # Duplicate inputs reduced to unique set
-        with self.assertRaises(ValueError):
-            provider.random_sample_unique('aabcd', 5)
+            provider.random_sample('abcde', 6)
 
         # Same length
-        sample = provider.random_sample_unique('aabcd', 4)
-        self.assertEqual(sample, set('abcd'))
+        sample = provider.random_sample('abcd', 4)
+        self.assertEqual(sorted(sample), list('abcd'))
 
-        sample = provider.random_sample_unique('abcde', 5)
-        self.assertEqual(sample, set('abcde'))
+        sample = provider.random_sample('abcde', 5)
+        self.assertEqual(sorted(sample), list('abcde'))
 
         # Length = 3
-        sample = provider.random_sample_unique('abcde', 3)
+        sample = provider.random_sample('abcde', 3)
         self.assertEqual(len(sample), 3)
-        self.assertTrue(sample.issubset(set('abcde')))
+        self.assertTrue(set(sample).issubset(set('abcde')))
 
         # Length = 1
-        sample = provider.random_sample_unique('abcde', 1)
+        sample = provider.random_sample('abcde', 1)
         self.assertEqual(len(sample), 1)
-        self.assertTrue(sample.issubset(set('abcde')))
+        self.assertTrue(set(sample).issubset(set('abcde')))
 
         # Length = 0
-        sample = provider.random_sample_unique('abcde', 0)
-        self.assertEqual(sample, set())
+        sample = provider.random_sample('abcde', 0)
+        self.assertEqual(sample, [])
 
     def test_random_number(self):
         from faker.providers import BaseProvider

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,5 +1,5 @@
 from faker.utils.loading import find_available_locales
-from faker.utils.distribution import choice_distribution
+from faker.utils.distribution import choices_distribution, choices_distribution_unique
 from faker.utils.datasets import add_dicts
 from faker.config import PROVIDERS
 from faker.generator import random
@@ -18,7 +18,7 @@ class UtilsTestCase(unittest.TestCase):
         a = ('a', 'b', 'c', 'd')
         p = (0.5, 0.2, 0.2, 0.1)
 
-        sample = choice_distribution(a, p)
+        sample = choices_distribution(a, p)[0]
         self.assertTrue(sample in a)
 
         with open(os.path.join(TEST_DIR, 'random_state.json'), 'r') as fh:
@@ -26,7 +26,7 @@ class UtilsTestCase(unittest.TestCase):
         random_state[1] = tuple(random_state[1])
 
         random.setstate(random_state)
-        samples = [choice_distribution(a, p) for i in range(100)]
+        samples = choices_distribution(a, p, length=100)
         a_pop = len([i for i in samples if i == 'a'])
         b_pop = len([i for i in samples if i == 'b'])
         c_pop = len([i for i in samples if i == 'c'])
@@ -41,6 +41,15 @@ class UtilsTestCase(unittest.TestCase):
         self.assertTrue(boundaries[1][0] > b_pop > boundaries[1][1])
         self.assertTrue(boundaries[2][0] > c_pop > boundaries[2][1])
         self.assertTrue(boundaries[3][0] > d_pop > boundaries[3][1])
+
+    def test_choices_distribution_unique(self):
+        a = ('a', 'b', 'c', 'd')
+        p = (0.25, 0.25, 0.25, 0.25)
+        with self.assertRaises(AssertionError):
+            choices_distribution_unique(a, p, length=5)
+
+        samples = choices_distribution_unique(a, p, length=4)
+        self.assertEqual(len(set(samples)), len(samples))
 
     def test_add_dicts(self):
         t1 = {'a':1, 'b':2}


### PR DESCRIPTION
Breaking changes:

* `.random_sample_unique` is removed in favor of `.random_sample`
* `.random_sample` now returns a list of unique elements instead of a set.

Non-Breaking changes:
* added `random_choices`

The plan is to release v0.8.18 _without_ this merged in, then merge it and release v1.0.0.

### What does this changes

* `.random_sample()` now returns a list of unique elements instead of a set.
* `.random_sample_unique()` is removed in favor of `.random_sample()`
* added `random_choices()`, `random_elements()` and `random_letters()`
* added `faker.utils.distribution.choices_distribution_unique()`

### What was wrong

Various methods on the `BaseProvider` were implemented with loops or list comprehensions where Python's `random` module already has more optimized methods to returns sequences.

### How this fixes it

The goal of this refactor is to improve performance by removing loops and leveraging `random` more.

