### PR TITLE
Use six compatibility shims; avoid reimplementing them

### DIFF
--- a/faker/build_docs.py
+++ b/faker/build_docs.py
@@ -7,13 +7,7 @@ import os
 import pprint
 import sys
 
-
-if sys.version < '3':
-    text_type = unicode
-    binary_type = str
-else:
-    text_type = str
-    binary_type = bytes
+import six
 
 
 DOCS_ROOT = os.path.abspath(os.path.join('..', 'docs'))
@@ -41,7 +35,7 @@ def write_provider(fh, doc, provider, formatters, excludes=None):
             # `pprint` can't format sets of heterogenous types.
             if not isinstance(example, set):
                 example = pprint.pformat(example, indent=4)
-            lines = text_type(example).expandtabs().splitlines()
+            lines = six.text_type(example).expandtabs().splitlines()
         except UnicodeEncodeError:
             msg = 'error on "{0}" with value "{1}"'.format(signature, example)
             raise Exception(msg)

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -8,19 +8,13 @@ import sys
 import argparse
 
 import random
+import six
 
 from faker import Faker, documentor
 from faker import VERSION
 from faker.config import AVAILABLE_LOCALES, DEFAULT_LOCALE, META_PROVIDERS_MODULES
 
 import logging
-
-if sys.version < '3':
-    text_type = unicode
-    binary_type = str
-else:
-    text_type = str
-    binary_type = bytes
 
 
 __author__ = 'joke2k'
@@ -40,7 +34,7 @@ def print_provider(doc, provider, formatters, excludes=None, output=None):
         if signature in excludes:
             continue
         try:
-            lines = text_type(example).expandtabs().splitlines()
+            lines = six.text_type(example).expandtabs().splitlines()
         except UnicodeDecodeError:
             # The example is actually made of bytes.
             # We could coerce to bytes, but that would fail anyway when we wiil

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -5,16 +5,9 @@ from __future__ import unicode_literals
 from decimal import Decimal
 import sys
 
+import six
+
 from .. import BaseProvider
-
-
-if sys.version_info[0] == 2:
-    string_types = (basestring,)
-elif sys.version_info[0] == 3:
-    string_types = (str, bytes)
-else:
-    raise SystemError(
-        "Unrecognized python version: {}".format(sys.version_info[0]))
 
 
 class Provider(BaseProvider):
@@ -113,7 +106,7 @@ class Provider(BaseProvider):
             variable_nb_elements=True,
             *value_types):
 
