### PR TITLE
Hostname

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -75,7 +75,7 @@ class Provider(BaseProvider):
     tlds = (
         'com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org',
     )
-
+    hostname_prefixes = ('db', 'srv', 'desktop', 'laptop', 'lt', 'email', 'web')
     uri_pages = (
         'index', 'home', 'search', 'main', 'post', 'homepage', 'category',
         'register', 'login', 'faq', 'about', 'terms', 'privacy', 'author',
@@ -189,6 +189,22 @@ class Provider(BaseProvider):
             self.bothify(self.generator.parse(pattern)).lower(),
         )
         return username
+
+    @lowercase
+    def hostname(self, levels=1):
+        """
+        Produce a hostname with specified number of subdomain levels.
+
+        >>> hostname()
+        db-01.nichols-phillips.com
+        >>> hostname(0)
+        laptop-56
+        >>> hostname(2)
+        web-12.williamson-hopkins.jackson.com
+        """
+        if levels < 1:
+            return self.random_element(self.hostname_prefixes) + '-' + self.numerify('##')
+        return self.random_element(self.hostname_prefixes) + '-' + self.numerify('##') + '.' + self.domain_name(levels)
 
     @lowercase
     def domain_name(self, levels=1):

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -39,6 +39,11 @@ class TestInternetProvider(unittest.TestCase):
         url = self.factory.image_url()
         assert 'https://dummyimage.com/' in url
 
+    def test_hostname(self):
+        hostname = self.factory.hostname(levels=1)
+        assert hostname
+        assert isinstance(hostname, six.string_types)
+
 
 class TestInternetProviderUrl(unittest.TestCase):
     """ Test internet url generation """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -40,10 +40,16 @@ class TestInternetProvider(unittest.TestCase):
         assert 'https://dummyimage.com/' in url
 
     def test_hostname(self):
-        hostname = self.factory.hostname(levels=1)
-        assert hostname
-        self.assertIsInstance(hostname, six.string_types)
+        hostname_1_level = self.factory.hostname(levels=1)
+        hostname_parts = hostname_1_level.split(".")
+        assert hostname_1_level
+        self.assertIsInstance(hostname_1_level, six.string_types)
+        assert len(hostname_parts) == 3
 
+
+        hostname_0_level = self.factory.hostname(levels=0)
+        assert hostname_0_level
+        self.assertIsInstance(hostname_0_level, six.string_types)
 
 class TestInternetProviderUrl(unittest.TestCase):
     """ Test internet url generation """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -46,10 +46,10 @@ class TestInternetProvider(unittest.TestCase):
         self.assertIsInstance(hostname_1_level, six.string_types)
         assert len(hostname_parts) == 3
 
-
         hostname_0_level = self.factory.hostname(levels=0)
         assert hostname_0_level
         self.assertIsInstance(hostname_0_level, six.string_types)
+
 
 class TestInternetProviderUrl(unittest.TestCase):
     """ Test internet url generation """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -42,7 +42,7 @@ class TestInternetProvider(unittest.TestCase):
     def test_hostname(self):
         hostname = self.factory.hostname(levels=1)
         assert hostname
-        assert isinstance(hostname, six.string_types)
+        self.assertIsInstance(hostname, six.string_types)
 
 
 class TestInternetProviderUrl(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

This adds a function that generates a fake hostname.

### What was wrong

There was no functionality that was able to generate believable hostnames, only domain names.

### How this fixes it

Description of how the changes fix the issue.

Fixes #674 
