### PR TITLE
Refactor IPv4 address generation to use ipaddress module #803

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -20,10 +20,8 @@ class _IPv4Constants:
     IPv4 network constants used to group networks into different categories.
     Structure derived from `ipaddress._IPv4Constants`.
 
-    Private network list is updated to comply with current IANA list.
-
-    Excluded networks are added to allow filtering out certain networks
-    from faker output.
+    Excluded network list is updated to comply with current IANA list of
+    private and reserved networks.
     """
     _network_classes = {
         'a': ip_network('0.0.0.0/1'),
@@ -31,35 +29,43 @@ class _IPv4Constants:
         'c': ip_network('192.0.0.0/3')
     }
 
-    _linklocal_network = IPv4Address._constants._linklocal_network
+    _linklocal_network = ip_network('169.254.0.0/16')
 
-    _loopback_network = IPv4Address._constants._loopback_network
+    _loopback_network = ip_network('127.0.0.0/8')
 
-    _multicast_network = IPv4Address._constants._multicast_network
+    _multicast_network = ip_network('224.0.0.0/4')
 
-    _reserved_network = IPv4Address._constants._reserved_network
-
-    # Add IANA reserved ranges missing from Python ipaddress module
-    # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-    _private_networks = list(IPv4Address._constants._private_networks) + [
-        ip_network('100.64.0.0/10'),
-        ip_network('192.0.0.0/24'),
-        ip_network('192.0.0.0/29'),
-        ip_network('192.0.0.8/32'),
-        ip_network('192.0.0.9/32'),
-        ip_network('192.0.0.10/32'),
-        ip_network('192.31.196.0/24'),
-        ip_network('192.52.193.0/24'),
-        ip_network('192.88.99.0/24'),
-        ip_network('192.175.48.0/24')
+    # Three common private networks from class A, B and CIDR
+    # to generate private addresses from.
+    _private_networks = [
+        ip_network('10.0.0.0/8'),
+        ip_network('172.16.0.0/12'),
+        ip_network('192.168.0.0/16')
     ]
 
     # List of networks from which IP addresses will never be generated,
-    # includes 0.0.0.0/8, as it can't be used for destination addresses.
+    # includes other private IANA and reserved networks from
+    # ttps://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
     _excluded_networks = [
         ip_network('0.0.0.0/8'),
         ip_network('100.64.0.0/10'),
-        ip_network('192.0.0.0/24')
+        ip_network('127.0.0.0/8'),
+        ip_network('169.254.0.0/16'),
+        ip_network('192.0.0.0/24'),
+        ip_network('192.0.2.0/24'),
+        ip_network('192.31.196.0/24'),
+        ip_network('192.52.193.0/24'),
+        ip_network('192.88.99.0/24'),
+        ip_network('192.175.48.0/24'),
+        ip_network('198.18.0.0/15'),
+        ip_network('198.51.100.0/24'),
+        ip_network('203.0.113.0/24'),
+        ip_network('240.0.0.0/4'),
+        ip_network('255.255.255.255/32')
+    ] + [
+        _linklocal_network,
+        _loopback_network,
+        _multicast_network
     ]
 
 
@@ -346,7 +352,7 @@ class Provider(BaseProvider):
         :param address_class: IPv4 address class (a, b, or c)
         :returns: Private IPv4
         """
-        # compute private networks
+        # compute private networks from given class
         supernet = _IPv4Constants._network_classes[
             address_class or self.ipv4_network_class()
         ]

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -41,7 +41,7 @@ class _IPv4Constants:
 
     # Add IANA reserved ranges missing from Python ipaddress module
     # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-    _private_networks = IPv4Address._constants._private_networks.copy() + [
+    _private_networks = list(IPv4Address._constants._private_networks) + [
         ip_network('100.64.0.0/10'),
         ip_network('192.0.0.0/24'),
         ip_network('192.0.0.0/29'),

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "mock",
     ],
     extras_require={
-        ':python_version<"3.5"': [
+        ':python_version=="2.7"': [
             'ipaddress',
         ],
     }

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "mock",
     ],
     extras_require={
-        ':python_version=="2.7"': [
+        ':python_version<"3.5"': [
             'ipaddress',
         ],
     }

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -6,7 +6,7 @@ import re
 import unittest
 import string
 import sys
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address, ip_network, IPv4Address
 
 import logging
 
@@ -441,8 +441,13 @@ class FactoryTestCase(unittest.TestCase):
             self.assertIn(klass, 'abc')
 
     def test_ipv4_private(self):
-        from faker.providers.internet import Provider
+        from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
+
+        # monkeypatch IPv4Address private networks to include
+        # current IANA entries used by faker
+        IPv4Address._constants._private_networks += \
+            _IPv4Constants._private_networks
 
         for _ in range(999):
             address = provider.ipv4_private()
@@ -463,8 +468,12 @@ class FactoryTestCase(unittest.TestCase):
                 re.compile(r'^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$').search(address))
 
     def test_ipv4_private_class_a(self):
