### PR TITLE
sv_SE license plates added

### DIFF
--- a/faker/providers/automotive/sv_SE/__init__.py
+++ b/faker/providers/automotive/sv_SE/__init__.py
@@ -9,8 +9,8 @@ class Provider(AutomotiveProvider):
     # Source: https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Sweden
     # New possible format: https://goo.gl/gSjsnV
     license_formats = (
-    	# Classic format 
+        # Classic format
         '??? ###',
         # New possible format
-        '??? ##?'
+        '??? ##?',
     )

--- a/faker/providers/automotive/sv_SE/__init__.py
+++ b/faker/providers/automotive/sv_SE/__init__.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+
+
+from __future__ import unicode_literals
+from .. import Provider as AutomotiveProvider
+
+
+class Provider(AutomotiveProvider):
+    # Source: https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Sweden
+    # New possible format: https://goo.gl/gSjsnV
+    license_formats = (
+    	# Classic format 
+        '??? ###',
+        # New possible format
+        '??? ##?'
+    )

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -39,3 +39,13 @@ class TestDeDe(unittest.TestCase):
         plate = self.factory.license_plate()
         assert re.match(r"[A-Z\u00D6\u00DC]{1,3}-[A-Z]{1,2}-\d{1,4}", plate, flags=re.UNICODE), \
             "%s is not in the correct format." % plate
+
+
+class TestSvSE(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = Faker('sv_SE')
+
+    def test_hu_HU_plate_format(self):
+        plate = self.factory.license_plate()
+        assert re.match(r"[A-Z]{3} \d{2}[\dA-Z]{1}", plate), "%s is not in the correct format." % plate

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -46,6 +46,6 @@ class TestSvSE(unittest.TestCase):
     def setUp(self):
         self.factory = Faker('sv_SE')
 
-    def test_hu_HU_plate_format(self):
+    def test_sv_SE_plate_format(self):
         plate = self.factory.license_plate()
         assert re.match(r"[A-Z]{3} \d{2}[\dA-Z]{1}", plate), "%s is not in the correct format." % plate


### PR DESCRIPTION
### What does this changes

Added Swedish license plate format.

### What was wrong

```python
fake.license_plate()
 #=> 'RRT-6172'
```

### How this fixes it

```python
fake.license_plate()
 #=> 'VDA 15B'
```