### PR TITLE
Remove unused pep8 installation/configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
     - python: 3.7
       sudo: required
       dist: xenial
-before_install:
-    - pip install pep8
 install:
   - pip install -U setuptools
   - pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.txt
-
-[pep8]
-max-line-length = 80


### PR DESCRIPTION
In Travis CI, pep8 was installed but it never run.