### PR TITLE
Fix/master/make words return unique words

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -34,6 +34,7 @@ class Provider(BaseProvider):
         :param nb: how many words to return
         :param ext_word_list: a list of words you would like to have instead of
             'Lorem ipsum'
+        :param unique: If True, the returned word list will contain unique words
 
         :rtype: list
         """

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -26,7 +26,7 @@ class Provider(BaseProvider):
     word_connector = ' '
     sentence_punctuation = '.'
 
-    def words(self, nb=3, ext_word_list=None):
+    def words(self, nb=3, ext_word_list=None, unique=False):
         """
         :returns: An array of random words. for example: ['Lorem', 'ipsum', 'dolor']
 
@@ -38,6 +38,8 @@ class Provider(BaseProvider):
         :rtype: list
         """
         word_list = ext_word_list if ext_word_list else self.word_list
+        if unique:
+            return self.random_sample(word_list, length=nb)
         return self.random_choices(word_list, length=nb)
 
     def word(self, ext_word_list=None):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -330,6 +330,91 @@ class FactoryTestCase(unittest.TestCase):
         word = fake.word(ext_word_list=my_word_list)
         self.assertIn(word, my_word_list)
 
+    def test_no_words(self):
+        fake = Faker()
+
+        words = fake.words(0)
+        self.assertEqual(words, [])
+
+    def test_some_words(self):
+        fake = Faker()
+
+        num_words = 5
+        words = fake.words(num_words)
+        self.assertTrue(isinstance(words, list))
+        self.assertEqual(len(words), num_words)
+
+        for word in words:
+            self.assertTrue(isinstance(word, string_types))
+            self.assertTrue(re.match(r'^[a-z].*$', word))
+
+    def test_words_ext_word_list(self):
+        fake = Faker()
+
+        my_word_list = [
+            'danish',
+            'cheesecake',
+            'sugar',
+            'Lollipop',
+            'wafer',
+            'Gummies',
+            'Jelly',
+            'pie',
+        ]
+
+        num_words = 5
+        words = fake.words(5, ext_word_list=my_word_list)
+        self.assertTrue(isinstance(words, list))
+        self.assertEqual(len(words), num_words)
+
+        for word in words:
+            self.assertTrue(isinstance(word, string_types))
+            self.assertIn(word, my_word_list)
+
+    def test_words_ext_word_list_unique(self):
+        fake = Faker()
+
+        my_word_list = [
+            'danish',
+            'cheesecake',
+            'sugar',
+            'Lollipop',
+            'wafer',
+            'Gummies',
+            'Jelly',
+            'pie',
+        ]
+
+        num_words = 5
+        words = fake.words(5, ext_word_list=my_word_list)
+        self.assertTrue(isinstance(words, list))
+        self.assertEqual(len(words), num_words)
+
+        checked_words = []
+        for word in words:
+            self.assertTrue(isinstance(word, string_types))
+            self.assertIn(word, my_word_list)
+            # Check that word is unique
+            self.assertTrue(word not in checked_words)
+            checked_words.append(word)
+
+    def test_unique_words(self):
+        fake = Faker()
+
+        num_words = 20
+        words = fake.words(num_words, unique=True)
+        self.assertTrue(isinstance(words, list))
+        self.assertEqual(len(words), num_words)
+
+        checked_words = []
+        for word in words:
+            self.assertTrue(isinstance(word, string_types))
+            # Check that word is lowercase letters. No numbers, symbols, etc
+            self.assertTrue(re.match(r'^[a-z].*$', word))
+            # Check that word list is unique
+            self.assertTrue(word not in checked_words)
+            checked_words.append(word)
+
     def test_random_pystr_characters(self):
         from faker.providers.python import Provider
         provider = Provider(self.generator)


### PR DESCRIPTION
### What does this change

Close #791. Add `unique` option to `words()` to get a list of unique words. Add new tests for `words()`.

### What was wrong

`words()` did not have an option for retrieving a list of unique words. See #791.

### How this fixes it

Adds `unique` as a boolean argument to `words()`. Default behavior for `words()` is non-unique. Additional unit tests are added for testing the behavior of `words()`.
