### PR TITLE
Unit Tests for fa_IR Provider

### DIFF
--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -205,6 +205,15 @@ class TestFaIR(unittest.TestCase):
         assert isinstance(city_prefix, string_types)
         assert city_prefix in IrProvider.city_prefixes
 
+    def test_secondary_address(self):
+        secondary_address = self.factory.secondary_address()
+        assert isinstance(secondary_address, string_types)
+
+    def test_state(self):
+        state = self.factory.state()
+        assert isinstance(state, string_types)
+        assert state in IrProvider.states
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -203,6 +203,7 @@ class TestFaIR(unittest.TestCase):
     def test_city_prefix(self):
         city_prefix = self.factory.city_prefix()
         assert isinstance(city_prefix, string_types)
+        assert city_prefix in IrProvider.city_prefixes
 
 
 class TestFiFI(unittest.TestCase):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -193,6 +193,13 @@ class TestDeDE(unittest.TestCase):
         assert isinstance(city_with_postcode, string_types)
 
 
+class TestFaIR(unittest.TestCase):
+    """ Tests in addresses in the fa_IR locale """
+
+    def setUp(self):
+        self.factory = Faker('fa_IR')
+
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -199,6 +199,10 @@ class TestFaIR(unittest.TestCase):
     def setUp(self):
         self.factory = Faker('fa_IR')
 
+    def test_city_prefix(self):
+        city_prefix = self.factory.city_prefix()
+        assert isinstance(city_prefix, string_types)
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -11,6 +11,7 @@ from ukpostcodeparser.parser import parse_uk_postcode
 from faker import Faker
 from faker.providers.address.de_AT import Provider as DeAtProvider
 from faker.providers.address.de_DE import Provider as DeProvider
+from faker.providers.address.fa_IR import Provider as IrProvider
 from faker.providers.address.el_GR import Provider as GrProvider
 from faker.providers.address.en_AU import Provider as EnAuProvider
 from faker.providers.address.en_CA import Provider as EnCaProvider


### PR DESCRIPTION
### What does this changes

Adds unit tests for ```fa_IR``` address provider.

### What was wrong

Address provider ```fa_IR``` was missing unit tests.

### How this fixes it

Adds the missing unit tests.

Unit test suite executed locally - all green.