### PR TITLE
Recommend running tests with tox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,23 +356,11 @@ you pinned the version of ``Faker`` down to the patch number.
 Tests
 -----
 
-Installing dependencies:
-
-.. code:: bash
-
-    $ pip install -e .
-
 Run tests:
 
 .. code:: bash
 
-    $ python setup.py test
-
-or
-
-.. code:: bash
-
-    $ python -m unittest -v tests
+    $ tox
 
 Write documentation for providers:
 


### PR DESCRIPTION
### What does this changes

Recommend running tests with tox. Simplify testing instructions.

### What was wrong

Testing requires `pytest` and `freezegun`, which are not installed with instruction `pip install -e .`. 

### How this fixes it

`tox` is closer to what the CI tool does, installs dependencies automatically, runs linters and
checks the manifest.