### PR TITLE
[fixed] image_url generates invalid urls.

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -111,7 +111,7 @@ class Provider(BaseProvider):
         '{{url}}{{uri_path}}/{{uri_page}}{{uri_extension}}',
     )
     image_placeholder_services = (
-        'https://placeholdit.imgix.net/~text',
+        'https://placeholdit.imgix.net/~text'
         '?txtsize=55&txt={width}x{height}&w={width}&h={height}',
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',


### PR DESCRIPTION
### What does this changes
fixes wrong formatted `image_url`s

### What was wrong
In the latest version there was added a ','
in the list `image_placeholder_services`,
which introduces an invalid url in the second element of the list.

e.g. '?txtsize=55&txt={width}x{height}&w={width}&h={height}'
### How this fixes it
Restored the list by removing the wrong ','  
Now the first element of the list is:
'https://placeholdit.imgix.net/~text?txtsize=55&txt={width}x{height}&w={width}&h={height}'