-        from faker.providers.internet import Provider
+        from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
+        
+        class_network = _IPv4Constants._network_classes['a']
+        class_min = class_network.network_address
+        class_max = class_network.broadcast_address
 
         for _ in range(999):
             address = provider.ipv4_private(address_class='a')
@@ -472,12 +481,16 @@ class FactoryTestCase(unittest.TestCase):
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
-            self.assertTrue(
-                re.compile(r'^10\.(\d{1,3}\.){2}\d{1,3}$').search(address))
+            self.assertTrue(ip_address(address) >= class_min)
+            self.assertTrue(ip_address(address) <= class_max)
 
     def test_ipv4_private_class_b(self):
-        from faker.providers.internet import Provider
+        from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
+        
+        class_network = _IPv4Constants._network_classes['b']
+        class_min = class_network.network_address
+        class_max = class_network.broadcast_address
 
         for _ in range(999):
             address = provider.ipv4_private(address_class='b')
@@ -485,12 +498,16 @@ class FactoryTestCase(unittest.TestCase):
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
-            self.assertTrue(
-                re.compile(r'^172\.(\d{1,3}\.){2}\d{1,3}$').search(address))
+            self.assertTrue(ip_address(address) >= class_min)
+            self.assertTrue(ip_address(address) <= class_max)
 
     def test_ipv4_private_class_c(self):
-        from faker.providers.internet import Provider
+        from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
+        
+        class_network = _IPv4Constants._network_classes['c']
+        class_min = class_network.network_address
+        class_max = class_network.broadcast_address
 
         for _ in range(999):
             address = provider.ipv4_private(address_class='c')
@@ -498,12 +515,17 @@ class FactoryTestCase(unittest.TestCase):
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
-            self.assertTrue(
-                re.compile(r'^192\.168\.\d{1,3}\.\d{1,3}$').search(address))
+            self.assertTrue(ip_address(address) >= class_min)
+            self.assertTrue(ip_address(address) <= class_max)
 
     def test_ipv4_public(self):
-        from faker.providers.internet import Provider
+        from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
+
+        # monkeypatch IPv4Address private networks to include
+        # current IANA entries used by faker
+        IPv4Address._constants._private_networks += \
+            _IPv4Constants._private_networks        
 
         for _ in range(999):
             address = provider.ipv4_public()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -444,11 +444,6 @@ class FactoryTestCase(unittest.TestCase):
         from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
 
-        # monkeypatch IPv4Address private networks to include
-        # current IANA entries used by faker
-        IPv4Address._constants._private_networks += \
-            _IPv4Constants._private_networks
-
         for _ in range(999):
             address = provider.ipv4_private()
             address = text.force_text(address)
@@ -520,12 +515,7 @@ class FactoryTestCase(unittest.TestCase):
 
     def test_ipv4_public(self):
         from faker.providers.internet import Provider, _IPv4Constants
-        provider = Provider(self.generator)
-
-        # monkeypatch IPv4Address private networks to include
-        # current IANA entries used by faker
-        IPv4Address._constants._private_networks += \
-            _IPv4Constants._private_networks        
+        provider = Provider(self.generator)   
 
         for _ in range(999):
             address = provider.ipv4_public()


### PR DESCRIPTION
### What does this changes

I refactored generation of IPv4 addresses with huge help and input @kungfu71186 to use `ipaddress` module instead of doing internal math on ranges. Network constants have been provided based on `ipaddress._IPv4Constants` with private networks updated to reflect current IANA lists. The IP generation now follows the general pattern both for public and private addresses:

1) Choose the desired network class (a, b or c)
2a) For private networks - choose all private networks overlapping the class
2b) For public networks - exclude all private networks from the class
3) Exclude special networks that should not yield IPs from faker such as 0.0.0.0/8
4) Choose a random subnet from the lot, and then a random IP from the subnet

Tests have been updated to reflect the changes.

**Caveat for discussion:** private IP generation chooses from all private networks from IANA list, not only from `10.0.0.0`, `172.16.0.0` and `192.168.0.0` ranges. This may not be a desired effect and it's possible additional constant should be added for private IP generation to yield only IPs from general use private subnets.

### What was wrong

`faker` was using internal constants for private networks that was not up to date with IANA documents, yielding non-public addresses from public method. After digging in it appears that `ipaddress` constants are not up to date either.

### How this fixes it

The core issue is fixed by replacing the private network constants with an up to date list. Refactor for the generation method is a side effect.

Fixes #803
