### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+cache: pip
 branches:
   only:
     - master


### PR DESCRIPTION
Slightly speed up builds and reduce load on PyPI servers.