### PR TITLE
Run tests against Python 3.7 on travis and add classifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ python:
   - 3.6
   - "pypy-5.3.1"
   - "pypy3"
+matrix:
+  include:
+    - python: 3.7
+      sudo: required
+      dist: xenial
 before_install:
     - pip install pep8
 install:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
### What does this changes

- Run tests against Python 3.7 on travis
- Add classifier for Python 3.7 to setup.py