### PR TITLE
Address Unit Tests: fr_FR provider

### DIFF
--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -226,6 +226,12 @@ class TestFrFR(unittest.TestCase):
         assert isinstance(street_prefix, string_types)
         assert street_prefix in FrProvider.street_prefixes
 
+    def test_city_prefix(self):
+        city_prefix = self.factory.city_prefix()
+        assert isinstance(city_prefix, string_types)
+        assert city_prefix in FrProvider.city_prefixes
+
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -231,6 +231,11 @@ class TestFrFR(unittest.TestCase):
         assert isinstance(city_prefix, string_types)
         assert city_prefix in FrProvider.city_prefixes
 
+    def test_region(self):
+        region = self.factory.region()
+        assert isinstance(region, string_types)
+        assert region in FrProvider.regions
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -225,22 +225,22 @@ class TestFrFR(unittest.TestCase):
     def test_street_prefix(self):
         street_prefix = self.factory.street_prefix()
         assert isinstance(street_prefix, string_types)
-        assert street_prefix in FrProvider.street_prefixes
+        assert street_prefix in FrFrProvider.street_prefixes
 
     def test_city_prefix(self):
         city_prefix = self.factory.city_prefix()
         assert isinstance(city_prefix, string_types)
-        assert city_prefix in FrProvider.city_prefixes
+        assert city_prefix in FrFrProvider.city_prefixes
 
     def test_region(self):
         region = self.factory.region()
         assert isinstance(region, string_types)
-        assert region in FrProvider.regions
+        assert region in FrFrProvider.regions
 
     def test_department(self):
         department = self.factory.department()
         assert isinstance(department, string_types)
-        assert department in FrProvider.departments
+        assert department in FrFrProvider.departments
 
     def test_department_name(self):
         department_name = self.factory.department_name()

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -221,6 +221,10 @@ class TestFrFR(unittest.TestCase):
     def setUp(self):
         self.factory = Faker('fr_FR')
 
+    def test_street_prefix(self):
+        street_prefix = self.factory.street_prefix()
+        assert isinstance(street_prefix, string_types)
+        assert street_prefix in FrProvider.street_prefixes
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -236,6 +236,11 @@ class TestFrFR(unittest.TestCase):
         assert isinstance(region, string_types)
         assert region in FrProvider.regions
 
+    def test_department(self):
+        department = self.factory.department()
+        assert isinstance(department, string_types)
+        assert department in FrProvider.departments
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -241,6 +241,10 @@ class TestFrFR(unittest.TestCase):
         assert isinstance(department, string_types)
         assert department in FrProvider.departments
 
+    def test_department_name(self):
+        department_name = self.factory.department_name()
+        assert isinstance(department_name, string_types)
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -215,6 +215,13 @@ class TestFaIR(unittest.TestCase):
         assert state in IrProvider.states
 
 
+class TestFrFR(unittest.TestCase):
+    """ Tests addresses in the fr_FR locale """
+
+    def setUp(self):
+        self.factory = Faker('fr_FR')
+
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -239,7 +239,7 @@ class TestFrFR(unittest.TestCase):
 
     def test_department(self):
         department = self.factory.department()
-        assert isinstance(department, string_types)
+        assert isinstance(department, tuple)
         assert department in FrFrProvider.departments
 
     def test_department_name(self):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -16,6 +16,7 @@ from faker.providers.address.el_GR import Provider as GrProvider
 from faker.providers.address.en_AU import Provider as EnAuProvider
 from faker.providers.address.en_CA import Provider as EnCaProvider
 from faker.providers.address.en_US import Provider as EnUsProvider
+from faker.providers.address.fr_FR import Provider as FrFrProvider
 from faker.providers.address.fi_FI import Provider as FiProvider
 from faker.providers.address.pt_PT import Provider as PtPtProvider
 from faker.providers.address.ja_JP import Provider as JaProvider

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -248,7 +248,7 @@ class TestFrFR(unittest.TestCase):
 
     def test_department_number(self):
         department_number = self.factory.department_number()
-        assert isinstance(department_number, int)
+        assert isinstance(department_number, string_types)
 
 
 class TestFiFI(unittest.TestCase):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -245,6 +245,10 @@ class TestFrFR(unittest.TestCase):
         department_name = self.factory.department_name()
         assert isinstance(department_name, string_types)
 
+    def test_department_number(self):
+        department_number = self.factory.department_number()
+        assert isinstance(department_number, int)
+
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """


### PR DESCRIPTION
### What does this changes

Adds unit tests for ```fr_FR``` address provider.

### What was wrong

The unit test module for ```fr_FR``` address provider was missing.

### How this fixes it

Implemented the unit tests.

Unit tests executed locally - all green. Thank you.