### PR TITLE
Unify test environments between Travis CI & tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,32 @@ sudo: false
 branches:
   only:
     - master
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - "pypy-5.3.1"
-  - "pypy3"
+
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
     - python: 3.7
+      env: TOXENV=py37
       sudo: required
       dist: xenial
+    - python: pypy-5.3.1
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+
 before_install:
     - pip install pep8
 install:
-  - pip install -U setuptools
-  - pip install -e .
-  - pip install -r tests/requirements.txt
-  - pip install coveralls
+  - pip install tox
 script:
-  - coverage run --source=faker setup.py test
+  - tox
 after_success:
+  - pip install coveralls
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -347,7 +347,7 @@ Installing dependencies:
 
 .. code:: bash
 
-    $ pip install -r tests/requirements.txt
+    $ pip install -e .
 
 Run tests:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,11 +40,6 @@ init:
   - "ECHO %PYTHON%"
   - ps: "ls C:/Python*"
 
-install:
-  - "%PYTHON%/python.exe -m pip install -U pip"
-  - "%PYTHON%/Scripts/pip.exe install -e ."
-  - "%PYTHON%/Scripts/pip.exe install -r tests/requirements.txt"
-
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
   - "%PYTHON%/python.exe setup.py test"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,0 @@
-mock==2.0.0
-UkPostcodeParser==1.1.2
-email_validator==1.0.3
-python-dateutil>=2.4
-six>=1.10
-text-unidecode==1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist=py{27,34,35,36,37,py250,py3240}
+envlist=py{27,34,35,36,37,py,py3}
 skip_missing_interpreters = true
 
 [testenv]
-commands = python setup.py test
-deps = -r{toxinidir}/tests/requirements.txt
+deps = coverage
+commands =
+    coverage run --source=faker setup.py test
+    coverage report


### PR DESCRIPTION
Now, the running tests locally uses a Python environment closer to
Travis. Allows more easily verifying tests across all supported
environments with a single command.