-        value_types = [t if isinstance(t, string_types) else getattr(t, '__name__', type(t).__name__).lower()
+        value_types = [t if isinstance(t, six.string_types) else getattr(t, '__name__', type(t).__name__).lower()
                        for t in value_types
                        # avoid recursion
                        if t not in ['iterable', 'list', 'tuple', 'dict', 'set']]
@@ -145,7 +138,7 @@ class Provider(BaseProvider):
 
     def pystruct(self, count=10, *value_types):
 
-        value_types = [t if isinstance(t, string_types) else getattr(t, '__name__', type(t).__name__).lower()
+        value_types = [t if isinstance(t, six.string_types) else getattr(t, '__name__', type(t).__name__).lower()
                        for t in value_types
                        # avoid recursion
                        if t != 'struct']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-try:
-    string_types = (basestring,)
-except NameError:  # pragma: no cover
-    string_types = (str,)

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 import unittest
 import re
 
+import six
+
 from faker import Faker
 from faker.providers.company.hu_HU import Provider as HuProvider
 from faker.providers.company.ja_JP import Provider as JaProvider
@@ -12,7 +14,6 @@ from faker.providers.company.pt_BR import company_id_checksum
 from faker.providers.company.pl_PL import (
     company_vat_checksum, regon_checksum, local_regon_checksum,
 )
-from tests import string_types
 
 
 class TestFiFI(unittest.TestCase):
@@ -39,11 +40,11 @@ class TestJaJP(unittest.TestCase):
         prefixes = JaProvider.company_prefixes
 
         prefix = self.factory.company_prefix()
-        assert isinstance(prefix, string_types)
+        assert isinstance(prefix, six.string_types)
         assert prefix in prefixes
 
         company = self.factory.company()
-        assert isinstance(company, string_types)
+        assert isinstance(company, six.string_types)
         assert any(prefix in company for prefix in prefixes)
         assert any(company.startswith(prefix) for prefix in prefixes)
 
@@ -83,12 +84,12 @@ class TestHuHU(unittest.TestCase):
 
     def test_company_suffix(self):
         suffix = self.factory.company_suffix()
-        assert isinstance(suffix, string_types)
+        assert isinstance(suffix, six.string_types)
         assert suffix in self.valid_suffixes
 
     def test_company(self):
         company = self.factory.company()
-        assert isinstance(company, string_types)
+        assert isinstance(company, six.string_types)
         assert company.split(" ")[-1] in self.valid_suffixes
 
 

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -7,13 +7,13 @@ import time
 import unittest
 import random
 
+import six
+
 from faker import Faker
 from faker.providers.date_time import Provider as DatetimeProvider
 from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
-
-from tests import string_types
 
 
 class UTC(tzinfo):
@@ -44,11 +44,11 @@ class TestKoKR(unittest.TestCase):
 
     def test_day(self):
         day = self.factory.day_of_week()
-        assert isinstance(day, string_types)
+        assert isinstance(day, six.string_types)
 
     def test_month(self):
         month = self.factory.month()
-        assert isinstance(month, string_types)
+        assert isinstance(month, six.string_types)
 
 
 class TestDateTime(unittest.TestCase):
@@ -63,11 +63,11 @@ class TestDateTime(unittest.TestCase):
 
     def test_day(self):
         day = self.factory.day_of_week()
-        assert isinstance(day, string_types)
+        assert isinstance(day, six.string_types)
 
     def test_month(self):
         month = self.factory.month()
-        assert isinstance(month, string_types)
+        assert isinstance(month, six.string_types)
 
     def test_past_datetime(self):
         past_datetime = self.factory.past_datetime()

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -7,13 +7,13 @@ from itertools import cycle
 import unittest
 
 import mock
+import six
 
 from email_validator import validate_email
 
 from faker import Faker
 from faker.providers.person.ja_JP import Provider as JaProvider
 from faker.utils import text
-from tests import string_types
 
 
 class TestInternetProvider(unittest.TestCase):
@@ -69,21 +69,21 @@ class TestJaJP(unittest.TestCase):
         names = JaProvider.last_romanized_names
 
         domain_word = self.factory.domain_word()
-        self.assertIsInstance(domain_word, string_types)
+        self.assertIsInstance(domain_word, six.string_types)
         self.assertTrue(any(domain_word == text.slugify(name) for name in names))
 
         domain_name = self.factory.domain_name()
         deep_domain_name = self.factory.domain_name(3)
-        self.assertIsInstance(domain_name, string_types)
-        self.assertIsInstance(deep_domain_name, string_types)
+        self.assertIsInstance(domain_name, six.string_types)
+        self.assertIsInstance(deep_domain_name, six.string_types)
         self.assertEqual(deep_domain_name.count('.'), 3)
         self.assertRaises(ValueError, self.factory.domain_name, -1)
 
         user_name = self.factory.user_name()
-        self.assertIsInstance(user_name, string_types)
+        self.assertIsInstance(user_name, six.string_types)
 
         tld = self.factory.tld()
-        self.assertIsInstance(tld, string_types)
+        self.assertIsInstance(tld, six.string_types)
 
 
 class TestZhCN(unittest.TestCase):
@@ -114,11 +114,11 @@ class TestHuHU(unittest.TestCase):
 
     def test_internet(self):
         domain_name = self.factory.domain_name()
-        self.assertIsInstance(domain_name, string_types)
+        self.assertIsInstance(domain_name, six.string_types)
         tld = self.factory.tld()
-        self.assertIsInstance(tld, string_types)
+        self.assertIsInstance(tld, six.string_types)
         email = self.factory.email()
-        self.assertIsInstance(email, string_types)
+        self.assertIsInstance(email, six.string_types)
 
 
 class TestPlPL(unittest.TestCase):

--- a/tests/providers/test_job.py
+++ b/tests/providers/test_job.py
@@ -4,9 +4,9 @@ from __future__ import unicode_literals
 
 import unittest
 
-from faker import Faker
+import six
 
-from tests import string_types
+from faker import Faker
 
 
 class TestJob(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestJob(unittest.TestCase):
 
     def test_job(self):
         job = self.factory.job()
-        assert isinstance(job, string_types)
+        assert isinstance(job, six.string_types)
 
 
 class TestKoKR(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestKoKR(unittest.TestCase):
 
     def test_job(self):
         job = self.factory.job()
-        assert isinstance(job, string_types)
+        assert isinstance(job, six.string_types)
 
 
 class TestHuHU(unittest.TestCase):
@@ -43,4 +43,4 @@ class TestHuHU(unittest.TestCase):
 
     def test_job(self):
         job = self.factory.job()
-        assert isinstance(job, string_types)
+        assert isinstance(job, six.string_types)

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 import re
 import unittest
 
+import six
+
 from faker import Faker
 from faker.providers.person.ar_AA import Provider as ArProvider
 from faker.providers.person.fi_FI import Provider as FiProvider
@@ -13,7 +15,6 @@ from faker.providers.person.sv_SE import Provider as SvSEProvider
 from faker.providers.person.pl_PL import (
     checksum_identity_card_number as pl_checksum_identity_card_number,
 )
-from tests import string_types
 
 
 class TestAr(unittest.TestCase):
@@ -26,20 +27,20 @@ class TestAr(unittest.TestCase):
         # General first name
         name = self.factory.first_name()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.first_names)
 
         # Females first name
         name = self.factory.first_name_female()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.first_names)
         self.assertIn(name, ArProvider.first_names_female)
 
         # Male first name
         name = self.factory.first_name_male()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.first_names)
         self.assertIn(name, ArProvider.first_names_male)
 
@@ -53,20 +54,20 @@ class TestAr(unittest.TestCase):
         # General first name.
         name = self.factory.last_name()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.last_names)
 
         # Females last name.
         name = self.factory.last_name_female()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.last_names)
         self.assertIn(name, ArProvider.last_names)
 
         # Male last name.
         name = self.factory.last_name_male()
         self.assertTrue(name)
