### PR TITLE
Add faker-microservice to community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -21,8 +21,11 @@ Here's a list of Providers written by the community:
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |
 |               | for testing purposes     |                                  |
 +---------------+--------------------------+----------------------------------+
+| Microservice  | Fake microservice names  | `faker_microservice`_            |
++---------------+--------------------------+----------------------------------+
 
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_cloud: https://pypi.org/project/faker-cloud/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
+.. _faker_microservice: https://pypi.org/project/faker-microservice/


### PR DESCRIPTION
### What does this changes

Adds `faker-microservice` to the list of community providers.

### What was wrong

Documentation didn't include a link to the provider I wrote last night.

Not sure if there are any noteworthiness requirements for being added to this list, but this is something I wanted to perhaps somebody else will as well.

### How this fixes it

Adds a link to the provider.