### PR TITLE
Implement fico8, fico5, fico2, and fico4 credit score models

### DIFF
--- a/faker/providers/credit_score/__init__.py
+++ b/faker/providers/credit_score/__init__.py
@@ -1,15 +1,11 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
 
 from .. import BaseProvider
 
 
-class CreditScore(object):
-    def __init__(self, name, provider, score_range):
-        self.name = name
-        self.provider = provider
-        self.score_range = score_range
+CreditScore = namedtuple("CreditScore", ["name", "provider", "score_range"])
 
 
 class Provider(BaseProvider):

--- a/faker/providers/credit_score/__init__.py
+++ b/faker/providers/credit_score/__init__.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from collections import OrderedDict
+
+from .. import BaseProvider
+
+
+class CreditScore(object):
+    def __init__(self, name, provider, score_range):
+        self.name = name
+        self.provider = provider
+        self.score_range = score_range
+
+
+class Provider(BaseProvider):
+    """ Provider for Credit Score. """
+
+    # FICO 8 Score is the most widely-used non-industry specific credit score model,
+    # followed by 5, 2, and 4 as per https://www.myfico.com/credit-education/credit-scores/fico-score-versions
+    #
+    # Ranges obtained here and validated elsewhere:
+    #
+    # * https://blog.myfico.com/whats-a-good-credit-score-range/
+    # * https://www.wrightrealtors.com/home/credit-score.htm
+
+    fico8_range = [300, 850]
+    fico5_range = [334, 818]
+    fico2_range = [320, 844]
+    fico4_range = [309, 839]
+
+    credit_score_types = OrderedDict(
+        (
+            ("fico8", CreditScore("FICO Score 8", "FICO", fico8_range)),
+            ("fico5", CreditScore("Equifax Beacon 5.0", "Equifax", fico5_range)),
+            ("fico2", CreditScore("Experian/Fair Isaac Risk Model V2SM", "Experian", fico2_range)),
+            ("fico4", CreditScore("TransUnion FICO Risk Score, Classic 04", "TransUnion", fico4_range)),
+        )
+    )
+    credit_score_types["fico"] = credit_score_types["fico8"]
+
+    def credit_score_name(self, score_type=None):
+        """ Returns the name of the credit score. """
+        if score_type is None:
+            score_type = self.random_element(self.credit_score_types.keys())
+        return self._credit_score_type(score_type).name
+
+    def credit_score_provider(self, score_type=None):
+        """ Returns the name of the credit score provider. """
+        if score_type is None:
+            score_type = self.random_element(self.credit_score_types.keys())
+        return self._credit_score_type(score_type).provider
+
+    def credit_score(self, score_type=None):
+        """ Returns a valid credit score. """
+        credit_score_summary = self._credit_score_type(score_type)
+        score = self._generate_credit_score(credit_score_summary.score_range)
+        return score
+
+    def credit_score_full(self, score_type=None):
+        credit_score_summary = self._credit_score_type(score_type)
+
+        tpl = "{name}\n" "{provider}\n" "{credit_score}\n"
+
+        tpl = tpl.format(
+            name=self.credit_score_name(credit_score_summary),
+            provider=self.credit_score_provider(credit_score_summary),
+            credit_score=self.credit_score(credit_score_summary),
+        )
+        return self.generator.parse(tpl)
+
+    def _credit_score_type(self, score_type=None):
+        """ Returns a credit score type instance of the specified type (random if none provided). """
+        if score_type is None:
+            score_type = self.random_element(self.credit_score_types.keys())
+        elif isinstance(score_type, CreditScore):
+            return score_type
+        return self.credit_score_types[score_type]
+
+    def _generate_credit_score(self, credit_score_range):
+        """ Returns an integer within the range specified by credit_score_range. """
+        return self.generator.random_int(*credit_score_range)

--- a/faker/providers/credit_score/en_US/__init__.py
+++ b/faker/providers/credit_score/en_US/__init__.py
@@ -1,0 +1,5 @@
+from .. import Provider as CreditScoreProvider
+
+
+class Provider(CreditScoreProvider):
+    pass

--- a/tests/providers/test_credit_score.py
+++ b/tests/providers/test_credit_score.py
@@ -1,0 +1,69 @@
+#  -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Faker
+
+
+class TestEnUS(unittest.TestCase):
+    def setUp(self):
+        self.factory = Faker("en_US")
+        self.factory.seed(0)
+
+    def test_random_credit_score(self):
+        for _ in range(100):
+            credit_score = self.factory.credit_score()
+            assert 300 <= credit_score <= 850
+
+    def test_credit_score_of_a_specific_type(self):
+        for _ in range(100):
+            credit_score = self.factory.credit_score("fico8")
+            assert 300 <= credit_score <= 850
+
+    def test_random_credit_score_provider(self):
+        for _ in range(100):
+            provider = self.factory.credit_score_provider()
+            assert provider in ("FICO", "Experian", "Equifax", "TransUnion")
+
+    def test_credit_score_provider_of_a_specific_type(self):
+        for _ in range(100):
+            provider = self.factory.credit_score_provider("fico5")
+            assert provider == "Equifax"
+
+    def test_random_credit_score_name(self):
+        for _ in range(100):
+            name = self.factory.credit_score_name()
+            assert name in (
+                "FICO Score 8",
+                "Equifax Beacon 5.0",
+                "Experian/Fair Isaac Risk Model V2SM",
+                "TransUnion FICO Risk Score, Classic 04",
+            )
+
+    def test_credit_score_name_of_a_specific_type(self):
+        for _ in range(100):
+            name = self.factory.credit_score_name("fico5")
+            assert name == "Equifax Beacon 5.0"
+
+    def test_random_credit_score_full(self):
+        """ Output looks like this (provider/model is random):
+        Equifax Beacon 5.0
+        Equifax
+        660
+        """
+        for _ in range(100):
+            output = self.factory.credit_score_full()
+            assert re.match(r".+\n.+\n\d{3}\n", output)
+
+    def test_credit_score_full_of_a_specific_type(self):
+        """ Output looks like this:
+        Equifax Beacon 5.0
+        Equifax
+        660
+        """
+        for _ in range(100):
+            output = self.factory.credit_score_full("fico5")
+            assert re.match(r"Equifax Beacon 5\.0\nEquifax\n\d{3}\n", output)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -75,6 +75,7 @@ class UtilsTestCase(unittest.TestCase):
             'faker.providers.color',
             'faker.providers.company',
             'faker.providers.credit_card',
+            'faker.providers.credit_score',
             'faker.providers.currency',
             'faker.providers.date_time',
             'faker.providers.file',


### PR DESCRIPTION
### What does this change

Implements generation of the top four most common general credit score models:

* FICO Score 8
* Equifax Beacon 5.0
* Experian/Fair Isaac Risk Model V2SM
* TransUnion FICO Risk Score, Classic 04

Test coverage:

```shell
$ coverage report | grep credit_score
faker/providers/credit_score/__init__.py            40      0   100%
faker/providers/credit_score/en_US/__init__.py       3      3     0%
```

Closes #801 
