### PR TITLE
Simplify slugify; use six.text_type instead of force_text

### DIFF
--- a/faker/utils/text.py
+++ b/faker/utils/text.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-import datetime
-from decimal import Decimal
 import re
 
 import six
@@ -11,61 +9,6 @@ import unicodedata
 _re_pattern = re.compile(r'[^\w\s-]', flags=re.U)
 _re_pattern_allow_dots = re.compile(r'[^\.\w\s-]', flags=re.U)
 _re_spaces = re.compile(r'[-\s]+', flags=re.U)
-
-
-_PROTECTED_TYPES = six.integer_types + (
-    type(None), float, Decimal,
-    datetime.datetime, datetime.date, datetime.time,
-)
-
-
-def is_protected_type(obj):
-    """Determine if the object instance is of a protected type.
-    Objects of protected types are preserved as-is when passed to
-    force_text(strings_only=True).
-    """
-    return isinstance(obj, _PROTECTED_TYPES)
-
-
-def force_text(s, encoding='utf-8', strings_only=False, errors='strict'):
-    """
-    Similar to smart_text, except that lazy instances are resolved to
-    strings, rather than kept as lazy objects.
-    If strings_only is True, don't convert (some) non-string-like objects.
-    """
-    # Handle the common case first for performance reasons.
-    if issubclass(type(s), six.text_type):
-        return s
-    if strings_only and is_protected_type(s):
-        return s
-    try:
-        if not issubclass(type(s), six.string_types):
-            if six.PY3:
-                if isinstance(s, bytes):
-                    s = six.text_type(s, encoding, errors)
-                else:
-                    s = six.text_type(s)
-            elif hasattr(s, '__unicode__'):
-                s = six.text_type(s)
-            else:
-                s = six.text_type(bytes(s), encoding, errors)
-        else:
-            # Note: We use .decode() here, instead of six.text_type(s, encoding,
-            # errors), so that if s is a SafeBytes, it ends up being a
-            # SafeText at the end.
-            s = s.decode(encoding, errors)
-    except UnicodeDecodeError as e:
-        if not isinstance(s, Exception):
-            raise ValueError(s, *e.args)
-        else:
-            # If we get to here, the caller has passed in an Exception
-            # subclass populated with non-ASCII bytestring data without a
-            # working unicode method. Try to handle this without raising a
-            # further exception by individually forcing the exception args
-            # to unicode.
-            s = ' '.join(force_text(arg, encoding, strings_only, errors)
-                         for arg in s)
-    return s
 
 
 def slugify(value, allow_dots=False, allow_unicode=False):
@@ -81,7 +24,7 @@ def slugify(value, allow_dots=False, allow_unicode=False):
     else:
         pattern = _re_pattern
 
-    value = force_text(value)
+    value = six.text_type(value)
     if allow_unicode:
         value = unicodedata.normalize('NFKC', value)
         value = pattern.sub('', value).strip().lower()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -525,7 +525,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_private()
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
@@ -534,7 +534,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_private(network=True)
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 9)
             self.assertTrue(len(address) <= 18)
             self.assertTrue(ip_network(address)[0].is_private)
@@ -551,7 +551,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_private(address_class='a')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
@@ -568,7 +568,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_private(address_class='b')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
@@ -585,7 +585,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_private(address_class='c')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertTrue(ip_address(address).is_private)
@@ -598,7 +598,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_public()
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertFalse(ip_address(address).is_private, address)
@@ -607,7 +607,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_public(network=True)
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 9)
             self.assertTrue(len(address) <= 18)
             # Hack around ipaddress module
@@ -624,7 +624,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_public(address_class='a')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertFalse(ip_address(address).is_private, address)
@@ -635,7 +635,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_public(address_class='b')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertFalse(ip_address(address).is_private, address)
@@ -646,7 +646,7 @@ class FactoryTestCase(unittest.TestCase):
 
         for _ in range(99):
             address = provider.ipv4_public(address_class='c')
-            address = text.force_text(address)
+            address = six.text_type(address)
             self.assertTrue(len(address) >= 7)
             self.assertTrue(len(address) <= 15)
             self.assertFalse(ip_address(address).is_private, address)


### PR DESCRIPTION
Django's `force_text()` is overkill for the purposes of Faker's `slugifly`. Simply need to coerce the input to Unicode text. Django's `force_text()` is designed to handle many more cases that don't apply to developer controlled data.
