### PR TITLE
#491 Add replacements for non-ascii characters in pt_BR.

### DIFF
--- a/faker/providers/internet/pt_BR/__init__.py
+++ b/faker/providers/internet/pt_BR/__init__.py
@@ -13,3 +13,11 @@ class Provider(InternetProvider):
         'bol.com.br',
         'ig.com.br')
     tlds = ('com', 'com', 'com', 'net', 'org', 'br', 'br', 'br')
+    replacements = (
+        ('à', 'a'), ('â', 'a'), ('ã', 'a'),
+        ('ç', 'c'),
+        ('é', 'e'), ('ê', 'e'),
+        ('í', 'i'),
+        ('ô', 'o'), ('ö', 'o'), ('õ', 'o'),
+        ('ú', 'u'),
+    )

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -202,3 +202,37 @@ class TestArAa(unittest.TestCase):
         email = self.factory.ascii_company_email()
         validate_email(email, check_deliverability=False)
         self.assertEqual(email.split('@')[0], 'asyl')
+
+
+class TestPtBR(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = Faker('pt_BR')
+        self.provider = self.factory.provider('faker.providers.internet')
+
+    @mock.patch(
+        'faker.providers.internet.Provider.user_name',
+        lambda x: 'VitóriaMagalhães'
+    )
+    def test_ascii_safe_email(self):
+        email = self.factory.ascii_safe_email()
+        validate_email(email, check_deliverability=False)
+        self.assertEqual(email.split('@')[0], 'vitoriamagalhaes')
+
+    @mock.patch(
+        'faker.providers.internet.Provider.user_name',
+        lambda x: 'JoãoSimões'
+    )
+    def test_ascii_free_email(self):
+        email = self.factory.ascii_free_email()
+        validate_email(email, check_deliverability=False)
+        self.assertEqual(email.split('@')[0], 'joaosimoes')
+
+    @mock.patch(
+        'faker.providers.internet.Provider.user_name',
+        lambda x: 'AndréCauã'
+    )
+    def test_ascii_company_email(self):
+        email = self.factory.ascii_company_email()
+        validate_email(email, check_deliverability=False)
+        self.assertEqual(email.split('@')[0], 'andrecaua')


### PR DESCRIPTION
### What does this changes

Add replacements tuples to specify the mapping between non-ascii characters to ascii characters.

### What was wrong

Some non-ascii characters shows up in ascii_* methods.

### How this fixes it

Added replacements tuples in `faker/providers/internet/pt_BR/__init__.py`.

Added some unit tests.

### Note

In addition, ``string = unidecode(string)`` from ``_to_ascii(str)`` should cover any characters that are missed in the replacements.  The replacements tuples basically force the character mappings that may be overlooked by unidecode.

Fixes #491 
