### PR TITLE
Set tzinfo correctly when generating date-of-birth (ticket #796)

### DIFF
--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -545,7 +545,7 @@ class DatesOfBirth(unittest.TestCase):
             days_since_five_years_ago = now - now.replace(year=now.year-5)
             days_since_six_years_ago = now - now.replace(year=now.year-6)
 
-            dob = self.factory.date_of_birth(minimum_age=5, maximum_age=5)
+            dob = self.factory.date_of_birth(tzinfo=utc, minimum_age=5, maximum_age=5)
             days_since_dob = now - dob
 
             assert isinstance(dob, date)


### PR DESCRIPTION
Without this patch applied, the test_identical_age_range unit-test can
fail at certain times of day on systems where local time is behind UTC.
This is because the test generates "now" based off UTC, but apparently
lets "dob" follow the local timezone.

The actual library funtionality appears to be sane; only the unit-tests
are affected.

### What does this changes

With this change, we set tzinfo=utc when generating date-of-birth.

### What was wrong

For timezones behind UTC, the date in UTC can be one day ahead of the localized date depending on time-of-day.  Failing to set a consistent timezone in this case allows the date-of-birth to be exactly six years old.

### How this fixes it

Timezone is set consistently when reading current time and when generating date-of-birth.

Fixes #796 
