### PR TITLE
Close #912. Skip tests on 32bit systems

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git/
+
+build
+dist
+*.egg-info
+*.egg/
+*.pyc
+*.swp
+
+.tox
+.coverage
+html/*
+__pycache__
+
+# Compiled Documentation
+docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ branches:
 
 matrix:
   include:
+    - python: 3.7
+      env: TOXENV=flake8
+    - python: 3.7
+      env: TOXENV=checkmanifest
     - python: 2.7
       env: TOXENV=py27
     - python: 3.4
@@ -23,9 +27,8 @@ matrix:
     - python: pypy3.5-6.0
       env: TOXENV=pypy3
     - python: 3.7
-      env: TOXENV=flake8
-    - python: 3.7
-      env: TOXENV=checkmanifest
+      os: linux
+      env: TOXENV=32bit
 
 install:
   - pip install tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,9 +7,10 @@ recursive-include tests *.json
 recursive-include tests *.py
 
 global-exclude *.py[cod] __pycache__ *.so
-exclude Makefile tox.ini .coveragerc .bumpversion.cfg
+exclude Makefile tox.ini .coveragerc .bumpversion.cfg .dockerignore
 exclude ISSUE_TEMPLATE.md PULL_REQUEST_TEMPLATE.md
 exclude appveyor.yml readthedocs.yml
+exclude build32bit.sh
 prune docs
 prune .circleci
 

--- a/build32bit.sh
+++ b/build32bit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker run -v ${PWD}:/code -e INSTALL_REQUIREMENTS=${INSTALL_REQUIREMENTS} i386/ubuntu bash -c "
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -yq python3 locales python3-pip debianutils \
+    && pip3 install tox coveralls \
+    && locale-gen en_US.UTF-8 \
+    && cd /code \
+    && coverage run --source=faker setup.py test \
+    && coverage report"

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -11,8 +11,8 @@ from time import time
 from dateutil import relativedelta
 from dateutil.tz import tzlocal, tzutc
 
-from faker.utils.datetime_safe import date, datetime, real_date, real_datetime
 from faker.utils import is_string
+from faker.utils.datetime_safe import date, datetime, real_date, real_datetime
 
 from .. import BaseProvider
 
@@ -1664,11 +1664,17 @@ class Provider(BaseProvider):
             datetime_to_timestamp(datetime_start),
             datetime_to_timestamp(datetime_end),
         )
-        if tzinfo is None:
-            pick = datetime.fromtimestamp(timestamp, tzlocal())
-            pick = pick.astimezone(tzutc()).replace(tzinfo=None)
-        else:
-            pick = datetime.fromtimestamp(timestamp, tzinfo)
+        try:
+            if tzinfo is None:
+                pick = datetime.fromtimestamp(timestamp, tzlocal())
+                pick = pick.astimezone(tzutc()).replace(tzinfo=None)
+            else:
+                pick = datetime.fromtimestamp(timestamp, tzinfo)
+        except OverflowError:
+            raise OverflowError(
+                "You specified an end date with a timestamp bigger than the maximum allowed on this"
+                " system. Please specify an earlier date.",
+            )
         return pick
 
     def date_between_dates(self, date_start=None, date_end=None):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',
         'Topic :: Utilities',
-        'License :: OSI Approved :: MIT License'
+        'License :: OSI Approved :: MIT License',
     ],
     keywords='faker fixtures data test mock generator',
     author='joke2k',
@@ -80,5 +80,5 @@ setup(
         ':python_version=="2.7"': [
             'ipaddress',
         ],
-    }
+    },
 )

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -6,6 +6,7 @@ from datetime import time as datetime_time
 import time
 import unittest
 import random
+import sys
 
 import six
 
@@ -16,6 +17,10 @@ from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
 
 import pytest
+
+
+def is64bit():
+    return sys.maxsize > 2**32
 
 
 class UTC(tzinfo):
@@ -225,6 +230,7 @@ class TestDateTime(unittest.TestCase):
     def _datetime_to_time(self, value):
         return int(time.mktime(value.timetuple()))
 
+    @unittest.skipUnless(is64bit(), "requires 64bit")
     def test_date_time_this_period(self):
         # test century
         this_century_start = self._datetime_to_time(
@@ -292,6 +298,7 @@ class TestDateTime(unittest.TestCase):
             self._datetime_to_time(datetime.now())
         )
 
+    @unittest.skipUnless(is64bit(), "requires 64bit")
     def test_date_time_this_period_with_tzinfo(self):
         # ensure all methods provide timezone aware datetimes
         with pytest.raises(TypeError):
@@ -329,6 +336,7 @@ class TestDateTime(unittest.TestCase):
             replace(second=0, microsecond=0) == datetime.now(utc).replace(second=0, microsecond=0)
         )
 
+    @unittest.skipUnless(is64bit(), "requires 64bit")
     def test_date_this_period(self):
         # test century
         assert self.factory.date_this_century(after_today=False) <= date.today()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35,36,37,py,py3},flake8,checkmanifest
+envlist=py{27,34,35,36,37,py,py3},32bit,flake8,checkmanifest
 skip_missing_interpreters = true
 
 [testenv]
@@ -24,6 +24,10 @@ deps =
 commands =
     check-manifest
 
+[testenv:32bit]
+basepython = python
+commands = ./build32bit.sh
+
 [flake8]
 max-line-length = 120
-exclude = faker/lib,faker/bin
+exclude = faker/lib,faker/bin,.eggs,docs


### PR DESCRIPTION
### What does this changes

* Catches a possible `OverflowError` and re-raises it with a more descriptive message.
* Adds a 32bit build to travis
* Skips failing tests on the 32bit build.

### What was wrong

Tests in `TestDateTime` were failing on 32bit systems, which we weren't testing for.

### How this fixes it

The new build should help catching failures on 32bit in the future.