### PR TITLE
Fix fr_FR postcodes_format

### DIFF
--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -40,7 +40,7 @@ class Provider(AddressProvider):
     )
 
     building_number_formats = ('%', '%#', '%#', '%#', '%##')
-    postcode_formats = ('#####', '## ###')
+    postcode_formats = ('#####', )
     countries = (
         'Afghanistan', 'Afrique du sud', 'Albanie', 'Algérie', 'Allemagne', 'Andorre', 'Angola', 'Anguilla',
         'Antarctique', 'Antigua et Barbuda', 'Antilles néerlandaises', 'Arabie saoudite', 'Argentine', 'Arménie',


### PR DESCRIPTION
### What does this changes

It fixes the way french postcodes are formatted

### What was wrong

French postcodes should never be formatted ## ####
see https://datanova.laposte.fr/explore/dataset/laposte_hexasmal/table/
The "Official french database of postal codes"

### How this fixes it

Only ##### is used to format french postcodes