### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 cache: pip
@@ -17,16 +18,12 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      sudo: required
-      dist: xenial
-    - python: pypy-5.3.1
+    - python: pypy2.7-6.0
       env: TOXENV=pypy
-    - python: pypy3
+    - python: pypy3.5-6.0
       env: TOXENV=pypy3
     - python: 3.7
       env: TOXENV=flake8
-      sudo: required
-      dist: xenial
 
 before_install:
   - pip install pep8


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release