-        self.assertIsInstance(name, string_types)
+        self.assertIsInstance(name, six.string_types)
         self.assertIn(name, ArProvider.last_names)
         self.assertIn(name, ArProvider.last_names)
 
@@ -80,55 +81,55 @@ class TestJaJP(unittest.TestCase):
     def test_person(self):
         name = self.factory.name()
         assert name
-        assert isinstance(name, string_types)
+        assert isinstance(name, six.string_types)
 
         first_name = self.factory.first_name()
         assert first_name
-        assert isinstance(first_name, string_types)
+        assert isinstance(first_name, six.string_types)
 
         last_name = self.factory.last_name()
         assert last_name
-        assert isinstance(last_name, string_types)
+        assert isinstance(last_name, six.string_types)
 
         kana_name = self.factory.kana_name()
         assert kana_name
-        assert isinstance(kana_name, string_types)
+        assert isinstance(kana_name, six.string_types)
 
         first_kana_name = self.factory.first_kana_name()
         assert first_kana_name
-        assert isinstance(first_kana_name, string_types)
+        assert isinstance(first_kana_name, six.string_types)
 
         first_kana_name_male = self.factory.first_kana_name_male()
         assert first_kana_name_male
-        assert isinstance(first_kana_name_male, string_types)
+        assert isinstance(first_kana_name_male, six.string_types)
 
         first_kana_name_female = self.factory.first_kana_name_female()
         assert first_kana_name_female
-        assert isinstance(first_kana_name_female, string_types)
+        assert isinstance(first_kana_name_female, six.string_types)
 
         last_kana_name = self.factory.last_kana_name()
         assert last_kana_name
