### PR TITLE
Close #906

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1379,8 +1379,11 @@ class Provider(BaseProvider):
         """
         Get a timedelta object
         """
+        start_datetime = self._parse_start_datetime('now')
         end_datetime = self._parse_end_datetime(end_datetime)
-        ts = self.generator.random.randint(0, end_datetime)
+        seconds = end_datetime - start_datetime
+
+        ts = self.generator.random.randint(*sorted([0, seconds]))
         return timedelta(seconds=ts)
 
     def date_time(self, tzinfo=None, end_datetime=None):

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1507,20 +1507,20 @@ class Provider(BaseProvider):
         raise ParseError("Invalid format for timedelta '{0}'".format(value))
 
     @classmethod
-    def _parse_date_time(cls, text, tzinfo=None):
-        if isinstance(text, (datetime, date, real_datetime, real_date)):
-            return datetime_to_timestamp(text)
+    def _parse_date_time(cls, value, tzinfo=None):
+        if isinstance(value, (datetime, date, real_datetime, real_date)):
+            return datetime_to_timestamp(value)
         now = datetime.now(tzinfo)
-        if isinstance(text, timedelta):
-            return datetime_to_timestamp(now - text)
-        if is_string(text):
-            if text == 'now':
+        if isinstance(value, timedelta):
+            return datetime_to_timestamp(now + value)
+        if is_string(value):
+            if value == 'now':
                 return datetime_to_timestamp(datetime.now(tzinfo))
-            time_params = cls._parse_date_string(text)
+            time_params = cls._parse_date_string(value)
             return datetime_to_timestamp(now + timedelta(**time_params))
-        if isinstance(text, int):
-            return datetime_to_timestamp(now + timedelta(text))
-        raise ParseError("Invalid format for date '{0}'".format(text))
+        if isinstance(value, int):
+            return datetime_to_timestamp(now + timedelta(value))
+        raise ParseError("Invalid format for date '{0}'".format(value))
 
     @classmethod
     def _parse_date(cls, value):
@@ -1530,7 +1530,7 @@ class Provider(BaseProvider):
             return value
         today = date.today()
         if isinstance(value, timedelta):
-            return today - value
+            return today + value
         if is_string(value):
             if value in ('today', 'now'):
                 return today

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -91,7 +91,7 @@ class TestDateTime(unittest.TestCase):
         timestamp = DatetimeProvider._parse_date_time('+30d')
         now = DatetimeProvider._parse_date_time('now')
         assert timestamp > now
-        delta = timedelta(days=-30)
+        delta = timedelta(days=30)
         from_delta = DatetimeProvider._parse_date_time(delta)
         from_int = DatetimeProvider._parse_date_time(30)
 
@@ -114,7 +114,7 @@ class TestDateTime(unittest.TestCase):
         assert DatetimeProvider._parse_date(datetime.now()) == today
         assert DatetimeProvider._parse_date(parsed) == parsed
         assert DatetimeProvider._parse_date(30) == parsed
-        assert DatetimeProvider._parse_date(timedelta(days=-30)) == parsed
+        assert DatetimeProvider._parse_date(timedelta(days=30)) == parsed
 
     def test_timezone_conversion(self):
         from faker.providers.date_time import datetime_to_timestamp

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -168,6 +168,22 @@ class TestDateTime(unittest.TestCase):
     def test_time_object(self):
         assert isinstance(self.factory.time_object(), datetime_time)
 
+    def test_timedelta(self):
+        delta = self.factory.time_delta(end_datetime=timedelta(seconds=60))
+        assert delta.seconds <= 60
+
+        delta = self.factory.time_delta(end_datetime=timedelta(seconds=-60))
+        assert delta.seconds >= -60
+
+        delta = self.factory.time_delta(end_datetime='+60s')
+        assert delta.seconds <= 60
+
+        delta = self.factory.time_delta(end_datetime='-60s')
+        assert delta.seconds >= 60
+
+        delta = self.factory.time_delta(end_datetime='now')
+        assert delta.seconds <= 0
+
     def test_date_time_between_dates(self):
         timestamp_start = random.randint(0, 2000000000)
         timestamp_end = timestamp_start + 1


### PR DESCRIPTION
### What does this changes

* fix parsing of timedeltas in date_time provider
* Fix time_delta method of `date_time` provider

### What was wrong

For whatever reason, we were _subtracting_ the timedelta to the current datetime instead of adding.
Additionally, the range we use to get the random duration was completely wrong. We were picking any number of seconds from 0 to whatever the unix timestamp of `end_datetime` is.

### How this fixes it

Time deltas are now parsed correctly, and the `time_delta` method picks numbers from the correct range.

Fixes #906 
