### PR TITLE
Added enhancement that allows uuid4 generator to return UUID object

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -133,7 +133,8 @@ class Provider(BaseProvider):
     def uuid4(self, cast_to=str):
         """
         Generates a random UUID4 string.
-        @param cast_to: String. What date type you would like the UUID to be cast to. Default is string.
+        :param cast_to: Specify what type the UUID should be cast to. Default is `str`
+        :type cast_to: callable, None
         """
         # Based on http://stackoverflow.com/q/41186818
         value = uuid.uuid4(int=self.generator.random.getrandbits(128))

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -134,13 +134,10 @@ class Provider(BaseProvider):
         """
         Generates a random UUID4 string.
         :param cast_to: Specify what type the UUID should be cast to. Default is `str`
-        :type cast_to: callable, None
+        :type cast_to: callable
         """
         # Based on http://stackoverflow.com/q/41186818
-        value = uuid.UUID(int=self.generator.random.getrandbits(128), version=4)
-        if cast_to:
-            return cast_to(value)
-        return value
+        return cast_to(uuid.UUID(int=self.generator.random.getrandbits(128), version=4))
 
     def password(
             self,

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -130,11 +130,14 @@ class Provider(BaseProvider):
     def language_code(self):
         return self.random_element(Provider.language_locale_codes.keys())
 
-    def uuid4(self):
+    def uuid4(self, uuid_object=False):
         """
         Generates a random UUID4 string.
+        @param uuid_object: Boolean. Whether to return UUID object or string
         """
         # Based on http://stackoverflow.com/q/41186818
+        if uuid_object:
+            return uuid.UUID(int=self.generator.random.getrandbits(128))
         return str(uuid.UUID(int=self.generator.random.getrandbits(128)))
 
     def password(

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -136,7 +136,7 @@ class Provider(BaseProvider):
         @param cast_to: String. What date type you would like the UUID to be cast to. Default is string.
         """
         # Based on http://stackoverflow.com/q/41186818
-        value = uuid.UUID(int=self.generator.random.getrandbits(128))
+        value = uuid.uuid4(int=self.generator.random.getrandbits(128))
         if cast_to:
             return cast_to(value)
         return value

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -130,15 +130,16 @@ class Provider(BaseProvider):
     def language_code(self):
         return self.random_element(Provider.language_locale_codes.keys())
 
-    def uuid4(self, uuid_object=False):
+    def uuid4(self, cast_to=str):
         """
         Generates a random UUID4 string.
         @param uuid_object: Boolean. Whether to return UUID object or string
         """
         # Based on http://stackoverflow.com/q/41186818
-        if uuid_object:
-            return uuid.UUID(int=self.generator.random.getrandbits(128))
-        return str(uuid.UUID(int=self.generator.random.getrandbits(128)))
+        value = uuid.UUID(int=self.generator.random.getrandbits(128))
+        if cast_to:
+            return cast_to(value)
+        return value
 
     def password(
             self,

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -137,7 +137,7 @@ class Provider(BaseProvider):
         :type cast_to: callable, None
         """
         # Based on http://stackoverflow.com/q/41186818
-        value = uuid.uuid4(int=self.generator.random.getrandbits(128))
+        value = uuid.UUID(int=self.generator.random.getrandbits(128), version=4)
         if cast_to:
             return cast_to(value)
         return value

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -133,7 +133,7 @@ class Provider(BaseProvider):
     def uuid4(self, cast_to=str):
         """
         Generates a random UUID4 string.
-        @param uuid_object: Boolean. Whether to return UUID object or string
+        @param cast_to: String. What date type you would like the UUID to be cast to. Default is string.
         """
         # Based on http://stackoverflow.com/q/41186818
         value = uuid.UUID(int=self.generator.random.getrandbits(128))

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -1,5 +1,6 @@
 import unittest
 import uuid
+import six
 
 from faker import Faker
 
@@ -11,9 +12,14 @@ class TestMisc(unittest.TestCase):
     def test_uuid4(self):
         uuid4 = self.factory.uuid4()
         assert uuid4
-        assert isinstance(uuid4, str)
+        assert isinstance(uuid4, six.string_types)
+
+    def test_uuid4_int(self):
+        uuid4 = self.factory.uuid4(cast_to=int)
+        assert uuid4
+        assert isinstance(uuid4, six.integer_types)
 
     def test_uuid4_uuid_object(self):
-        uuid4 = self.factory.uuid4(uuid_object=True)
+        uuid4 = self.factory.uuid4(cast_to=None)
         assert uuid4
         assert isinstance(uuid4, uuid.UUID)

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -20,6 +20,6 @@ class TestMisc(unittest.TestCase):
         assert isinstance(uuid4, six.integer_types)
 
     def test_uuid4_uuid_object(self):
-        uuid4 = self.factory.uuid4(cast_to=None)
+        uuid4 = self.factory.uuid4(cast_to=lambda x: x)
         assert uuid4
         assert isinstance(uuid4, uuid.UUID)

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -4,6 +4,7 @@ import six
 
 from faker import Faker
 
+
 class TestMisc(unittest.TestCase):
     """Tests miscellaneous generators"""
     def setUp(self):

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -1,0 +1,19 @@
+import unittest
+import uuid
+
+from faker import Faker
+
+class TestMisc(unittest.TestCase):
+    """Tests miscellaneous generators"""
+    def setUp(self):
+        self.factory = Faker()
+
+    def test_uuid4(self):
+        uuid4 = self.factory.uuid4()
+        assert uuid4
+        assert isinstance(uuid4, str)
+
+    def test_uuid4_uuid_object(self):
+        uuid4 = self.factory.uuid4(uuid_object=True)
+        assert uuid4
+        assert isinstance(uuid4, uuid.UUID)


### PR DESCRIPTION
### What does this changes
This allows faker.uuid4() the option to return a UUID object instead of a string. faker.uuid4() still returns a string as its default functionality.

### What was wrong
faker.uuid4() only was able to return a string

### How this fixes it
Description of how the changes fix the issue.

Fixes #858