### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,4 +3,3 @@ current_version = 0.9.1
 files = setup.py faker/__init__.py docs/conf.py
 commit = True
 tag = True
-

--- a/faker/providers/address/en_CA/__init__.py
+++ b/faker/providers/address/en_CA/__init__.py
@@ -326,6 +326,6 @@ class Provider(AddressProvider):
                       lambda x: self.postal_code_letter(),
                       self.random_element(self.postal_code_formats))
         return self.numerify(temp)
-    
+
     def postalcode(self):
         return self.postcode()

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1964,7 +1964,7 @@ class Provider(BaseProvider):
         :param tzinfo Defaults to None.
         :param minimum_age Defaults to 0.
         :param maximum_age Defaults to 115.
-        
+
         :example Date('1979-02-02')
         :return Date
         """
@@ -1985,8 +1985,8 @@ class Provider(BaseProvider):
             raise ValueError("minimum_age must be less than or equal to maximum_age.")
 
         # In order to return the full range of possible dates of birth, add one
-        # year to the potential age cap and subtract one day if we land on the 
-        # boundary. 
+        # year to the potential age cap and subtract one day if we land on the
+        # boundary.
 
         now = datetime.now(tzinfo).date()
         start_date = now.replace(year=now.year - (maximum_age+1))

--- a/faker/providers/ssn/en_CA/__init__.py
+++ b/faker/providers/ssn/en_CA/__init__.py
@@ -41,9 +41,9 @@ def checksum(sin):
 
 class Provider(SsnProvider):
 
-    # In order to create a valid SIN we need to provide a number that 
-    # passes a simple modified Luhn Algorithm checksum. 
-    # 
+    # In order to create a valid SIN we need to provide a number that
+    # passes a simple modified Luhn Algorithm checksum.
+    #
     # This function reverses the checksum steps to create a random
     # valid nine-digit Canadian SIN (Social Insurance Number) in the
     # format '### ### ###'.
@@ -52,7 +52,7 @@ class Provider(SsnProvider):
         # Create an array of 8 elements initialized randomly.
         digits = self.generator.random.sample(range(9), 8)
 
-        # The final step of the validation requires that all of the 
+        # The final step of the validation requires that all of the
         # digits sum to a multiple of 10. First, sum the first 8 and
         # set the 9th to the value that results in a multiple of 10.
         check_digit = 10 - (sum(digits) % 10)
@@ -60,7 +60,7 @@ class Provider(SsnProvider):
 
         digits.append(check_digit)
 
-        # digits is now the digital root of the number we want 
+        # digits is now the digital root of the number we want
         # multiplied by the magic number 121 212 121. The next step is
         # to reverse the multiplication which occurred on every other
         # element.

--- a/faker/providers/ssn/en_US/__init__.py
+++ b/faker/providers/ssn/en_US/__init__.py
@@ -34,7 +34,7 @@ class Provider(BaseProvider):
 
     def ein(self):
         """Generate a random United States Employer Identification Number (EIN).
-        
+
          An United States An Employer Identification Number (EIN) is
          also known as a Federal Tax Identification Number, and is
          used to identify a business entity. EINs follow a format of a
@@ -155,7 +155,7 @@ class Provider(BaseProvider):
             # Numbers. The area (first 3 digits) cannot be 666 or 900-999.
             # The group number (middle digits) cannot be 00. The serial
             # (last 4 digits) cannot be 0000.
-        
+
             area = self.random_int(min=1, max=899)
             if area == 666:
                 area += 1
@@ -164,6 +164,6 @@ class Provider(BaseProvider):
 
             ssn = "{0:03d}-{1:02d}-{2:04d}".format(area, group, serial)
             return ssn
-    
+
         else:
             raise ValueError("taxpayer_identification_number_type must be one of 'SSN', 'EIN', or 'ITIN'.")

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -395,7 +395,7 @@ class TestDateTime(unittest.TestCase):
 
             # Ensure relative unix_times partially-constrained by a start time are generated correctly
             one_day_ago = datetime.today()-timedelta(days=1)
