### PR TITLE
Issue/944/throw error in unix time generation

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -6,7 +6,6 @@ import re
 
 from calendar import timegm
 from datetime import timedelta, MAXYEAR
-from time import time
 
 from dateutil import relativedelta
 from dateutil.tz import tzlocal, tzutc
@@ -1474,7 +1473,7 @@ class Provider(BaseProvider):
     @classmethod
     def _parse_end_datetime(cls, value):
         if value is None:
-            return int(time())
+            return datetime_to_timestamp(datetime.now())
 
         return cls._parse_date_time(value)
 

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -3,10 +3,13 @@ from __future__ import unicode_literals
 
 from datetime import date, datetime, timedelta, tzinfo
 from datetime import time as datetime_time
-import time
-import unittest
+import os
+import platform
+import pytest
 import random
 import sys
+import time
+import unittest
 
 import six
 
@@ -16,10 +19,6 @@ from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
-
-import pytest
-import os
-import platform
 
 
 def is64bit():

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -18,6 +18,8 @@ from faker.providers.date_time.ar_EG import Provider as EgProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
 
 import pytest
+import os
+import platform
 
 
 def is64bit():
@@ -448,7 +450,7 @@ class TestDateTime(unittest.TestCase):
         from faker.providers.date_time import datetime_to_timestamp
 
         for _ in range(100):
-            now = datetime.now(utc).replace(microsecond=0)
+            now = datetime.now().replace(microsecond=0)
             epoch_start = datetime(1970, 1, 1, tzinfo=utc)
 
             # Ensure doubly-constrained unix_times are generated correctly
@@ -489,6 +491,14 @@ class TestDateTime(unittest.TestCase):
 
             self.assertIsInstance(constrained_unix_time, int)
             self.assertBetween(constrained_unix_time, 0, datetime_to_timestamp(now))
+
+            # Ensure it does not throw error with startdate='now' for machines with negative offset
+            if platform.system() != 'Windows':
+                os.environ['TZ'] = 'Europe/Paris'
+                time.tzset()
+            self.factory.unix_time(start_datetime='now')
+            if platform.system() != 'Windows':
+                del os.environ['TZ']
 
 
 class TestPlPL(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Replace the `time.time()` by `datetime_to_timestamp(datetime.now())` to avoid problems with negative offsets in machine as specified in #944

### What was wrong

These lines of code used to throw an error
```python
import faker
f = faker.Faker()
f.unix_time(start_datetime='now')
```

### How to fix it
Changed the calculation with `end_datetime=None`. Added a test to set an offset during tests to avoid this :bug: to happen again.
