### PR TITLE
Pin more-itertools only for python < 3.0

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,6 @@
+* Faker version:
+* OS:
+
 Brief summary of the issue goes here.
 
 ### Steps to reproduce

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -111,8 +111,6 @@ class Provider(BaseProvider):
         '{{url}}{{uri_path}}/{{uri_page}}{{uri_extension}}',
     )
     image_placeholder_services = (
-        'https://placeholdit.imgix.net/~text'
-        '?txtsize=55&txt={width}x{height}&w={width}&h={height}',
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',
         'https://placekitten.com/{width}/{height}',

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -196,3 +196,16 @@ class Provider(BaseProvider):
                 text.pop()
 
         return "".join(text)
+
+    def texts(self, nb_texts=3, max_nb_chars=200, ext_word_list=None):
+        """
+        Generate an array of texts
+        :example [text1, text2, text3]
+        :param nb_texts: How many texts to return
+        :param max_nb_chars: Maximum number of characters the text should contain (minimum 5)
+        :param ext_word_list: a list of words you would like to have instead of 'Lorem ipsum'.
+
+        :rtype: list
+        """
+        return [self.text(max_nb_chars, ext_word_list)
+                for _ in range(0, nb_texts)]

--- a/faker/providers/person/es_CA/__init__.py
+++ b/faker/providers/person/es_CA/__init__.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from ..es_ES import Provider as PersonProvider
+
+
+class Provider(PersonProvider):
+    """
+    Adds popular Catalan names.
+    https://www.idescat.cat/pub/?id=aec&n=946&lang=es&t=2018
+    https://www.idescat.cat/pub/?id=aec&n=947&lang=es&t=2018
+    """
+    first_names_male = (
+        'Adam',
+        'Albert',
+        'Aleix',
+        'Álex',
+        'Antonio',
+        'Arnau',
+        'Biel',
+        'Bruno',
+        'Carlos',
+        'Daniel',
+        'David',
+        'Enzo',
+        'Èric',
+        'Francisco',
+        'Hugo',
+        'Jan',
+        'Javier',
+        'Joan',
+        'Jordi',
+        'Jorge',
+        'Josep',
+        'José',
+        'José María',
+        'Juan',
+        'Leo',
+        'Lucas',
+        'Manuel',
+        'Marc',
+        'Martí',
+        'Max',
+        'Miguel',
+        'Nil',
+        'Pau',
+        'Pedro',
+        'Pol',
+        'Ramón',
+        'Xavier')
+
+    first_names_female = (
+        'Abril',
+        'Aina',
+        'Ana',
+        'Anna',
+        'Antonia',
+        'Antònia',
+        'Arlet',
+        'Carla',
+        'Carmen',
+        'Chlóe',
+        'Clàudia',
+        'Cristina',
+        'Dolores',
+        'Emma',
+        'Francisca',
+        'Isabel',
+        'Jana',
+        'Josefa',
+        'Júlia',
+        'Laia',
+        'Laura',
+        'Lucia',
+        'Marta',
+        'Martina',
+        'María',
+        'María Del Carmen',
+        'María Dolores',
+        'María Teresa',
+        'Mia',
+        'Montserrat',
+        'Noa',
+        'Núria',
+        'Ona',
+        'Paula',
+        'Rosa',
+        'Sara',
+        'Sofía',
+        'Sílvia',
+        'Valèria')
+
+    first_names = first_names_male + first_names_female

--- a/faker/providers/person/ro_RO/__init__.py
+++ b/faker/providers/person/ro_RO/__init__.py
@@ -104,6 +104,8 @@ class Provider(PersonProvider):
         'Vasilică', 'Veniamin', 'Vicențiu', 'Victor', 'Vincențiu', 'Viorel', 'Visarion', 'Vlad', 'Vladimir', 'Vlaicu',
         'Voicu', 'Zamfir', 'Zeno')
 
