### PR TITLE
Close #800. Allow territories to be excluded from `state_abbr()` for `en_US`.

### DIFF
--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -283,6 +283,8 @@ class Provider(AddressProvider):
         'AS', 'FM', 'GU', 'MH', 'MP', 'PW', 'PR', 'VI',
     )
 
+    states_and_territories_abbr = states_abbr + territories_abbr
+
     military_state_abbr = ('AE', 'AA', 'AP')
 
     military_ship_prefix = ('USS', 'USNS', 'USNV', 'USCGC')
@@ -340,10 +342,9 @@ class Provider(AddressProvider):
         :param include_territories: If True, territories will be included.
             If False, only states will be returned.
         """
-        abbr_options = self.states_abbr
         if include_territories:
-            abbr_options += self.territories_abbr
-        return self.random_element(abbr_options)
+            self.random_element(self.states_and_territories_abbr)
+        return self.random_element(self.states_abbr)
 
     def postcode(self):
         return "%05d" % self.generator.random.randint(501, 99950)

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -272,11 +272,15 @@ class Provider(AddressProvider):
         'West Virginia', 'Wisconsin', 'Wyoming',
     )
     states_abbr = (
-        'AL', 'AK', 'AS', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FM', 'FL',
-        'GA', 'GU', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MH',
-        'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM',
-        'NY', 'NC', 'ND', 'MP', 'OH', 'OK', 'OR', 'PW', 'PA', 'PR', 'RI', 'SC',
-        'SD', 'TN', 'TX', 'UT', 'VT', 'VI', 'VA', 'WA', 'WV', 'WI', 'WY',
+        'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI',
+        'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN',
+        'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH',
+        'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA',
+        'WV', 'WI', 'WY',
+    )
+
+    territories_abbr = (
+        'AS', 'FM', 'GU', 'MH', 'MP', 'PW', 'PR', 'VI',
     )
 
     military_state_abbr = ('AE', 'AA', 'AP')
@@ -329,8 +333,17 @@ class Provider(AddressProvider):
     def state(self):
         return self.random_element(self.states)
 
-    def state_abbr(self):
-        return self.random_element(self.states_abbr)
+    def state_abbr(self, include_territories=True):
+        """
+        :returns: A random state or territory abbreviation.
+
+        :param include_territories: If True, territories will be included.
+            If False, only states will be returned.
+        """
+        abbr_options = self.states_abbr
+        if include_territories:
+            abbr_options += self.territories_abbr
+        return self.random_element(abbr_options)
 
     def postcode(self):
         return "%05d" % self.generator.random.randint(501, 99950)

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -313,8 +313,7 @@ class TestEnUS(unittest.TestCase):
     def test_state_abbr(self):
         state_abbr = self.factory.state_abbr()
         assert isinstance(state_abbr, string_types)
-        states_and_territories = (EnUsProvider.states_abbr
-                                  + EnUsProvider.territories_abbr)
+        states_and_territories = EnUsProvider.states_and_territories_abbr
         assert state_abbr in states_and_territories
 
     def test_state_abbr_no_territories(self):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -313,6 +313,13 @@ class TestEnUS(unittest.TestCase):
     def test_state_abbr(self):
         state_abbr = self.factory.state_abbr()
         assert isinstance(state_abbr, string_types)
+        states_and_territories = (EnUsProvider.states_abbr
+                                  + EnUsProvider.territories_abbr)
+        assert state_abbr in states_and_territories
+
+    def test_state_abbr_no_territories(self):
+        state_abbr = self.factory.state_abbr(include_territories=False)
+        assert isinstance(state_abbr, string_types)
         assert state_abbr in EnUsProvider.states_abbr
 
     def test_postcode(self):


### PR DESCRIPTION
### What does this changes

Adds `include_territories` parameter to `state_abbr()`, which allows including/excluding US territories from `state_abbr()` return. Default is True, to include territories.

### What was wrong

`state_abbr()` did not allow excluding US territories from returned state abbreviations. See #800.

### How this fixes it

Removed territories from the `Provider.address.en_US.states_abbr` list, and created new list, `Provider.address.en_US.territories_abbr` for only territories.

Updated the method `Provider.address.en_US.state_abbr()` to have new boolean parameter `include_territories=True`, allowing exclusion of territories if needed.

Updated unit tests to reflect the change in behavior for `state_abbr()`.