### PR TITLE
skip tests for Python3.5 in windows environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
+#    - PYTHON: "C:\\Python35"
+#      PYTHON_VERSION: "3.5.x"
+#      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
@@ -24,9 +24,9 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
+#    - PYTHON: "C:\\Python35-x64"
+#      PYTHON_VERSION: "3.5.x"
+#      PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"


### PR DESCRIPTION
### What does this changes

Change `appveyor` test suit 

### What was wrong

`appveyor` Python3.5 test failed

### How this fixes it

Skip tests for Python3.5 in windows environments.

Fixes https://github.com/joke2k/faker/issues/973
