### PR TITLE
fix incorrect codding utf8 to # -*- coding: utf-8 -*-

### DIFF
--- a/faker/providers/internet/hu_HU/__init__.py
+++ b/faker/providers/internet/hu_HU/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from __future__ import unicode_literals
 from .. import Provider as InternetProvider
 


### PR DESCRIPTION
### What does this changes

replace `# coding=utf8` to `# -*- coding: utf-8 -*-` in `/faker/providers/internet/hu_HU/__init__.py`

### What was wrong

Django2 does not make translation files. Error:
```
xgettext: ./env/lib/python3.6/site-packages/faker/providers/internet/hu_HU/__init__.py:1: Кодировка «utf8» неизвестна. Вместо неё используем ASCII.
xgettext: Не ASCII-строка у ./env/lib/python3.6/site-packages/faker/providers/internet/hu_HU/__init__.py:25.
          Укажите входную кодировку с помощью параметра --from-code или с помощью
          комментария, как описано на http://www.python.org/peps/pep-0263.html.
          
```