-            
+
             recent_unix_time = self.factory.unix_time(start_datetime=one_day_ago)
 
             self.assertIsInstance(recent_unix_time, int)
@@ -405,7 +405,7 @@ class TestDateTime(unittest.TestCase):
             one_day_after_epoch_start = datetime(1970, 1, 2, tzinfo=utc)
 
             distant_unix_time = self.factory.unix_time(end_datetime=one_day_after_epoch_start)
-            
+
             self.assertIsInstance(distant_unix_time, int)
             self.assertBetween(distant_unix_time, datetime_to_timestamp(epoch_start), datetime_to_timestamp(one_day_after_epoch_start))
 
@@ -518,12 +518,12 @@ class DatesOfBirth(unittest.TestCase):
 
             days_since_now = now - now
             days_since_six_years_ago = now - now.replace(year=now.year-6)
-            
+
             dob = self.factory.date_of_birth(tzinfo=utc, minimum_age=0, maximum_age=5)
             days_since_dob = now - dob
 
             assert isinstance(dob, date)
-            assert days_since_six_years_ago > days_since_dob >= days_since_now 
+            assert days_since_six_years_ago > days_since_dob >= days_since_now
 
     def test_acceptable_age_range_eighteen_years(self):
         for _ in range(100):
@@ -531,13 +531,13 @@ class DatesOfBirth(unittest.TestCase):
 
             days_since_now = now - now
             days_since_nineteen_years_ago = now - now.replace(year=now.year-19)
-            
+
             dob = self.factory.date_of_birth(tzinfo=utc, minimum_age=0, maximum_age=18)
             days_since_dob = now - dob
 
             assert isinstance(dob, date)
             assert days_since_nineteen_years_ago > days_since_dob >= days_since_now
-    
+
     def test_identical_age_range(self):
         for _ in range(100):
             now = datetime.now(utc).date()

--- a/tests/providers/test_isbn.py
+++ b/tests/providers/test_isbn.py
@@ -49,4 +49,3 @@ class TestProvider(unittest.TestCase):
         with self.assertRaises(Exception):
             r = RegistrantRule('0000000', '0000001', 1)
             self.prov._registrant_publication('0000002', [r])
-

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -267,7 +267,7 @@ class TestFiFI(unittest.TestCase):
     def test_ssn_sanity(self):
         for age in range(100):
             self.factory.ssn(min_age=age, max_age=age+1)
-    
+
     def test_valid_ssn(self):
         ssn = self.factory.ssn(artificial=False)
         individual_number = int(ssn[7:10])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -550,7 +550,7 @@ class FactoryTestCase(unittest.TestCase):
     def test_ipv4_private_class_a(self):
         from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
-        
+
         class_network = _IPv4Constants._network_classes['a']
         class_min = class_network.network_address
         class_max = class_network.broadcast_address
@@ -567,7 +567,7 @@ class FactoryTestCase(unittest.TestCase):
     def test_ipv4_private_class_b(self):
         from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
-        
+
         class_network = _IPv4Constants._network_classes['b']
         class_min = class_network.network_address
         class_max = class_network.broadcast_address
@@ -584,7 +584,7 @@ class FactoryTestCase(unittest.TestCase):
     def test_ipv4_private_class_c(self):
         from faker.providers.internet import Provider, _IPv4Constants
         provider = Provider(self.generator)
-        
+
         class_network = _IPv4Constants._network_classes['c']
         class_min = class_network.network_address
         class_max = class_network.broadcast_address
@@ -600,7 +600,7 @@ class FactoryTestCase(unittest.TestCase):
 
     def test_ipv4_public(self):
         from faker.providers.internet import Provider, _IPv4Constants
-        provider = Provider(self.generator)   
+        provider = Provider(self.generator)
 
         for _ in range(99):
             address = provider.ipv4_public()


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.