### PR TITLE
Add method to generate a cell phone number to pt-BR localization

### DIFF
--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -71,6 +71,7 @@ class Provider(PhoneNumberProvider):
         '#### ####',
         '####-####',
     )
+    
     msisdn_formats = (
         '5511#########',
         '5521#########',
@@ -80,6 +81,10 @@ class Provider(PhoneNumberProvider):
         '5561#########',
         '5571#########',
         '5581#########',
+    )
+
+    cellphone_formats = (
+        
     )
 
     def cellphone_number(self):

--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -81,3 +81,7 @@ class Provider(PhoneNumberProvider):
         '5571#########',
         '5581#########',
     )
+
+    def cellphone_number(self):
+        pattern = self.random_element(self.cellphone_formats)
+        return self.numerify(self.generator.parse(pattern))

--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -84,7 +84,7 @@ class Provider(PhoneNumberProvider):
     )
 
     cellphone_formats = (
-        '+55 9#### ####'
+        '+55 9#### ####',
     )
 
     def cellphone_number(self):

--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -71,7 +71,7 @@ class Provider(PhoneNumberProvider):
         '#### ####',
         '####-####',
     )
-    
+
     msisdn_formats = (
         '5511#########',
         '5521#########',
@@ -84,7 +84,7 @@ class Provider(PhoneNumberProvider):
     )
 
     cellphone_formats = (
-        
+        '+55 9#### ####'
     )
 
     def cellphone_number(self):

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -67,9 +67,8 @@ class TestPhoneNumber(unittest.TestCase):
     def test_cellphone_pt_br(self):
         factory = Faker('pt_BR')
         cellphone = factory.cellphone_number()
-
         assert cellphone is not None
-        assert len(cellphone) == 13
+        assert len(cellphone) == 14
 
 
 class TestHuHU(unittest.TestCase):

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -64,6 +64,13 @@ class TestPhoneNumber(unittest.TestCase):
         assert msisdn.isdigit()
         assert msisdn[0:4] in formats
 
+    def test_cellphone_pt_br(self):
+        factory = Faker('pt_BR')
+        cellphone = factory.cellphone_number()
+
+        assert cellphone is not None
+        assert len(cellphone) == 13
+
 
 class TestHuHU(unittest.TestCase):
 


### PR DESCRIPTION
### What does this changes

As per #760, Brazilian localization method for ```cellphone_number()``` method was displaying landline number.

### What was wrong

The main problem was that the ```pt_BR``` localization was missing a ```cellphone_number()``` method. As such, the format was defaulting to landline.

### How this fixes it

The method ```cellphone_number``` has been now added to main localization with a relevant unit test. Tested with ```python setup.py test```, all green.

Fixes #760. 
