### PR TITLE
Added an Invalid SSN generator to the en_US SSN Provider for use case…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ nosetests.xml
 
 # IDE
 *.sw[po]
+*.iml
+*.ipr

--- a/faker/providers/ssn/en_US/__init__.py
+++ b/faker/providers/ssn/en_US/__init__.py
@@ -188,13 +188,13 @@ class Provider(BaseProvider):
             random_group_or_serial = self.random_int(min=1, max=1000)
             if random_group_or_serial <= 500:
                 group = 0
-                serial = self.random_int(1, 9999)
+                serial = self.random_int(0, 9999)
             else:
-                group = self.random_int(1, 99)
+                group = self.random_int(0, 99)
                 serial = 0
         elif area in {666, 0}:
-            group = self.random_int(1, 99)
-            serial = self.random_int(1, 9999)
+            group = self.random_int(0, 99)
+            serial = self.random_int(0, 9999)
         else:
             group = random.choice([x for x in range(0, 100) if x not in itin_group_numbers])
             serial = self.random_int(0, 9999)

--- a/faker/providers/ssn/en_US/__init__.py
+++ b/faker/providers/ssn/en_US/__init__.py
@@ -6,6 +6,7 @@ from .. import Provider as BaseProvider
 
 
 class Provider(BaseProvider):
+    INVALID_SSN_TYPE = 'INVALID_SSN'
     SSN_TYPE = 'SSN'
     ITIN_TYPE = 'ITIN'
     EIN_TYPE = 'EIN'
@@ -139,6 +140,68 @@ class Provider(BaseProvider):
         ein = "{0:s}-{1:07d}".format(ein_prefix, sequence)
         return ein
 
