### PR TITLE
Rename pyint min and max to min_value and max_value

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -71,8 +71,8 @@ class Provider(BaseProvider):
             self.random_number(right_digits),
         ))
 
-    def pyint(self, min=0, max=9999, step=1):
-        return self.generator.random_int(min, max, step=step)
+    def pyint(self, min_value=0, max_value=9999, step=1):
+        return self.generator.random_int(min_value, max_value, step=step)
 
     def pydecimal(self, left_digits=None, right_digits=None, positive=False,
                   min_value=None, max_value=None):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -20,16 +20,16 @@ class TestPyint(unittest.TestCase):
         self.assertEqual(0, random_int % 2)
 
     def test_pyint_bound_0(self):
-        self.assertEqual(0, self.factory.pyint(min=0, max=0))
+        self.assertEqual(0, self.factory.pyint(min_value=0, max_value=0))
 
     def test_pyint_bound_positive(self):
-        self.assertEqual(5, self.factory.pyint(min=5, max=5))
+        self.assertEqual(5, self.factory.pyint(min_value=5, max_value=5))
 
     def test_pyint_bound_negative(self):
-        self.assertEqual(-5, self.factory.pyint(min=-5, max=-5))
+        self.assertEqual(-5, self.factory.pyint(min_value=-5, max_value=-5))
 
     def test_pyint_range(self):
-        self.assertTrue(0 <= self.factory.pyint(min=0, max=2) <= 2)
+        self.assertTrue(0 <= self.factory.pyint(min_value=0, max_value=2) <= 2)
 
 
 class TestPyfloat(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Rename `pyint`'s `min` and `max` arguments to `min_value` and `max_value`.

### What was wrong

Other generators `pyfloat` and `pydecimal` already name their arguments `min_value` and `max_value`, `pyint` should follow that convention.
