### PR TITLE
Close #899. Move shared methods to BaseProvider

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -19,8 +19,79 @@ class BaseProvider(object):
     __provider__ = 'base'
     __lang__ = None
 
+    # Locales supported by Linux Mint from `/usr/share/i18n/SUPPORTED`
+    language_locale_codes = {
+        'aa': ('DJ', 'ER', 'ET'), 'af': ('ZA',), 'ak': ('GH',), 'am': ('ET',),
+        'an': ('ES',), 'apn': ('IN',),
+        'ar': ('AE', 'BH', 'DJ', 'DZ', 'EG', 'EH', 'ER', 'IL', 'IN',
+               'IQ', 'JO', 'KM', 'KW', 'LB', 'LY', 'MA', 'MR', 'OM',
+               'PS', 'QA', 'SA', 'SD', 'SO', 'SS', 'SY', 'TD', 'TN',
+               'YE'),
+        'as': ('IN',), 'ast': ('ES',), 'ayc': ('PE',), 'az': ('AZ', 'IN'),
+        'be': ('BY',), 'bem': ('ZM',), 'ber': ('DZ', 'MA'), 'bg': ('BG',),
+        'bhb': ('IN',), 'bho': ('IN',), 'bn': ('BD', 'IN'), 'bo': ('CN', 'IN'),
+        'br': ('FR',), 'brx': ('IN',), 'bs': ('BA',), 'byn': ('ER',),
+        'ca': ('AD', 'ES', 'FR', 'IT'), 'ce': ('RU',), 'ckb': ('IQ',),
+        'cmn': ('TW',), 'crh': ('UA',), 'cs': ('CZ',), 'csb': ('PL',),
+        'cv': ('RU',), 'cy': ('GB',), 'da': ('DK',),
+        'de': ('AT', 'BE', 'CH', 'DE', 'LI', 'LU'), 'doi': ('IN',),
+        'dv': ('MV',), 'dz': ('BT',), 'el': ('GR', 'CY'),
+        'en': ('AG', 'AU', 'BW', 'CA', 'DK', 'GB', 'HK', 'IE', 'IN', 'NG',
+               'NZ', 'PH', 'SG', 'US', 'ZA', 'ZM', 'ZW'),
+        'eo': ('US',),
+        'es': ('AR', 'BO', 'CL', 'CO', 'CR', 'CU', 'DO', 'EC', 'ES', 'GT',
+               'HN', 'MX', 'NI', 'PA', 'PE', 'PR', 'PY', 'SV', 'US', 'UY', 'VE',
+               ), 'et': ('EE',), 'eu': ('ES', 'FR'), 'fa': ('IR',),
+        'ff': ('SN',), 'fi': ('FI',), 'fil': ('PH',), 'fo': ('FO',),
+        'fr': ('CA', 'CH', 'FR', 'LU'), 'fur': ('IT',), 'fy': ('NL', 'DE'),
+        'ga': ('IE',), 'gd': ('GB',), 'gez': ('ER', 'ET'), 'gl': ('ES',),
+        'gu': ('IN',), 'gv': ('GB',), 'ha': ('NG',), 'hak': ('TW',),
+        'he': ('IL',), 'hi': ('IN',), 'hne': ('IN',), 'hr': ('HR',),
+        'hsb': ('DE',), 'ht': ('HT',), 'hu': ('HU',), 'hy': ('AM',),
+        'ia': ('FR',), 'id': ('ID',), 'ig': ('NG',), 'ik': ('CA',),
+        'is': ('IS',), 'it': ('CH', 'IT'), 'iu': ('CA',), 'iw': ('IL',),
+        'ja': ('JP',), 'ka': ('GE',), 'kk': ('KZ',), 'kl': ('GL',),
+        'km': ('KH',), 'kn': ('IN',), 'ko': ('KR',), 'kok': ('IN',),
+        'ks': ('IN',), 'ku': ('TR',), 'kw': ('GB',), 'ky': ('KG',),
+        'lb': ('LU',), 'lg': ('UG',), 'li': ('BE', 'NL'), 'lij': ('IT',),
+        'ln': ('CD',), 'lo': ('LA',), 'lt': ('LT',), 'lv': ('LV',),
+        'lzh': ('TW',), 'mag': ('IN',), 'mai': ('IN',), 'mg': ('MG',),
+        'mhr': ('RU',), 'mi': ('NZ',), 'mk': ('MK',), 'ml': ('IN',),
+        'mn': ('MN',), 'mni': ('IN',), 'mr': ('IN',), 'ms': ('MY',),
+        'mt': ('MT',), 'my': ('MM',), 'nan': ('TW',), 'nb': ('NO',),
+        'nds': ('DE', 'NL'), 'ne': ('NP',), 'nhn': ('MX',),
+        'niu': ('NU', 'NZ'), 'nl': ('AW', 'BE', 'NL'), 'nn': ('NO',),
+        'nr': ('ZA',), 'nso': ('ZA',), 'oc': ('FR',), 'om': ('ET', 'KE'),
+        'or': ('IN',), 'os': ('RU',), 'pa': ('IN', 'PK'),
+        'pap': ('AN', 'AW', 'CW'), 'pl': ('PL',), 'ps': ('AF',),
+        'pt': ('BR', 'PT'), 'quz': ('PE',), 'raj': ('IN',), 'ro': ('RO',),
+        'ru': ('RU', 'UA'), 'rw': ('RW',), 'sa': ('IN',), 'sat': ('IN',),
+        'sc': ('IT',), 'sd': ('IN', 'PK'), 'se': ('NO',), 'shs': ('CA',),
+        'si': ('LK',), 'sid': ('ET',), 'sk': ('SK',), 'sl': ('SI',),
+        'so': ('DJ', 'ET', 'KE', 'SO'), 'sq': ('AL', 'ML'), 'sr': ('ME', 'RS'),
+        'ss': ('ZA',), 'st': ('ZA',), 'sv': ('FI', 'SE'), 'sw': ('KE', 'TZ'),
+        'szl': ('PL',), 'ta': ('IN', 'LK'), 'tcy': ('IN',), 'te': ('IN',),
+        'tg': ('TJ',), 'th': ('TH',), 'the': ('NP',), 'ti': ('ER', 'ET'),
+        'tig': ('ER',), 'tk': ('TM',), 'tl': ('PH',), 'tn': ('ZA',),
+        'tr': ('CY', 'TR'), 'ts': ('ZA',), 'tt': ('RU',), 'ug': ('CN',),
+        'uk': ('UA',), 'unm': ('US',), 'ur': ('IN', 'PK'), 'uz': ('UZ',),
+        've': ('ZA',), 'vi': ('VN',), 'wa': ('BE',), 'wae': ('CH',),
+        'wal': ('ET',), 'wo': ('SN',), 'xh': ('ZA',), 'yi': ('US',),
+        'yo': ('NG',), 'yue': ('HK',), 'zh': ('CN', 'HK', 'SG', 'TW'),
+        'zu': ('ZA',),
+    }
+
     def __init__(self, generator):
         self.generator = generator
