### PR TITLE
Fix PyInstaller issues

### DIFF
--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -7,8 +7,15 @@ import pkgutil
 def get_path(module):
     if getattr(sys, 'frozen', False):
         # frozen
-        base_dir = os.path.dirname(sys.executable)
-        lib_dir = os.path.join(base_dir, "lib")
+
+        if getattr(sys, '_MEIPASS', False):
+            # PyInstaller
+            lib_dir = getattr(sys, '_MEIPASS')
+        else:
+            # others
+            base_dir = os.path.dirname(sys.executable)
+            lib_dir = os.path.join(base_dir, "lib")
+
         module_to_rel_path = os.path.join(*module.__package__.split("."))
         path = os.path.join(lib_dir, module_to_rel_path)
     else:
@@ -19,9 +26,14 @@ def get_path(module):
 
 def list_module(module):
     path = get_path(module)
-    modules = [name for _, name,
-               is_pkg in pkgutil.iter_modules([path]) if is_pkg]
-    return modules
+
+    if getattr(sys, '_MEIPASS', False):
+        # PyInstaller
+        return [name for name in os.listdir(path)
+                if os.path.isdir(os.path.join(path, name)) and
+                "__init__.py" in os.listdir(os.path.join(path, name))]
+    else:
+        return [name for _, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
 
 
 def find_available_locales(providers):


### PR DESCRIPTION
Following the discussion in #891, This PR is listing the modules directly from the filesystem.
 
According to this thread [#1905](https://github.com/pyinstaller/pyinstaller/issues/1905), PyInstaller is not supporting the `pkgutil.iter_modules` so the dynamic module loading is not working.

I have added a code to list the modules directly from the source code that needs to be included in the bundle for this to work.
It is using a small PyInstaller hook to fetch the providers source files:
```
from PyInstaller.utils.hooks import collect_submodules, collect_data_files

hiddenimports = collect_submodules('faker.providers')
datas = (collect_data_files('text_unidecode') +
         collect_data_files('faker.providers', include_py_files=True))
```
If this PR will be approved, I will submit a PR in PyInstaller to include this hook.

It is not working for me using cx_freeze, I have no experience with it and I could not get it to work, always give me an exception:
```
ImportError: No module named providers
```
From a small test, it seems that `pkgutil.iter_modules` is working in cx_freeze but I still got this error (even when I try to explicitly include the module).


I think that it will be better to find a generic way for all the "code freezers" work but not sure that it is possible.