### PR TITLE
add pwz generator and date_of_brith and sex asargument to pesel (`pl_PL`)

### DIFF
--- a/faker/providers/person/pl_PL/__init__.py
+++ b/faker/providers/person/pl_PL/__init__.py
@@ -738,17 +738,38 @@ class Provider(PersonProvider):
         https://en.wikipedia.org/wiki/PESEL
         """
 
-        birth = self.generator.date_of_birth()
+    @staticmethod
+    def pwz_doctor_compute_check_digit(x):
+        return sum((i+1)*d for i, d in enumerate(x)) % 11
 
-        year_pesel = str(birth.year)[-2:]
-        month_pesel = birth.month if birth.year < 2000 else birth.month + 20
-        day_pesel = birth.day
-        person_id = self.random_int(1000, 9999)
+    def pwz_doctor(self):
+        """
+        Function generates an identification number for medical doctors
+        Polish: Prawo Wykonywania Zawodu (PWZ)
 
-        current_pesel = '{year}{month:02d}{day:02d}{person_id:04d}'.format(year=year_pesel, month=month_pesel,
-                                                                           day=day_pesel,
-                                                                           person_id=person_id)
+        https://www.nil.org.pl/rejestry/centralny-rejestr-lekarzy/zasady-weryfikowania-nr-prawa-wykonywania-zawodu
+        """
+        core = [self.random_digit() for _ in range(6)]
+        check_digit = self.pwz_doctor_compute_check_digit(core)
 
-        checksum_value = generate_pesel_checksum_value(current_pesel)
-        return '{pesel_without_checksum}{checksum_value}'.format(pesel_without_checksum=current_pesel,
-                                                                 checksum_value=checksum_value)
+        if check_digit == 0:
+            core[-1] = (core[-1] + 1) % 10
+            check_digit = self.pwz_doctor_compute_check_digit(core)
+
+        return '{}{}'.format(check_digit, ''.join(map(str, core)))
+
+    def pwz_nurse(self, kind='nurse'):
+        """
+        Function generates an identification number for nurses and midwifes
+        Polish: Prawo Wykonywania Zawodu (PWZ)
+
+        http://arch.nipip.pl/index.php/prawo/uchwaly/naczelnych-rad/w-roku-2015/posiedzenie-15-17-grudnia/3664-uchwala-
+        nr-381-vi-2015-w-sprawie-trybu-postepowania-dotyczacego-stwierdzania-i-przyznawania-prawa-wykonywania-zawodu-pi
+        elegniarki-i-zawodu-poloznej-oraz-sposobu-prowadzenia-rejestru-pielegniarek-i-rejestru-poloznych-przez-okregowe
+        -rady-pielegniarek-i-polo
+        """
+        region = self.random_int(1, 45)
+        core = [self.random_digit() for _ in range(5)]
+        kind_char = 'A' if kind == 'midwife' else 'P'
+
+        return '{:02d}{}{}'.format(region, ''.join(map(str, core)), kind_char)

--- a/faker/providers/person/pl_PL/__init__.py
+++ b/faker/providers/person/pl_PL/__init__.py
@@ -704,9 +704,9 @@ class Provider(PersonProvider):
         return ''.join(str(character) for character in identity)
 
     @staticmethod
-    def pesel_compute_check_digit(x):
+    def pesel_compute_check_digit(pesel):
         checksum_values = [9, 7, 3, 1, 9, 7, 3, 1, 9, 7]
-        return sum(int(a) * b for a, b in zip(list(x), checksum_values)) % 10
+        return sum(int(a) * b for a, b in zip(pesel, checksum_values)) % 10
 
     def pesel(self, date_of_birth=None, sex=None):
         """
@@ -728,16 +728,16 @@ class Provider(PersonProvider):
             month=date_of_birth.month if date_of_birth.year < 2000 else date_of_birth.month + 20)
         pesel_date = pesel_date[2:]
 
-        pesel_core = ''.join(list(map(str, [self.random_digit() for _ in range(3)])))
+        pesel_core = ''.join(map(str, (self.random_digit() for _ in range(3))))
         pesel_sex = self.random_digit()
 
         if (sex == 'M' and pesel_sex % 2 == 0) or (sex == 'F' and pesel_sex % 2 == 1):
             pesel_sex = (pesel_sex + 1) % 10
 
-        pesel_core = '{date}{core}{sex}'.format(date=pesel_date, core=pesel_core, sex=pesel_sex)
-        pesel_core_digits = list(map(int, list(pesel_core)))
+        pesel = '{date}{core}{sex}'.format(date=pesel_date, core=pesel_core, sex=pesel_sex)
+        pesel += str(self.pesel_compute_check_digit(pesel))
 
-        return pesel_core + str(self.pesel_compute_check_digit(pesel_core_digits))
+        return pesel
 
     @staticmethod
     def pwz_doctor_compute_check_digit(x):
@@ -761,7 +761,7 @@ class Provider(PersonProvider):
 
     def pwz_nurse(self, kind='nurse'):
         """
-        Function generates an identification number for nurses and midwifes
+        Function generates an identification number for nurses and midwives
         Polish: Prawo Wykonywania Zawodu (PWZ)
 
         http://arch.nipip.pl/index.php/prawo/uchwaly/naczelnych-rad/w-roku-2015/posiedzenie-15-17-grudnia/3664-uchwala-

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import re
 import unittest
-
+import datetime
 import six
 
 try:
@@ -211,6 +211,24 @@ class TestPlPL(unittest.TestCase):
     def test_identity_card_number(self):
         for _ in range(100):
             assert re.search(r'^[A-Z]{3}\d{6}$', self.factory.identity_card_number())
+
+    @mock.patch.object(PlPLProvider, 'random_digit')
+    def test_pesel_birth_date(self, mock_random_digit):
+        mock_random_digit.side_effect = [3, 5, 8, 8, 7, 9, 9, 3]
+        assert self.factory.pesel(datetime.date(1999, 12, 31)) == '99123135885'
+        assert self.factory.pesel(datetime.date(2000,  1,  1)) == '00210179936'
+
+    @mock.patch.object(PlPLProvider, 'random_digit')
+    def test_pesel_sex_male(self, mock_random_digit):
+        mock_random_digit.side_effect = [1, 3, 4, 5, 6, 1, 7, 0]
+        assert self.factory.pesel(datetime.date(1909, 3, 3), 'M') == '09030313454'
+        assert self.factory.pesel(datetime.date(1913, 8, 16), 'M') == '13081661718'
+
+    @mock.patch.object(PlPLProvider, 'random_digit')
+    def test_pesel_sex_female(self, mock_random_digit):
+        mock_random_digit.side_effect = [4, 9, 1, 6, 6, 1, 7, 3]
+        assert self.factory.pesel(datetime.date(2007, 4, 13), 'F') == '07241349161'
+        assert self.factory.pesel(datetime.date(1933, 12, 16), 'F') == '33121661744'
 
     @mock.patch.object(PlPLProvider, 'random_digit')
     def test_pwz_doctor(self, mock_random_digit):


### PR DESCRIPTION
What does this changes

- `Person` in `pl_PL`

What was wrong

- it wasn't possible to generate pesel number for given date of birth and/or sex
- generator for a `pwz` number was unavailable 

How this fixes it

- adds pwz_doctor and pwz_nurse generator to `Person` (pl_PL)
- adds date_of_birth and sex as parameter to `Person.pesel` (pl_PL)

Fixes #931 
