### PR TITLE
Postcode + City format for de_DE provider

### DIFF
--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -8,6 +8,8 @@ class Provider(AddressProvider):
 
     city_formats = ('{{city_name}}', )
 
+    city_with_postcode_formats = ('{{city_name}} {{postcode}}')
+
     street_name_formats = (
         '{{first_name}}-{{last_name}}-{{street_suffix_long}}',
         '{{last_name}}{{street_suffix_short}}',

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -8,7 +8,7 @@ class Provider(AddressProvider):
 
     city_formats = ('{{city_name}}', )
 
-    city_with_postcode_formats = ('{{city_name}} {{postcode}}')
+    city_with_postcode_formats = ('{{city_name}} {{postcode}}', )
 
     street_name_formats = (
         '{{first_name}}-{{last_name}}-{{street_suffix_long}}',
@@ -191,5 +191,8 @@ class Provider(AddressProvider):
     def country(self):
         return self.random_element(self.countries)
 
+    def postcode(self):
+        return self.bothify(self.random_element(self.postcode_formats))
+
     def city_with_postcode(self):
-        return self.random_element(self.city_with_postcode_formats)
+        return self.random_element(self.cities)

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -188,3 +188,6 @@ class Provider(AddressProvider):
 
     def country(self):
         return self.random_element(self.countries)
+
+    def postcode(self):
+        return postcode

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -189,5 +189,5 @@ class Provider(AddressProvider):
     def country(self):
         return self.random_element(self.countries)
 
-    def postcode(self):
-        return postcode
+    def city_with_postcode(self):
+        return city_with_postcode

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -192,4 +192,4 @@ class Provider(AddressProvider):
         return self.random_element(self.countries)
 
     def city_with_postcode(self):
-        return city_with_postcode
+        return self.random_element(self.city_with_postcode_formats)

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -195,4 +195,4 @@ class Provider(AddressProvider):
         return self.bothify(self.random_element(self.postcode_formats))
 
     def city_with_postcode(self):
-        return self.random_element(self.cities)
+        return self.postcode() + " " + self.random_element(self.cities)

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -149,6 +149,10 @@ class TestDeDE(unittest.TestCase):
         assert isinstance(country, string_types)
         assert country in DeProvider.countries
 
+    def test_city_with_postcode(self):
+        city_with_postcode = self.factory.city_with_postcode()
+        assert isinstance(city_with_postcode, string_types)
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """


### PR DESCRIPTION
### What does this changes

German localization (de_DE) was missing a method to produce city with a postcode in the format postcode + city, for example, "25842 Halberstadt". 

### What was wrong

There was no method for postcode or method to generate postcode with city. 

### How this fixes it

Added the methods mentioned above + added unit test. All tests passed.

Fixes #761 
