### PR TITLE
Add pytimezone for tzinfo objects

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -4,7 +4,7 @@ from calendar import timegm
 from datetime import MAXYEAR, timedelta
 
 from dateutil import relativedelta
-from dateutil.tz import tzlocal, tzutc
+from dateutil.tz import gettz, tzlocal, tzutc
 
 from faker.utils.datetime_safe import date, datetime, real_date, real_datetime
 
@@ -1961,6 +1961,17 @@ class Provider(BaseProvider):
     def timezone(self):
         return self.generator.random.choice(
             self.random_element(self.countries)['timezones'])
+
+    def pytimezone(self, *args, **kwargs):
+        """
+        Generate a random timezone (see `faker.timezone` for any args)
+        and return as a python object usable as a `tzinfo` to `datetime`
+        or other fakers.
+
+        :example faker.pytimezone()
+        :return dateutil.tz.tz.tzfile
+        """
+        return gettz(self.timezone(*args, **kwargs))
 
     def date_of_birth(self, tzinfo=None, minimum_age=0, maximum_age=115):
         """

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -138,6 +138,16 @@ class TestDateTime(unittest.TestCase):
         today_back = datetime.fromtimestamp(timestamp, utc).date()
         assert today == today_back
 
+    def test_pytimezone(self):
+        import dateutil
+        pytz = self.fake.pytimezone()
+        assert isinstance(pytz, dateutil.tz.tz.tzfile)
+
+    def test_pytimezone_usable(self):
+        pytz = self.fake.pytimezone()
+        date = datetime(2000, 1, 1, tzinfo=pytz)
+        assert date.tzinfo == pytz
+
     def test_datetime_safe(self):
         from faker.utils import datetime_safe
         # test using example provided in module


### PR DESCRIPTION
### What does this changes

Adds a python object faker around the existing `timezone` name faker.

### What was wrong

It was a bit of a pain (multiple steps) to fake dates with fake tzinfo.

### How this fixes it

It removes one of the steps!

Fixes #988 


NB:

I thought about also doing something like `tzinfo=True` (or a new kwarg) as an argument to the other datetime methods, that makes them use `pytimezone` to generate a tzinfo instead of expecting one. That's more work though, so I thought I'd leave it without agreement on the principle.