+    def invalid_ssn(self):
+        """ Generate a random invalid United States Social Security Identification Number (SSN).
+
+        Invalid SSNs have the following characteristics:
+        Cannot begin with the number 9
+        Cannot begin with 666 in positions 1 - 3
+        Cannot begin with 000 in positions 1 - 3
+        Cannot contain 00 in positions 4 - 5
+        Cannot contain 0000 in positions 6 - 9
+
+        https://www.ssa.gov/kc/SSAFactSheet--IssuingSSNs.pdf
+
+        Additionally, return an invalid SSN that is NOT a valid ITIN by excluding certain ITIN related "group" values
+        """
+        itin_group_numbers = [
+            70,
+            71,
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            88,
+            90,
+            91,
+            92,
+            94,
+            95,
+            96,
+            97,
+            98,
+            99]
+        area = self.random_int(min=0, max=999)
+        if area < 900 and area not in {666, 0}:
+            random_group_or_serial = self.random_int(min=1, max=1000)
+            if random_group_or_serial <= 500:
+                group = 0
+                serial = self.random_int(1, 9999)
+            else:
+                group = self.random_int(1, 99)
+                serial = 0
+        elif area in {666, 0}:
+            group = self.random_int(1, 99)
+            serial = self.random_int(1, 9999)
+        else:
+            group = random.choice([x for x in range(0, 100) if x not in itin_group_numbers])
+            serial = self.random_int(0, 9999)
+
+        invalid_ssn = "{0:03d}-{1:02d}-{2:04d}".format(area, group, serial)
+        return invalid_ssn
+
     def ssn(self, taxpayer_identification_number_type=SSN_TYPE):
         """ Generate a random United States Taxpayer Identification Number of the specified type.
 
@@ -149,6 +212,8 @@ class Provider(BaseProvider):
             return self.itin()
         elif taxpayer_identification_number_type == self.EIN_TYPE:
             return self.ein()
+        elif taxpayer_identification_number_type == self.INVALID_SSN_TYPE:
+            return self.invalid_ssn()
         elif taxpayer_identification_number_type == self.SSN_TYPE:
 
             # Certain numbers are invalid for United States Social Security
@@ -166,4 +231,5 @@ class Provider(BaseProvider):
             return ssn
 
         else:
-            raise ValueError("taxpayer_identification_number_type must be one of 'SSN', 'EIN', or 'ITIN'.")
+            raise ValueError("taxpayer_identification_number_type must be one of 'SSN', 'EIN', 'ITIN',"
+                             " or 'INVALID_SSN'.")

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -114,83 +114,94 @@ class TestEnUS(unittest.TestCase):
             assert area != '666'
 
     def test_invalid_ssn(self):
-        self.factory.seed(19030)
-        for _ in range(100):
-            ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        # Magic Numbers used generate '666-44-9370', '000-19-8911', '978-45-0926', '241-00-1691',
+        # and 812-11-0000 respectively:
+        #
+        # Ensure that generated SSNs are 11 characters long
+        # including dashes, consist of dashes and digits only, and the tested number
+        # violates the requirements below, ensuring an INVALID SSN is returned:
+        #
+        # A United States Social Security Number
+        # (SSN) is a tax processing number issued by the Internal
+        # Revenue Service with the format "AAA-GG-SSSS".  The
+        # number is divided into three parts: the first three
+        # digits, known as the area number because they were
+        # formerly assigned by geographical region; the middle two
+        # digits, known as the group number; and the final four
+        # digits, known as the serial number. SSNs with the
+        # following characteristics are not allocated:
+        #
+        # 1) Numbers with all zeros in any digit group
+        # (000-##-####, ###-00-####, ###-##-0000).
+        #
+        # 2) Numbers with 666 or 900-999 in the first digit group.
+        #
+        # https://en.wikipedia.org/wiki/Social_Security_number
+        #
+        # ITIN explained:
+        # https://www.irs.gov/individuals/international-taxpayers/general-itin-information
 
-            # The Magic Number for the Seed returns an SSN beginning with 666 to test the Area value properly
-            #
-            # Ensure that generated SSNs are 11 characters long
-            # including dashes, consist of dashes and digits only, and the tested number
-            # violates the requirements below, ensuring an INVALID SSN is returned:
-            #
-            # A United States Social Security Number
-            # (SSN) is a tax processing number issued by the Internal
-            # Revenue Service with the format "AAA-GG-SSSS".  The
-            # number is divided into three parts: the first three
-            # digits, known as the area number because they were
-            # formerly assigned by geographical region; the middle two
-            # digits, known as the group number; and the final four
-            # digits, known as the serial number. SSNs with the
-            # following characteristics are not allocated:
-            #
-            # 1) Numbers with all zeros in any digit group
-            # (000-##-####, ###-00-####, ###-##-0000).
-            #
-            # 2) Numbers with 666 or 900-999 in the first digit group.
-            #
-            # https://en.wikipedia.org/wiki/Social_Security_number
-            #
-            # ITIN explained:
-            # https://www.irs.gov/individuals/international-taxpayers/general-itin-information
+        itin_group_numbers = [
+            70,
+            71,
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            88,
+            90,
+            91,
+            92,
+            94,
+            95,
+            96,
+            97,
+            98,
+            99]
 
-            itin_group_numbers = [
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86,
-                87,
-                88,
-                90,
-                91,
-                92,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99]
-            assert len(ssn) == 11
-            assert ssn.replace('-', '').isdigit()
+        self.factory.seed(2432)
+        ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        [area, group, serial] = ssn.split('-')
 
-            [area, group, serial] = ssn.split('-')
+        assert len(ssn) == 11
+        assert ssn.replace('-', '').isdigit()
+        assert int(area) == 666 and int(group) >= 1 and int(serial) >= 1
 
-            if int(area) in {666, 0}:
-                assert int(group) >= 1
-                assert int(serial) >= 1
-            elif 0 not in {int(group), int(serial)}:
-                assert 900 <= int(area) <= 999 and int(group) not in itin_group_numbers
-            elif (int(area) < 900) and (0 not in {int(serial)}):
-                assert int(group) == 0
-            elif (int(area) < 900) and (0 not in {int(group)}):
-                assert int(serial) == 0
-            else:
-                assert int(area) >= 900
-                assert int(group) >= 0 and int(group) not in itin_group_numbers
-                assert int(serial) >= 0
+        self.factory.seed(1514)
+        ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        [area, group, serial] = ssn.split('-')
+
+        assert int(area) == 0 and int(group) >= 1 and int(serial) >= 1
+
+        self.factory.seed(2)
+        ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        [area, group, serial] = ssn.split('-')
+
+        assert 900 <= int(area) <= 999 and int(group) not in itin_group_numbers and int(serial) >= 0
+
+        self.factory.seed(4)
+        ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        [area, group, serial] = ssn.split('-')
+
+        assert int(area) < 900 and int(group) == 0 and int(serial) >= 1
+
+        self.factory.seed(6)
+        ssn = self.factory.ssn(taxpayer_identification_number_type='INVALID_SSN')
+        [area, group, serial] = ssn.split('-')
+
+        assert int(area) < 900 and int(group) >= 1 and int(serial) == 0
 
     def test_prohibited_ssn_value(self):
         # 666 is a prohibited value. The magic number selected as a seed


### PR DESCRIPTION
…s where an Invalid en_US format SSN is needed.

### What does this change

In use cases where a genuine United States' en_US format SSN may pull a credit report, an invalid SSN can be substituted, preventing a live credit pull. Additionally, by ensuring many thousands of random invalid SSNs can be generated,  this can reduce or eliminate reusing the same invalid SSN during data driven testing, or development purposes.

### What was wrong

No Invalid United States en_US format SSN function.

### How this fixes it

Adds "invalid_ssn" en_US format SSN function to en_US Provider, which returns an invalid SSN.

Fixes # [961](https://github.com/joke2k/faker/issues/961).
