### PR TITLE
Add bounds to pyint

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -70,8 +70,8 @@ class Provider(BaseProvider):
             self.random_number(right_digits),
         ))
 
-    def pyint(self):
-        return self.generator.random_int()
+    def pyint(self, min=0, max=9999):
+        return self.generator.random_int(min, max)
 
     def pydecimal(self, left_digits=None, right_digits=None, positive=False,
                   min_value=None, max_value=None):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -15,6 +15,18 @@ class TestPyint(unittest.TestCase):
     def test_pyint_bounds(self):
         self.assertTrue(0 <= self.factory.pyint() <= 9999)
 
+    def test_pyint_bound_0(self):
+        self.assertEqual(0, self.factory.pyint(min=0, max=0))
+
+    def test_pyint_bound_positive(self):
+        self.assertEqual(5, self.factory.pyint(min=5, max=5))
+
+    def test_pyint_bound_negative(self):
+        self.assertEqual(-5, self.factory.pyint(min=-5, max=-5))
+
+    def test_pyint_range(self):
+        self.assertTrue(0 <= self.factory.pyint(min=0, max=2) <= 2)
+
 
 class TestPyfloat(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -5,6 +5,17 @@ import unittest
 from faker import Faker
 
 
+class TestPyint(unittest.TestCase):
+    def setUp(self):
+        self.factory = Faker()
+
+    def test_pyint(self):
+        self.assertIsInstance(self.factory.pyint(), int)
+
+    def test_pyint_bounds(self):
+        self.assertTrue(0 <= self.factory.pyint() <= 9999)
+
+
 class TestPyfloat(unittest.TestCase):
     def setUp(self):
         self.factory = Faker()


### PR DESCRIPTION
### What does this changes

Allow specifying bounds for `pyint()`.

### What was wrong

`Faker().pyint()`'s range was forced to `[0, 9999]`

---

Superseds https://github.com/joke2k/faker/pull/869.