### PR TITLE
Unit Tests for he_IL Address Provider

### DIFF
--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -242,6 +242,13 @@ class TestFrFR(unittest.TestCase):
         assert isinstance(department_number, string_types)
 
 
+class TestHeIL(unittest.TestCase):
+    """ Tests addresses in the he_IL locale """
+
+    def setUp(self):
+        self.factory = Faker('he_IL')
+
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -252,6 +252,10 @@ class TestHeIL(unittest.TestCase):
         city_name = self.factory.city_name()
         assert isinstance(city_name, string_types)
 
+    def test_street_title(self):
+        street_title = self.factory.street_title()
+        assert isinstance(street_title, string_types)
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -248,6 +248,9 @@ class TestHeIL(unittest.TestCase):
     def setUp(self):
         self.factory = Faker('he_IL')
 
+    def test_city_name(self):
+        city_name = self.factory.city_name()
+        assert isinstance(city_name, string_types)
 
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -256,6 +256,7 @@ class TestHeIL(unittest.TestCase):
         street_title = self.factory.street_title()
         assert isinstance(street_title, string_types)
 
+
 class TestFiFI(unittest.TestCase):
     """ Tests in addresses in the fi_FI locale """
 


### PR DESCRIPTION
### What does this changes

Adds unit tests for ```he_IL``` address provider.

### What was wrong

Address provider for ```he_IL``` was lacking unit tests.

### How this fixes it

Adds the unit tests.
