### PR TITLE
Add categories to Japanese company provider

### DIFF
--- a/faker/providers/company/ja_JP/__init__.py
+++ b/faker/providers/company/ja_JP/__init__.py
@@ -5,15 +5,15 @@ from .. import Provider as CompanyProvider
 
 class Provider(CompanyProvider):
     formats = (
-        '{{company_prefix}}{{last_name}}{{category}}',
-        '{{last_name}}{{category}}{{company_prefix}}',
+        '{{company_prefix}}{{last_name}}{{company_category}}',
+        '{{last_name}}{{company_category}}{{company_prefix}}',
     )
 
     company_prefixes = ('株式会社', '有限会社', '合同会社')
-    categories = ('水産', '農林', '鉱業', '建設', '食品', '印刷', '電気', 'ガス', '情報', '通信', '運輸', '銀行', '保険')
+    company_categories = ('水産', '農林', '鉱業', '建設', '食品', '印刷', '電気', 'ガス', '情報', '通信', '運輸', '銀行', '保険')
 
     def company_prefix(self):
         return self.random_element(self.company_prefixes)
 
-    def category(self):
-        return self.random_element(self.categories)
+    def company_category(self):
+        return self.random_element(self.company_categories)

--- a/faker/providers/company/ja_JP/__init__.py
+++ b/faker/providers/company/ja_JP/__init__.py
@@ -5,10 +5,15 @@ from .. import Provider as CompanyProvider
 
 class Provider(CompanyProvider):
     formats = (
-        '{{company_prefix}} {{last_name}}',
+        '{{company_prefix}}{{last_name}}{{category}}',
+        '{{last_name}}{{category}}{{company_prefix}}',
     )
 
     company_prefixes = ('株式会社', '有限会社', '合同会社')
+    categories = ('水産', '農林', '鉱業', '建設', '食品', '印刷', '電気', 'ガス', '情報', '通信', '運輸', '銀行', '保険')
 
     def company_prefix(self):
         return self.random_element(self.company_prefixes)
+
+    def category(self):
+        return self.random_element(self.categories)

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -44,7 +44,6 @@ class TestJaJP(unittest.TestCase):
 
         company = self.factory.company()
         assert isinstance(company, six.string_types)
-        assert any(prefix in company for prefix in prefixes)
         assert any(company.startswith(prefix) or company.endswith(prefix) for prefix in prefixes)
 
 

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -37,14 +37,19 @@ class TestJaJP(unittest.TestCase):
 
     def test_company(self):
         prefixes = JaProvider.company_prefixes
-
         prefix = self.factory.company_prefix()
         assert isinstance(prefix, six.string_types)
         assert prefix in prefixes
 
+        categories = JaProvider.company_categories
+        category = self.factory.company_category()
+        assert isinstance(category, six.string_types)
+        assert category in categories
+
         company = self.factory.company()
         assert isinstance(company, six.string_types)
         assert any(company.startswith(prefix) or company.endswith(prefix) for prefix in prefixes)
+        assert any(category in company for category in categories)
 
 
 class TestPtBR(unittest.TestCase):

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -45,7 +45,7 @@ class TestJaJP(unittest.TestCase):
         company = self.factory.company()
         assert isinstance(company, six.string_types)
         assert any(prefix in company for prefix in prefixes)
-        assert any(company.startswith(prefix) for prefix in prefixes)
+        assert any(company.startswith(prefix) or company.endswith(prefix) for prefix in prefixes)
 
 
 class TestPtBR(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Added variety of Japanese company names.

The category list is from Ruby Faker. https://github.com/stympy/faker/blob/master/lib/locales/ja.yml#L28

### What was wrong

Nothing was wrong.

### How this fixes it

Added categories and format patterns.

