### PR TITLE
Remove installation of pep8 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
       sudo: required
       dist: xenial
 
-before_install:
-  - pip install pep8
 install:
   - pip install tox
 script:


### PR DESCRIPTION
Linting is handled by the flake8 tox target which manages its own dependencies. Installing pep8 every run is unnecessary overhead.