### PR TITLE
Request ipaddress on python 3.2/3.1/3.0 too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "freezegun==0.3.11",
     ],
     extras_require={
-        ':python_version=="2.7"': [
+        ':python_version<"3.3"': [
             'ipaddress',
         ],
     },


### PR DESCRIPTION
Even tho not directly supported it matches up reality of where the ipaddress is really required rather than 2.7 only

In reality this is no-op change, I just need to change all the == in the setup.py prior distributing it to >= as we are not hardcoding versions in distribution and this makes my life easier.