-        assert isinstance(last_kana_name, string_types)
+        assert isinstance(last_kana_name, six.string_types)
 
         romanized_name = self.factory.romanized_name()
         assert romanized_name
-        assert isinstance(romanized_name, string_types)
+        assert isinstance(romanized_name, six.string_types)
 
         first_romanized_name = self.factory.first_romanized_name()
         assert first_romanized_name
-        assert isinstance(first_romanized_name, string_types)
+        assert isinstance(first_romanized_name, six.string_types)
 
         first_romanized_name_male = self.factory.first_romanized_name_male()
         assert first_romanized_name_male
-        assert isinstance(first_romanized_name_male, string_types)
+        assert isinstance(first_romanized_name_male, six.string_types)
 
         first_romanized_name_female = self.factory.first_romanized_name_female()
         assert first_romanized_name_female
-        assert isinstance(first_romanized_name_female, string_types)
+        assert isinstance(first_romanized_name_female, six.string_types)
 
         last_romanized_name = self.factory.last_romanized_name()
         assert last_romanized_name
-        assert isinstance(last_romanized_name, string_types)
+        assert isinstance(last_romanized_name, six.string_types)
 
 
 class TestNeNP(unittest.TestCase):
@@ -138,7 +139,7 @@ class TestNeNP(unittest.TestCase):
 
     def test_names(self):
         name = self.factory.name().split()
-        assert all(isinstance(n, string_types) for n in name)
+        assert all(isinstance(n, six.string_types) for n in name)
         # name should always be 2-3 words. If 3, first word
         # should be a prefix.
         assert name[-2] in NeProvider.first_names
@@ -155,18 +156,18 @@ class TestFiFI(unittest.TestCase):
 
     def test_gender_first_names(self):
         female_name = self.factory.first_name_female()
-        self.assertIsInstance(female_name, string_types)
+        self.assertIsInstance(female_name, six.string_types)
         self.assertIn(female_name, FiProvider.first_names_female)
         male_name = self.factory.first_name_male()
-        self.assertIsInstance(male_name, string_types)
+        self.assertIsInstance(male_name, six.string_types)
         self.assertIn(male_name, FiProvider.first_names_male)
         first_name = self.factory.first_name()
-        self.assertIsInstance(first_name, string_types)
+        self.assertIsInstance(first_name, six.string_types)
         self.assertIn(first_name, FiProvider.first_names)
 
     def test_last_names(self):
         last_name = self.factory.last_name()
-        self.assertIsInstance(last_name, string_types)
+        self.assertIsInstance(last_name, six.string_types)
         self.assertIn(last_name, FiProvider.last_names)
 
 

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -5,8 +5,9 @@ from __future__ import unicode_literals
 import re
 import unittest
 
+import six
+
 from faker import Faker
-from tests import string_types
 
 
 class TestPhoneNumber(unittest.TestCase):
@@ -19,7 +20,7 @@ class TestPhoneNumber(unittest.TestCase):
         pn = self.factory.phone_number()
 
         assert pn
-        assert isinstance(pn, string_types)
+        assert isinstance(pn, six.string_types)
 
     def test_phone_number_ja(self):
         factory = Faker('ja')
@@ -27,7 +28,7 @@ class TestPhoneNumber(unittest.TestCase):
         formats = ('070', '080', '090')
 
         assert pn
-        assert isinstance(pn, string_types)
+        assert isinstance(pn, six.string_types)
         first, second, third = pn.split('-')
         assert first
         assert first.isdigit()
@@ -48,7 +49,7 @@ class TestPhoneNumber(unittest.TestCase):
         msisdn = self.factory.msisdn()
 
         assert msisdn is not None
-        assert isinstance(msisdn, string_types)
+        assert isinstance(msisdn, six.string_types)
         assert len(msisdn) == 13
         assert msisdn.isdigit()
 
@@ -58,7 +59,7 @@ class TestPhoneNumber(unittest.TestCase):
         formats = ('5511', '5521', '5531', '5541', '5551', '5561', '5571', '5581')
 
         assert msisdn is not None
