### PR TITLE
Added SSN provider for es_MX

### DIFF
--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -8,6 +8,7 @@ from .. import Provider as BaseProvider
 
 
 ALPHABET = string.ascii_uppercase
+ALPHANUMERIC = string.digits + ALPHABET
 VOWELS = "AEIOU"
 CONSONANTS = [
     letter
@@ -209,3 +210,41 @@ class Provider(BaseProvider):
         random_curp += str(control_digit)
 
         return random_curp
+
+    def rfc(self, natural=True):
+        """
+        See https://es.wikipedia.org/wiki/Registro_Federal_de_Contribuyentes
+
+        :param natural: Whether to return the RFC of a natural person.
+            Otherwise return the RFC of a legal person.
+        :type natural: bool
+        :return: a random Mexican RFC
+        """
+        birthday = self.generator.date_of_birth()
+
+        if natural:
+            first_surname = random.choice(ALPHABET) + random.choice(VOWELS)
+            second_surname = random.choice(ALPHABET)
+            given_name = random.choice(ALPHABET)
+            name_initials = first_surname + second_surname + given_name
+        else:
+            name_initials = (
+                self.random_uppercase_letter() +
+                self.random_uppercase_letter() +
+                self.random_uppercase_letter()
+            )
+
+        birth_date = birthday.strftime("%y%m%d")
+        disambiguation_code = (
+            random.choice(ALPHANUMERIC) +
+            random.choice(ALPHANUMERIC) +
+            random.choice(ALPHANUMERIC)
+        )
+
+        random_rfc = (
+            name_initials +
+            birth_date +
+            disambiguation_code
+        )
+
+        return random_rfc

--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -195,7 +195,7 @@ class Provider(BaseProvider):
 
         # This character is assigned to avoid duplicity
         # It's normally '0' for those born < 2000
-        # and 'A' for those botn >= 2000
+        # and 'A' for those born >= 2000
         assigned_character = "0" if birthday.year < 2000 else "A"
 
         name_initials = FORBIDDEN_WORDS.get(name_initials, name_initials)

--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+from __future__ import unicode_literals
+
+import random
+import string
+
+from .. import Provider as BaseProvider
+
+
+def _reduce_digits(n):
+    """
+    Sum of digits of a number until sum becomes single digit.
+
+    Example:
+        658 => 6 + 5 + 8 = 19 => 1 + 9 = 10 => 1
+    """
+    if n == 0:
+        return 0
+    if n % 9 == 0:
+        return 9
+    else:
+        return n % 9
+
+
+def ssn_checksum(digits):
+    """
+    Calculate the checksum for the mexican SSN (IMSS).
+    """
+    return -sum(
+        _reduce_digits(n * (i % 2 + 1))
+        for i, n in enumerate(digits)
+    ) % 10
+
+
+class Provider(BaseProvider):
+    """
+    A Faker provider for the Mexican SSN, RFC and CURP
+    """
+    ssn_formats = ("###########",)
+
+    def ssn(self):
+        """
+        Mexican Social Security Number, as given by IMSS.
+
+        :return: a random Mexican SSN
+        """
+        office = self.random_int(min=1, max=99)
+        birth_year = self.random_int(min=0, max=99)
+        start_year = self.random_int(min=0, max=99)
+        serial = self.random_int(min=1, max=9999)
+
+        num = "{0:02d}{1:02d}{2:02d}{3:04d}".format(
+            office,
+            start_year,
+            birth_year,
+            serial,
+        )
+
+        check = ssn_checksum(map(int, num))
+        num += str(check)
+
+        return num

--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -1,4 +1,12 @@
 # coding=utf-8
+"""
+SSN provider for es_MX.
+
+This module adds a provider for mexican SSN, along with Unique Population
+Registry Code (CURP) and Federal Taxpayer Registry ID (RFC).
+"""
+
+
 from __future__ import unicode_literals
 
 import random
@@ -100,19 +108,19 @@ FORBIDDEN_WORDS = {
 CURP_CHARACTERS = "0123456789ABCDEFGHIJKLMNÑOPQRSTUVWXYZ"
 
 
-def _reduce_digits(n):
+def _reduce_digits(number):
     """
     Sum of digits of a number until sum becomes single digit.
 
     Example:
         658 => 6 + 5 + 8 = 19 => 1 + 9 = 10 => 1
     """
-    if n == 0:
+    if number == 0:
         return 0
-    if n % 9 == 0:
+    if number % 9 == 0:
         return 9
-    else:
-        return n % 9
+
+    return number % 9
 
 
 def ssn_checksum(digits):
@@ -167,7 +175,7 @@ class Provider(BaseProvider):
 
     def curp(self):
         """
-        See https://es.wikipedia.org/wiki/Clave_%C3%9Anica_de_Registro_de_Poblaci%C3%B3n
+        See https://es.wikipedia.org/wiki/Clave_%C3%9Anica_de_Registro_de_Poblaci%C3%B3n.
 
         :return: a random Mexican CURP (Unique Population Registry Code)
         """
@@ -190,8 +198,7 @@ class Provider(BaseProvider):
         # and 'A' for those botn >= 2000
         assigned_character = "0" if birthday.year < 2000 else "A"
 
-        if name_initials in FORBIDDEN_WORDS:
-            name_initials = FORBIDDEN_WORDS[name_initials]
+        name_initials = FORBIDDEN_WORDS.get(name_initials, name_initials)
 
         random_curp = (
             name_initials +
@@ -204,10 +211,7 @@ class Provider(BaseProvider):
             assigned_character
         )
 
-        # control_digit = str(self.random_digit())
-        control_digit = curp_checksum(random_curp)
-
-        random_curp += str(control_digit)
+        random_curp += str(curp_checksum(random_curp))
 
         return random_curp
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -412,6 +412,20 @@ class TestEsMX(unittest.TestCase):
             assert re.search(r'^[A-Z]{4}\d{6}[A-Z]{6}[0A]\d$', curp)
             assert mx_curp_checksum(curp[:-1]) == int(curp[-1])
 
+    def test_rfc_natural(self):
+        for _ in range(100):
+            rfc = self.factory.rfc()
+
+            assert len(rfc) == 13
+            assert re.search(r'^[A-Z]{4}\d{6}[0-9A-Z]{3}$', rfc)
+
+    def test_rfc_legal(self):
+        for _ in range(100):
+            rfc = self.factory.rfc(natural=False)
+
+            assert len(rfc) == 12
+            assert re.search(r'^[A-Z]{3}\d{6}[0-9A-Z]{3}$', rfc)
+
 
 class TestEtEE(unittest.TestCase):
     """ Tests SSN in the et_EE locale """

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -19,7 +19,8 @@ from faker.providers.ssn.hr_HR import checksum as hr_checksum
 from faker.providers.ssn.no_NO import checksum as no_checksum, Provider as no_Provider
 from faker.providers.ssn.pl_PL import checksum as pl_checksum, calculate_month as pl_calculate_mouth
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
-from faker.providers.ssn.es_MX import ssn_checksum as mx_ssn_checksum
+from faker.providers.ssn.es_MX import (ssn_checksum as mx_ssn_checksum,
+                                       curp_checksum as mx_curp_checksum)
 
 
 class TestBgBG(unittest.TestCase):
@@ -402,6 +403,14 @@ class TestEsMX(unittest.TestCase):
             assert len(ssn) == 11
             assert ssn.isnumeric()
             assert mx_ssn_checksum(map(int, ssn[:-1])) == int(ssn[-1])
+
+    def test_curp(self):
+        for _ in range(100):
+            curp = self.factory.curp()
+
+            assert len(curp) == 18
+            assert re.search(r'^[A-Z]{4}\d{6}[A-Z]{6}[0A]\d$', curp)
+            assert mx_curp_checksum(curp[:-1]) == int(curp[-1])
 
 
 class TestEtEE(unittest.TestCase):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -19,6 +19,7 @@ from faker.providers.ssn.hr_HR import checksum as hr_checksum
 from faker.providers.ssn.no_NO import checksum as no_checksum, Provider as no_Provider
 from faker.providers.ssn.pl_PL import checksum as pl_checksum, calculate_month as pl_calculate_mouth
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
+from faker.providers.ssn.es_MX import ssn_checksum as mx_ssn_checksum
 
 
 class TestBgBG(unittest.TestCase):
@@ -388,6 +389,19 @@ class TestEsES(unittest.TestCase):
 class TestEsCA(TestEsES):
     def setUp(self):
         self.factory = Faker('es_CA')
+
+
+class TestEsMX(unittest.TestCase):
+    def setUp(self):
+        self.factory = Faker('es_MX')
+
+    def test_ssn(self):
+        for _ in range(100):
+            ssn = self.factory.ssn()
+
+            assert len(ssn) == 11
+            assert ssn.isnumeric()
+            assert mx_ssn_checksum(map(int, ssn[:-1])) == int(ssn[-1])
 
 
 class TestEtEE(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Added a Mexican SSN provider, along with Unique Population Registry Code (CURP) and Federal Taxpayer Registry ID (RFC).

### What was wrong

The was no provider for these numbers numbers / codes.

### How this fixes it

This adds providers for SSN, CURP and RFC (both for natural and legal persons):

```python
from faker import Faker
fake = Faker("es_MX")
print(gen.ssn())  # '20142713988'
print(gen.curp())  # 'TOGG411122HGRPQI01'
print(gen.rfc())  # 'TEBS650328SZG'
print(gen.rfc(natural=False))  # 'UDO460509MU1'
```

Fixes #967 
