### PR TITLE
date_time ignores tzinfo

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1557,7 +1557,12 @@ class Provider(BaseProvider):
             ts = start_date + self.generator.random.random()
         else:
             ts = self.generator.random.randint(start_date, end_date)
-        return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
+        if tzinfo is None:
+            return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
+        else:
+            return (
+                datetime(1970, 1, 1, tzinfo=tzutc()) + timedelta(seconds=ts)
+            ).astimezone(tzinfo)
 
     def date_between(self, start_date='-30y', end_date='today'):
         """


### PR DESCRIPTION
### What does this changes

TZinfo was overwritten by utc which caused faker to return correct datetime object only for utc TZinfo whenever datetime_to_timestamp function was used. Now it looks ok for instance:

`tz = pytz.timezone('Europe/Warsaw')`
`fake = faker.Faker()`
`fake.future_datetime(end_date="+1h", tzinfo=tz)` 

### What was wrong

Mistake in code.

### How this fixes it

Simple bugfix.
