### PR TITLE
Added enhancement that allows uuid4 generator to return UUID object

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -75,7 +75,7 @@ class Provider(BaseProvider):
     tlds = (
         'com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org',
     )
-
+    hostname_prefixes = ('db', 'srv', 'desktop', 'laptop', 'lt', 'email', 'web')
     uri_pages = (
         'index', 'home', 'search', 'main', 'post', 'homepage', 'category',
         'register', 'login', 'faq', 'about', 'terms', 'privacy', 'author',
@@ -189,6 +189,22 @@ class Provider(BaseProvider):
             self.bothify(self.generator.parse(pattern)).lower(),
         )
         return username
+
+    @lowercase
+    def hostname(self, levels=1):
+        """
+        Produce a hostname with specified number of subdomain levels.
+
+        >>> hostname()
+        db-01.nichols-phillips.com
+        >>> hostname(0)
+        laptop-56
+        >>> hostname(2)
+        web-12.williamson-hopkins.jackson.com
+        """
+        if levels < 1:
+            return self.random_element(self.hostname_prefixes) + '-' + self.numerify('##')
+        return self.random_element(self.hostname_prefixes) + '-' + self.numerify('##') + '.' + self.domain_name(levels)
 
     @lowercase
     def domain_name(self, levels=1):

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -130,11 +130,14 @@ class Provider(BaseProvider):
     def language_code(self):
         return self.random_element(Provider.language_locale_codes.keys())
 
-    def uuid4(self):
+    def uuid4(self, uuid_object=False):
         """
         Generates a random UUID4 string.
+        @param uuid_object: Boolean. Whether to return UUID object or string
         """
         # Based on http://stackoverflow.com/q/41186818
+        if uuid_object:
+            return uuid.UUID(int=self.generator.random.getrandbits(128))
         return str(uuid.UUID(int=self.generator.random.getrandbits(128)))
 
     def password(

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -39,6 +39,11 @@ class TestInternetProvider(unittest.TestCase):
         url = self.factory.image_url()
         assert 'https://dummyimage.com/' in url
 
+    def test_hostname(self):
+        hostname = self.factory.hostname(levels=1)
+        assert hostname
+        assert isinstance(hostname, six.string_types)
+
 
 class TestInternetProviderUrl(unittest.TestCase):
     """ Test internet url generation """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -42,7 +42,7 @@ class TestInternetProvider(unittest.TestCase):
     def test_hostname(self):
         hostname = self.factory.hostname(levels=1)
         assert hostname
-        assert isinstance(hostname, six.string_types)
+        self.assertIsInstance(hostname, six.string_types)
 
 
 class TestInternetProviderUrl(unittest.TestCase):

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -1,0 +1,19 @@
+import unittest
+import uuid
+
+from faker import Faker
+
+class TestMisc(unittest.TestCase):
+    """Tests miscellaneous generators"""
+    def setUp(self):
+        self.factory = Faker()
+
+    def test_uuid4(self):
+        uuid4 = self.factory.uuid4()
+        assert uuid4
+        assert isinstance(uuid4, str)
+
+    def test_uuid4_uuid_object(self):
+        uuid4 = self.factory.uuid4(uuid_object=True)
+        assert uuid4
+        assert isinstance(uuid4, uuid.UUID)


### PR DESCRIPTION
### What does this changes

This allows faker.uuid4() the option to return a UUID object instead of a string. faker.uuid4() still returns a string as its default functionality.

### What was wrong

faker.uuid4() only was able to return a string

### How this fixes it

Description of how the changes fix the issue.

Fixes #858 