+
+    def locale(self):
+        language_code = self.language_code()
+        return language_code + '_' + self.random_element(
+            BaseProvider.language_locale_codes[language_code],
+        )
+
+    def language_code(self):
+        return self.random_element(BaseProvider.language_locale_codes.keys())
 
     def random_int(self, min=0, max=9999):
         """

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -10,68 +10,6 @@ from .. import BaseProvider
 
 
 class Provider(BaseProvider):
-    # Locales supported by Linux Mint from `/usr/share/i18n/SUPPORTED`
-    language_locale_codes = {
-        'aa': ('DJ', 'ER', 'ET'), 'af': ('ZA',), 'ak': ('GH',), 'am': ('ET',),
-        'an': ('ES',), 'apn': ('IN',),
-        'ar': ('AE', 'BH', 'DJ', 'DZ', 'EG', 'EH', 'ER', 'IL', 'IN',
-               'IQ', 'JO', 'KM', 'KW', 'LB', 'LY', 'MA', 'MR', 'OM',
-               'PS', 'QA', 'SA', 'SD', 'SO', 'SS', 'SY', 'TD', 'TN',
-               'YE'),
-        'as': ('IN',), 'ast': ('ES',), 'ayc': ('PE',), 'az': ('AZ', 'IN'),
-        'be': ('BY',), 'bem': ('ZM',), 'ber': ('DZ', 'MA'), 'bg': ('BG',),
-        'bhb': ('IN',), 'bho': ('IN',), 'bn': ('BD', 'IN'), 'bo': ('CN', 'IN'),
-        'br': ('FR',), 'brx': ('IN',), 'bs': ('BA',), 'byn': ('ER',),
-        'ca': ('AD', 'ES', 'FR', 'IT'), 'ce': ('RU',), 'ckb': ('IQ',),
-        'cmn': ('TW',), 'crh': ('UA',), 'cs': ('CZ',), 'csb': ('PL',),
-        'cv': ('RU',), 'cy': ('GB',), 'da': ('DK',),
-        'de': ('AT', 'BE', 'CH', 'DE', 'LI', 'LU'), 'doi': ('IN',),
-        'dv': ('MV',), 'dz': ('BT',), 'el': ('GR', 'CY'),
-        'en': ('AG', 'AU', 'BW', 'CA', 'DK', 'GB', 'HK', 'IE', 'IN', 'NG',
-               'NZ', 'PH', 'SG', 'US', 'ZA', 'ZM', 'ZW'),
-        'eo': ('US',),
-        'es': ('AR', 'BO', 'CL', 'CO', 'CR', 'CU', 'DO', 'EC', 'ES', 'GT',
-               'HN', 'MX', 'NI', 'PA', 'PE', 'PR', 'PY', 'SV', 'US', 'UY', 'VE',
-               ), 'et': ('EE',), 'eu': ('ES', 'FR'), 'fa': ('IR',),
-        'ff': ('SN',), 'fi': ('FI',), 'fil': ('PH',), 'fo': ('FO',),
-        'fr': ('CA', 'CH', 'FR', 'LU'), 'fur': ('IT',), 'fy': ('NL', 'DE'),
-        'ga': ('IE',), 'gd': ('GB',), 'gez': ('ER', 'ET'), 'gl': ('ES',),
-        'gu': ('IN',), 'gv': ('GB',), 'ha': ('NG',), 'hak': ('TW',),
-        'he': ('IL',), 'hi': ('IN',), 'hne': ('IN',), 'hr': ('HR',),
-        'hsb': ('DE',), 'ht': ('HT',), 'hu': ('HU',), 'hy': ('AM',),
-        'ia': ('FR',), 'id': ('ID',), 'ig': ('NG',), 'ik': ('CA',),
-        'is': ('IS',), 'it': ('CH', 'IT'), 'iu': ('CA',), 'iw': ('IL',),
-        'ja': ('JP',), 'ka': ('GE',), 'kk': ('KZ',), 'kl': ('GL',),
-        'km': ('KH',), 'kn': ('IN',), 'ko': ('KR',), 'kok': ('IN',),
-        'ks': ('IN',), 'ku': ('TR',), 'kw': ('GB',), 'ky': ('KG',),
-        'lb': ('LU',), 'lg': ('UG',), 'li': ('BE', 'NL'), 'lij': ('IT',),
-        'ln': ('CD',), 'lo': ('LA',), 'lt': ('LT',), 'lv': ('LV',),
-        'lzh': ('TW',), 'mag': ('IN',), 'mai': ('IN',), 'mg': ('MG',),
-        'mhr': ('RU',), 'mi': ('NZ',), 'mk': ('MK',), 'ml': ('IN',),
-        'mn': ('MN',), 'mni': ('IN',), 'mr': ('IN',), 'ms': ('MY',),
-        'mt': ('MT',), 'my': ('MM',), 'nan': ('TW',), 'nb': ('NO',),
-        'nds': ('DE', 'NL'), 'ne': ('NP',), 'nhn': ('MX',),
-        'niu': ('NU', 'NZ'), 'nl': ('AW', 'BE', 'NL'), 'nn': ('NO',),
-        'nr': ('ZA',), 'nso': ('ZA',), 'oc': ('FR',), 'om': ('ET', 'KE'),
-        'or': ('IN',), 'os': ('RU',), 'pa': ('IN', 'PK'),
-        'pap': ('AN', 'AW', 'CW'), 'pl': ('PL',), 'ps': ('AF',),
-        'pt': ('BR', 'PT'), 'quz': ('PE',), 'raj': ('IN',), 'ro': ('RO',),
-        'ru': ('RU', 'UA'), 'rw': ('RW',), 'sa': ('IN',), 'sat': ('IN',),
-        'sc': ('IT',), 'sd': ('IN', 'PK'), 'se': ('NO',), 'shs': ('CA',),
-        'si': ('LK',), 'sid': ('ET',), 'sk': ('SK',), 'sl': ('SI',),
-        'so': ('DJ', 'ET', 'KE', 'SO'), 'sq': ('AL', 'ML'), 'sr': ('ME', 'RS'),
-        'ss': ('ZA',), 'st': ('ZA',), 'sv': ('FI', 'SE'), 'sw': ('KE', 'TZ'),
-        'szl': ('PL',), 'ta': ('IN', 'LK'), 'tcy': ('IN',), 'te': ('IN',),
-        'tg': ('TJ',), 'th': ('TH',), 'the': ('NP',), 'ti': ('ER', 'ET'),
-        'tig': ('ER',), 'tk': ('TM',), 'tl': ('PH',), 'tn': ('ZA',),
-        'tr': ('CY', 'TR'), 'ts': ('ZA',), 'tt': ('RU',), 'ug': ('CN',),
-        'uk': ('UA',), 'unm': ('US',), 'ur': ('IN', 'PK'), 'uz': ('UZ',),
-        've': ('ZA',), 'vi': ('VN',), 'wa': ('BE',), 'wae': ('CH',),
-        'wal': ('ET',), 'wo': ('SN',), 'xh': ('ZA',), 'yi': ('US',),
-        'yo': ('NG',), 'yue': ('HK',), 'zh': ('CN', 'HK', 'SG', 'TW'),
-        'zu': ('ZA',),
-    }
-
     def boolean(self, chance_of_getting_true=50):
         return self.generator.random.randint(1, 100) <= chance_of_getting_true
 
@@ -120,15 +58,6 @@ class Provider(BaseProvider):
         if raw_output:
             return res.digest()
         return res.hexdigest()
-
-    def locale(self):
-        language_code = self.language_code()
-        return language_code + '_' + self.random_element(
-            Provider.language_locale_codes[language_code],
-        )
-
-    def language_code(self):
-        return self.random_element(Provider.language_locale_codes.keys())
 
     def uuid4(self, cast_to=str):
         """


### PR DESCRIPTION
### What does this changes

Move some methods from the `misc` provider to the `BaseProvider`

### What was wrong

The `user_agent` provider was relying on some methods implemented in the `misc` provider. Those methods would not dynamically loaded in the `generator` if the `misc` provider is not loaded (eg when instantiating `faker` with the `providers=[]` argument)

### How this fixes it

Moving the shared methods to the `BaseProvider` makes sure they are always availale.

Fixes #899
