### PR TITLE
Close #525. Make `value_types` a keyword argument

### DIFF
--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -1,0 +1,74 @@
+import unittest
+import warnings
+
+from faker import Faker
+
+
+class TestPython(unittest.TestCase):
+    """Tests python generators"""
+    def setUp(self):
+        self.factory = Faker()
+
+    def test_pybool(self):
+        some_bool = self.factory.pybool()
+        assert isinstance(some_bool, bool)
+
+    def test_pyint(self):
+        some_int = self.factory.pyint()
+        assert isinstance(some_int, int)
+
+    def py_str(self):
+        some_string = self.factory.pystr()
+        assert isinstance(some_string, str)
+        assert len(some_string) <= 20
+
+        some_string = self.factory.pystr(min_chars=3)
+        assert isinstance(some_string, str)
+        assert len(some_string) >= 3
+        assert len(some_string) <= 20
+
+        some_string = self.factory.pystr(max_chars=5)
+        assert isinstance(some_string, str)
+        assert len(some_string) <= 5
+
+        with self.assertRaises(AssertionError):
+            self.factory.pystr(min_chars=6, max_chars=5)
+
+        with self.assertRaises(AssertionError):
+            self.factory.pystr(min_chars=5, max_chars=5)
+
+    def test_pylist(self):
+        with warnings.catch_warnings(record=True) as w:
+            some_list = self.factory.pylist()
+            assert len(w) == 0
+        assert some_list
+        assert isinstance(some_list, list)
+
+    def test_pylist_types(self):
+        with warnings.catch_warnings(record=True) as w:
+            some_list = self.factory.pylist(10, True, [int])
+            assert len(w) == 0
+        assert some_list
+        for item in some_list:
+            assert isinstance(item, int)
+
+        with warnings.catch_warnings(record=True) as w:
+            some_list = self.factory.pylist(10, True, value_types=[int])
+            assert len(w) == 0
+        assert some_list
+        for item in some_list:
+            assert isinstance(item, int)
+
+        with warnings.catch_warnings(record=True) as w:
+            some_list = self.factory.pylist(10, True, int)
+            assert len(w) == 1
+        assert some_list
+        for item in some_list:
+            assert isinstance(item, int)
+
+        with warnings.catch_warnings(record=True) as w:
+            some_list = self.factory.pylist(10, True, int, float)
+            assert len(w) == 1
+        assert some_list
+        for item in some_list:
+            assert isinstance(item, (int, float))


### PR DESCRIPTION
### What does this changes

In the `python` provider, `value_types` arguments are changed to be non-variadic.

An additional `allowed_types` variadic argument has been added to achieve backward compatibility.  The deprecation plan is:
1. on the next major version, promote the `PendingDeprecationWarning` to a `DeprecationWarning`
2. on the second next major version, remove `allowed_types` completely.

### What was wrong

* The method signatures are ambiguous and non intuitive. #366
* Tools like `factoryboy` can't easily integrate with Faker. #525, https://github.com/FactoryBoy/factory_boy/pull/456

### How this fixes it

It is now possible to pass the value types either as multiple arguments, or as a single argument which could be a list or tuple.

Fixes #525 
