### PR TITLE
Correct number of digits in norwegian phonenumbers

### DIFF
--- a/faker/providers/phone_number/no_NO/__init__.py
+++ b/faker/providers/phone_number/no_NO/__init__.py
@@ -4,7 +4,7 @@ from .. import Provider as PhoneNumberProvider
 
 class Provider(PhoneNumberProvider):
     formats = (
-        '+47#########',
+        '+47########',
         '+47 ## ## ## ##',
         '## ## ## ##',
         '## ## ## ##',


### PR DESCRIPTION
The first format had 9 digits, but norwegian phone numbers have 8 digits (excluding country code).
I was writing tests for some code, where libphonenumber suddenly starter failing the region formatting check, as norwegian phone numbers have 8 digits and not 9.