-        assert isinstance(msisdn, string_types)
+        assert isinstance(msisdn, six.string_types)
         assert len(msisdn) == 13
         assert msisdn.isdigit()
         assert msisdn[0:4] in formats

--- a/tests/test_base_provider.py
+++ b/tests/test_base_provider.py
@@ -1,9 +1,10 @@
 import unittest
 import string
 
+import six
+
 from faker import Generator
 from faker.providers import BaseProvider
-from tests import string_types
 
 
 class TestBaseProvider(unittest.TestCase):
@@ -25,12 +26,12 @@ class TestBaseProvider(unittest.TestCase):
 
         # all letters to choose from
         lexified = self.provider.lexify(text)
-        self.assertIsInstance(lexified, string_types)
+        self.assertIsInstance(lexified, six.string_types)
         self.assertEqual(len(lexified), len(text))
 
         # A set of letters to choose from
         lexified = self.provider.lexify(text, letters=letters)
-        self.assertIsInstance(lexified, string_types)
+        self.assertIsInstance(lexified, six.string_types)
         self.assertEqual(len(lexified), len(text))
         for letter in lexified:
             self.assertIn(letter, letters)
@@ -41,12 +42,12 @@ class TestBaseProvider(unittest.TestCase):
 
         # all letters to choose from
         lexified = self.provider.lexify(text)
-        self.assertIsInstance(lexified, string_types)
+        self.assertIsInstance(lexified, six.string_types)
         self.assertEqual(len(lexified), len(text))
 
         # A set of letters to choose from
         lexified = self.provider.lexify(text, letters=letters)
-        self.assertIsInstance(lexified, string_types)
+        self.assertIsInstance(lexified, six.string_types)
         self.assertEqual(len(lexified), len(text))
         for letter in lexified:
             self.assertIn(letter, letters + '# ')
@@ -57,12 +58,12 @@ class TestBaseProvider(unittest.TestCase):
 
         # all letters to choose from
         bothify = self.provider.bothify(text)
-        self.assertIsInstance(bothify, string_types)
+        self.assertIsInstance(bothify, six.string_types)
         self.assertEqual(len(bothify), len(text))
 
         # A set of letters to choose from
         bothify = self.provider.bothify(text, letters=letters)
-        self.assertIsInstance(bothify, string_types)
+        self.assertIsInstance(bothify, six.string_types)
         self.assertEqual(len(bothify), len(text))
         for letter in bothify:
             self.assertIn(letter, letters)
@@ -73,12 +74,12 @@ class TestBaseProvider(unittest.TestCase):
 
         # all letters to choose from
         bothify = self.provider.bothify(text)
-        self.assertIsInstance(bothify, string_types)
+        self.assertIsInstance(bothify, six.string_types)
         self.assertEqual(len(bothify), len(text))
 
         # A set of letters to choose from
         bothify = self.provider.bothify(text, letters=letters)
-        self.assertIsInstance(bothify, string_types)
+        self.assertIsInstance(bothify, six.string_types)
         self.assertEqual(len(bothify), len(text))
         for letter in bothify:
             self.assertIn(letter, letters + '0123456789# ')

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -10,15 +10,11 @@ from ipaddress import ip_address, ip_network, IPv4Address
 
 import logging
 
-try:
-    from StringIO import StringIO
-except ImportError:  # pragma: no cover
-    from io import StringIO
+import six
 
 from faker import Generator, Faker
 from faker.generator import random
 from faker.utils import text, decorators
-from tests import string_types
 
 
 class BarProvider(object):
@@ -95,7 +91,7 @@ class FactoryTestCase(unittest.TestCase):
 
     def test_documentor(self):
         from faker.cli import print_doc
-        output = StringIO()
+        output = six.StringIO()
         print_doc(output=output)
         print_doc('address', output=output)
         print_doc('faker.providers.person.it_IT', output=output)
@@ -107,7 +103,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.cli import Command
         orig_stdout = sys.stdout
         try:
-            sys.stdout = StringIO()
+            sys.stdout = six.StringIO()
             command = Command(['faker', 'address'])
             command.execute()
             assert sys.stdout.getvalue()
