### PR TITLE
New image URLs

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -115,13 +115,8 @@ class Provider(BaseProvider):
         '?txtsize=55&txt={width}x{height}&w={width}&h={height}',
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',
-        'https://baconmockup.com/{width}/{height}',
-        'https://loremflickr.com/{width}/{height}',
         'https://placekitten.com/{width}/{height}',
-        'https://www.placecage.com/{width}/{height}',
         'https://placeimg.com/{width}/{height}/any',
-        'https://placebear.com/{width}/{height}',
-        'https://picsum.photos/{width}/{height}',
     )
 
     replacements = tuple()

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -116,14 +116,11 @@ class Provider(BaseProvider):
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',
         'https://baconmockup.com/{width}/{height}',
-        'https://www.fillmurray.com/{width}/{height}',
         'https://loremflickr.com/{width}/{height}',
         'https://placekitten.com/{width}/{height}',
-        'https://placebeard.it/{width}x{height}',
         'https://www.placecage.com/{width}/{height}',
         'https://placeimg.com/{width}/{height}/any',
         'https://placebear.com/{width}/{height}',
-        'https://www.stevensegallery.com/{width}/{height}',
         'https://picsum.photos/{width}/{height}',
     )
 

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -115,6 +115,16 @@ class Provider(BaseProvider):
         '?txtsize=55&txt={width}x{height}&w={width}&h={height}',
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',
+        'https://baconmockup.com/{width}/{height}',
+        'https://www.fillmurray.com/{width}/{height}',
+        'https://loremflickr.com/{width}/{height}',
+        'https://placekitten.com/{width}/{height}',
+        'https://placebeard.it/{width}x{height}',
+        'https://www.placecage.com/{width}/{height}',
+        'https://placeimg.com/{width}/{height}/any',
+        'https://placebear.com/{width}/{height}',
+        'https://www.stevensegallery.com/{width}/{height}',
+        'https://picsum.photos/{width}/{height}',
     )
 
     replacements = tuple()

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -26,6 +26,18 @@ class TestInternetProvider(unittest.TestCase):
         email = self.factory.email(domain='example.com')
         self.assertEqual(email.split('@')[1], 'example.com')
 
+    @mock.patch(
+        'faker.providers.internet.Provider.image_placeholder_services',
+        {'https://dummyimage.com/{width}x{height}'}
+    )
+    def test_image_url(self):
+        my_width = 500
+        my_height = 1024
+        url = self.factory.image_url(my_width, my_height)
+        self.assertEqual('https://dummyimage.com/{}x{}'.format(my_width, my_height), url)
+        url = self.factory.image_url()
+        self.assertIn('https://dummyimage.com/', url)
+
 
 class TestInternetProviderUrl(unittest.TestCase):
     """ Test internet url generation """


### PR DESCRIPTION
### What does this changes

Add more image URLs for faker.provider.internet.image_url()

### What was wrong

This PR is just an enhancement.  No functionality of image_url() has been changed.

### How this fixes it

Add a few more image URL templates that I have used in the past.  I have verified, as of today, that the URLs work.

I have also added a unit test.