### PR TITLE
Fix/master/companies prefixes

### DIFF
--- a/faker/providers/company/__init__.py
+++ b/faker/providers/company/__init__.py
@@ -16,6 +16,8 @@ class Provider(BaseProvider):
 
     company_suffixes = ('Inc', 'and Sons', 'LLC', 'Group', 'PLC', 'Ltd')
 
+    company_prefixes = ()
+
     catch_phrase_words = (
         ('Adaptive',
          'Advanced',
@@ -500,6 +502,12 @@ class Provider(BaseProvider):
         """
         pattern = self.random_element(self.formats)
         return self.generator.parse(pattern)
+
+    def company_prefix(self):
+        """
+        :example 'Group'
+        """
+        return self.random_element(self.company_prefixes)
 
     def company_suffix(self):
         """

--- a/faker/providers/company/es_MX/__init__.py
+++ b/faker/providers/company/es_MX/__init__.py
@@ -137,17 +137,11 @@ class Provider(CompanyProvider):
         ),
     )
 
-    company_preffixes = ('Despacho', 'Grupo', 'Corporacin', 'Club',
+    company_prefixes = ('Despacho', 'Grupo', 'Corporacin', 'Club',
                          'Industrias', 'Laboratorios', 'Proyectos')
 
     company_suffixes = ('A.C.', 'S.A.', 'S.A. de C.V.', 'S.C.',
                         'S. R.L. de C.V.', 'e Hijos', 'y Asociados')
-
-    def company_prefix(self):
-        """
-        Ejemplo: Grupo
-        """
-        return self.random_element(self.company_preffixes)
 
     def catch_phrase(self):
         """

--- a/faker/providers/company/id_ID/__init__.py
+++ b/faker/providers/company/id_ID/__init__.py
@@ -23,6 +23,3 @@ class Provider(CompanyProvider):
     company_suffixes = (
         '(Persero) Tbk', 'Tbk',
     )
-
-    def company_prefix(self):
-        return self.random_element(self.company_prefixes)

--- a/faker/providers/company/ja_JP/__init__.py
+++ b/faker/providers/company/ja_JP/__init__.py
@@ -9,6 +9,3 @@ class Provider(CompanyProvider):
     )
 
     company_prefixes = ('株式会社', '有限会社', '合同会社')
-
-    def company_prefix(self):
-        return self.random_element(self.company_prefixes)

--- a/faker/providers/company/pl_PL/__init__.py
+++ b/faker/providers/company/pl_PL/__init__.py
@@ -55,6 +55,18 @@ def company_vat_checksum(digits):
 
 class Provider(CompanyProvider):
 
+    formats = (
+        '{{last_name}} {{company_suffix}}',
+        '{{last_name}}-{{last_name}} {{company_suffix}}',
+        '{{company_prefix}} {{last_name}}',
+        '{{company_prefix}} {{last_name}} {{company_suffix}}',
+        '{{company_prefix}} {{last_name}}-{{last_name}} {{company_suffix}}'
+    )
+
+    company_prefixes = ('Grupa', 'Spółdzielnia', 'Stowarzyszenie', 'Fundacja', 'PPUH', 'FPUH')
+
+    company_suffixes = ('Sp. z o.o.', 'S.A.', 'Sp. z o.o. Sp.k.', 'Sp.j.', 's.c.', 'Sp.k.', 'S.K.A.', 'i partnerzy')
+
     def regon(self):
         """
         Returns 9 character Polish National Business Registry Number,

--- a/faker/providers/company/ru_RU/__init__.py
+++ b/faker/providers/company/ru_RU/__init__.py
@@ -16,6 +16,3 @@ class Provider(CompanyProvider):
     company_prefixes = (
         'РАО', 'АО', 'ИП', 'НПО',
     )
-
-    def company_prefix(self):
-        return self.random_element(self.company_prefixes)

--- a/faker/providers/company/zh_CN/__init__.py
+++ b/faker/providers/company/zh_CN/__init__.py
@@ -21,6 +21,3 @@ class Provider(CompanyProvider):
                         "昊嘉", "鸿睿思博", "四通", "富罳", "商软冠联", "诺依曼软件",
                         "东方峻景", "华成育卓", "趋势", "维涛", "通际名联"]
     company_suffixes = [n + "有限公司" for n in ["科技", "网络", "信息", "传媒"]]
-
-    def company_prefix(self):
-        return self.random_element(self.company_prefixes)

--- a/faker/providers/company/zh_TW/__init__.py
+++ b/faker/providers/company/zh_TW/__init__.py
@@ -34,6 +34,3 @@ class Provider(CompanyProvider):
         "瑞輝大藥廠", "隆豐大飯店（北台君悅）", "資華粧業（生資堂）")
 
     company_suffixes = ("", "有限公司", "股份有限公司", "資訊有限公司")
-
-    def company_prefix(self):
-        return self.random_element(self.company_prefixes)


### PR DESCRIPTION
### What does this changes

Adds common functionality `company_prefix `to company provider
Adds company suffixes, company prefixes and company formats for pl-PL company provider

### What was wrong

Many implementations of company_prefix: in company providers for es_MX, id_ID, ja_JP, ru_RU, zh_CH and zh_TW
No Polish company names were implemented

### How this fixes it

Updates company provider implementations for s_MX, id_ID, ja_JP, pl-PL, ru_RU, zh_CH and zh_TW to be compatible with common `company_prefix ` implementation in main company provider

Fixes #811 
Supersedes #812 