@@ -118,7 +114,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.cli import Command
         orig_stdout = sys.stdout
         try:
-            sys.stdout = StringIO()
+            sys.stdout = six.StringIO()
             command = Command(['faker', 'foo', '-i', 'tests.mymodule.en_US'])
             command.execute()
             assert sys.stdout.getvalue()
@@ -129,7 +125,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.cli import Command
         orig_stdout = sys.stdout
         try:
-            sys.stdout = StringIO()
+            sys.stdout = six.StringIO()
             base_args = ['faker', 'address']
             target_args = ['--seed', '967']
             commands = [Command(base_args + target_args), Command(base_args + target_args)]
@@ -146,7 +142,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.cli import Command
         orig_stdout = sys.stdout
         try:
-            sys.stdout = StringIO()
+            sys.stdout = six.StringIO()
             base_args = ['faker', 'address', '-r', '3']
             target_args = ['--seed', '967']
             commands = [Command(base_args + target_args), Command(base_args + target_args)]
@@ -163,7 +159,7 @@ class FactoryTestCase(unittest.TestCase):
         from faker.cli import Command
         orig_stdout = sys.stdout
         try:
-            sys.stdout = StringIO()
+            sys.stdout = six.StringIO()
             base_args = ['faker', 'address', '--seed', '769']
             target_args = ['-v']
             commands = [Command(base_args), Command(base_args + target_args)]
@@ -257,7 +253,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             language_code = provider.language_code()
-            self.assertTrue(isinstance(language_code, string_types))
+            self.assertTrue(isinstance(language_code, six.string_types))
             self.assertTrue(re.match(r'^[a-z]{2,3}$', language_code))
 
     def test_locale(self):
@@ -291,8 +287,8 @@ class FactoryTestCase(unittest.TestCase):
         for locale in ("bg_BG", "dk_DK", "en", "ru_RU", "tr_TR"):
             f = Faker(locale=locale)
             for x in range(20):  # Probabilistic testing.
-                self.assertIsInstance(f.prefix(), string_types)
-                self.assertIsInstance(f.suffix(), string_types)
+                self.assertIsInstance(f.prefix(), six.string_types)
+                self.assertIsInstance(f.suffix(), six.string_types)
 
     def test_no_words_sentence(self):
         from faker.providers.lorem import Provider
@@ -345,7 +341,7 @@ class FactoryTestCase(unittest.TestCase):
         self.assertEqual(len(words), num_words)
 
         for word in words:
-            self.assertTrue(isinstance(word, string_types))
+            self.assertTrue(isinstance(word, six.string_types))
             self.assertTrue(re.match(r'^[a-z].*$', word))
 
     def test_words_ext_word_list(self):
@@ -368,7 +364,7 @@ class FactoryTestCase(unittest.TestCase):
         self.assertEqual(len(words), num_words)
 
         for word in words:
-            self.assertTrue(isinstance(word, string_types))
+            self.assertTrue(isinstance(word, six.string_types))
             self.assertIn(word, my_word_list)
 
     def test_words_ext_word_list_unique(self):
@@ -392,7 +388,7 @@ class FactoryTestCase(unittest.TestCase):
 
         checked_words = []
         for word in words:
-            self.assertTrue(isinstance(word, string_types))
+            self.assertTrue(isinstance(word, six.string_types))
             self.assertIn(word, my_word_list)
             # Check that word is unique
             self.assertTrue(word not in checked_words)
@@ -408,7 +404,7 @@ class FactoryTestCase(unittest.TestCase):
 
         checked_words = []
         for word in words:
-            self.assertTrue(isinstance(word, string_types))
+            self.assertTrue(isinstance(word, six.string_types))
             # Check that word is only letters. No numbers, symbols, etc
             self.assertTrue(re.match(r'^[a-zA-Z].*$', word))
             # Check that word list is unique


### PR DESCRIPTION
The six library is already a dependency. The text_type, binary_type, and
StringIO shims exist in the six library. No need to reimplement them.