+    first_names = first_names_female + first_names_male
+
     # sources: https://ro.wikipedia.org/wiki/Lista_celor_mai_uzuale_nume_de_familie#Rom%C3%A2nia
     last_names = (
         'Aanei', 'Ababei', 'Albu', 'Ardelean', 'Barbu', 'Cristea', 'Diaconescu', 'Diaconu', 'Dima', 'Dinu', 'Dobre',

--- a/faker/providers/ssn/es_CA/__init__.py
+++ b/faker/providers/ssn/es_CA/__init__.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+from ..es_ES import Provider as BaseProvider
+
+
+class Provider(BaseProvider):
+    """
+    A Faker provider for the Spanish VAT IDs and DOIs
+    """
+
+    pass

--- a/faker/providers/ssn/es_ES/__init__.py
+++ b/faker/providers/ssn/es_ES/__init__.py
@@ -1,10 +1,12 @@
 # coding=utf-8
+import random
+
 from .. import Provider as BaseProvider
 
 
 class Provider(BaseProvider):
     """
-    A Faker provider for the Spanish VAT IDs
+    A Faker provider for the Spanish VAT IDs and DOIs
     """
 
     vat_id_formats = (
@@ -20,3 +22,86 @@ class Provider(BaseProvider):
         """
 
         return self.bothify(self.random_element(self.vat_id_formats))
+
+    def nie(self):
+        """
+        https://es.wikipedia.org/wiki/N%C3%BAmero_de_identidad_de_extranjero
+        :return: a random Spanish NIE
+        """
+
+        first_chr = random.randrange(0, 3)
+        doi_body = str(random.randrange(0, 10000000)).zfill(7)
+        control = self._calculate_control_doi(str(first_chr) + doi_body)
+        return "XYZ"[first_chr] + doi_body + control
+
+    def nif(self):
+        """
+        https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal
+        :return: NIF
+        """
+
+        nie_body = str(random.randrange(0, 100000000))  # generate a number of a maximum of 8 characters long
+        return nie_body.zfill(8) + self._calculate_control_doi(nie_body)
+
+    def cif(self):
+        """
+        https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal
+        :return: a random Spanish CIF
+        """
+
+        first_chr = random.choice('ABCDEFGHJNPQRSUVW')
+        doi_body = str(random.randrange(0, 10000000)).zfill(7)
+        cif = first_chr + doi_body
+        return cif + self._calculate_control_cif(cif)
+
+    def doi(self):
+        """
+        https://es.wikipedia.org/wiki/Identificador_de_objeto_digital
+        :return: a random Spanish CIF or NIE or NIF
+        """
+
+        return random.choice([self.cif, self.nie, self.nif])()
+
+    @staticmethod
+    def _calculate_control_doi(doi):
+        """
+        Calculate the letter that corresponds to the end of a DOI
+        :param doi: calculated value so far needing a control character
+        :return: DOI control character
+        """
+
+        lookup = 'TRWAGMYFPDXBNJZSQVHLCKE'
+        return lookup[int(doi) % 23]
+
+    @classmethod
+    def _calculate_control_cif(cls, cif):
+        """
+        Calculate the letter that corresponds to the end of a CIF
+        :param cif: calculated value so far needing a control character
+        :return: CIF control character
+
+        Code was converted from the minified js of: https://generadordni.es/
+        """
+
+        sum_ = 0
+        first_chr, cif_value = cif[0], cif[1:]
+        for index, char in enumerate(cif_value):
+            if index % 2:
+                sum_ += int(char)
+            else:
+                sum_ += sum(map(int, str(int(char) * 2)))
+        if sum_ > 10:
+            sum_ = int(str(sum_)[-1])
+        else:
+            sum_ = sum_
+        sum_ = 10 - (sum_ % 10)
+
+        if first_chr in ['F', 'J', 'K', 'N', 'P', 'Q', 'R', 'S', 'U', 'V', 'W']:
+            return chr(64 + sum_)
+        elif first_chr in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'L', 'M']:
+            if sum_ == 10:
+                sum_ = 0
+            return str(sum_)
+        else:  # K, L, M  # pragma: no cover
+            # Old format that is no longer used, here for full compatability
+            return cls._calculate_control_doi(cif)  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "ukpostcodeparser>=1.1.1",
         "mock",
         "pytest>=3.8.0,<3.9",
-        "more-itertools<6.0.0",
+        "more-itertools<6.0.0 ; python_version < '3.0'",
         "random2==1.0.1",
         "freezegun==0.3.11",
     ],

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -410,6 +410,30 @@ class FactoryTestCase(unittest.TestCase):
             assert word not in checked_words
             checked_words.append(word)
 
+    def test_texts_count(self):
+        faker = Faker()
+
+        texts_count = 5
+        assert texts_count == len(faker.texts(nb_texts=texts_count))
+
+    def test_texts_chars_count(self):
+        faker = Faker()
+
+        chars_count = 5
+        for faker_text in faker.texts(max_nb_chars=chars_count):
+            assert chars_count >= len(faker_text)
+
+    def test_texts_word_list(self):
+        faker = Faker()
+
+        word_list = [
+            'test',
+            'faker',
+        ]
+        for faker_text in faker.texts(ext_word_list=word_list):
+            for word in word_list:
+                assert word in faker_text.lower()
+
     def test_random_pystr_characters(self):
         from faker.providers.python import Provider
         provider = Provider(self.generator)


### PR DESCRIPTION
### What does this changes

Force setup.py to install a version of `more-itertools` compatible with python 2.7 when python < 3.0

### What was wrong

Nothing *wrong* but this is better than https://github.com/joke2k/faker/pull/911 because we can use a more up to date version of `more-itertools` when  python >= 3.0.
Also it looks like it was causing problems on https://github.com/NixOS/nixpkgs/pull/61110 which were reported by @mmlb https://github.com/joke2k/faker/pull/911#issuecomment-490300392 and required a workaround. Hope this can fix it properly.

### How this fixes it

It makes use of [PEP 496 -- Environment Markers](https://www.python.org/dev/peps/pep-0496/) to conditionality install a specific version of `more-itertools` when python < 3.0