### PR TITLE
Add ranges to pyint

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -56,8 +56,8 @@ class Provider(BaseProvider):
             self.random_number(right_digits),
         ))
 
-    def pyint(self):
-        return self.generator.random_int()
+    def pyint(self, min=0, max=9999):
+        return self.generator.random_int(min, max)
 
     def pydecimal(self, left_digits=None, right_digits=None, positive=False):
         return Decimal(str(self.pyfloat(left_digits, right_digits, positive)))


### PR DESCRIPTION
### What does this changes

It adds two new parameters to `pyint()` to specify `min` and `max` values.

Example usage:
```
fake.pyint(0, 1000000)
```

### What was wrong

There was no way to specify ranges for random integers generated by faker, usually, I ended using `random.randint()`.

### How this fixes it

Devs can now specify ranges when calling `pyint()`