### PR TITLE
Fix the code of YellowGreen color

### DIFF
--- a/faker/providers/color/__init__.py
+++ b/faker/providers/color/__init__.py
@@ -148,7 +148,7 @@ class Provider(BaseProvider):
         ("White", "#FFFFFF"),
         ("WhiteSmoke", "#F5F5F5"),
         ("Yellow", "#FFFF00"),
-        ("YellowGreen", "#9ACD3"),
+        ("YellowGreen", "#9ACD32"),
     ))
 
     safe_colors = (

--- a/faker/providers/color/ar_PS/__init__.py
+++ b/faker/providers/color/ar_PS/__init__.py
@@ -146,7 +146,7 @@ class Provider(ColorProvider):
         ("أبيض", "#FFFFFF"),
         ("دخاني قمحي", "#F5F5F5"),
         ("أصفر", "#FFFF00"),
-        ("أصفر مخضر", "#9ACD3"),
+        ("أصفر مخضر", "#9ACD32"),
     ))
 
     safe_colors = (

--- a/faker/providers/color/hr_HR/__init__.py
+++ b/faker/providers/color/hr_HR/__init__.py
@@ -149,7 +149,7 @@ class Provider(ColorProvider):
         ('Žućkastosmeđa glina', '#A0522D'),
         ('Žuta svila', '#FFF8DC'),
         ('Žuta', '#FFFF00'),
-        ('Žutozelena', '#9ACD3'),
+        ('Žutozelena', '#9ACD32'),
     ))
 
     safe_colors = (

--- a/faker/providers/color/ru_RU/__init__.py
+++ b/faker/providers/color/ru_RU/__init__.py
@@ -64,7 +64,7 @@ class Provider(ColorProvider):
         ("Фиолетовый", "#EE82EE"),
         ("Белый", "#FFFFFF"),
         ("Желтый", "#FFFF00"),
-        ("Желто-зеленый", "#9ACD3"),
+        ("Желто-зеленый", "#9ACD32"),
     ))
 
     safe_colors = (


### PR DESCRIPTION
### What does this changes

This changes the code of YellowGreen color from '9ACD3' to '9ACD32'.

### What was wrong

The code of YellowGreen color was wrong for en-US, ar_PS, hr_HR and ru_RU locales. For other locales it is correct.
