### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -403,7 +403,7 @@ Credits
 
 .. |pypi| image:: https://img.shields.io/pypi/v/Faker.svg?style=flat-square&label=version
     :target: https://pypi.org/project/Faker/
-    :alt: Latest version released on PyPi
+    :alt: Latest version released on PyPI
 
 .. |coverage| image:: https://img.shields.io/coveralls/joke2k/faker/master.svg?style=flat-square
     :target: https://coveralls.io/r/joke2k/faker?branch=master


### PR DESCRIPTION
As spelled on https://pypi.org/.