### PR TITLE
fix docs about custom providers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,13 +234,13 @@ How to create a Provider
     # first, import a similar Provider or use the default one
     from faker.providers import BaseProvider
 
-    # create new provider class
-    class MyProvider(BaseProvider):
+    # create new provider class. Note that the class name _must_ be ``Provider``.
+    class Provider(BaseProvider):
         def foo(self):
             return 'bar'
 
     # then add new provider to faker instance
-    fake.add_provider(MyProvider)
+    fake.add_provider(Provider)
 
     # now you can use:
     fake.foo()


### PR DESCRIPTION
### What does this changes

Mention that custom provider's class _must_ be named ``Provider``.

### What was wrong

There was no mention of this requirement anywhere in the docs, which lead people to implement custom providers that can't be used with the command-line argument `-i`.

### How this fixes it

Specify the requirement so people can write custom providers that work.

Fixes #804 
