### PR TITLE
Revert "Close #628. Switch to text-unidecode"

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-from text_unidecode import unidecode
+import unidecode
 
 from .. import BaseProvider
 
@@ -123,7 +123,7 @@ class Provider(BaseProvider):
         for search, replace in self.replacements:
             string = string.replace(search, replace)
 
-        string = unidecode(string)
+        string = unidecode.unidecode(string)
         return string
 
     @lowercase

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "python-dateutil>=2.4",
         "six>=1.10",
-        "text-unidecode==1.2",
+        "unidecode",
     ],
     tests_require=[
         "validators>=0.13.0",


### PR DESCRIPTION
This reverts commit e32a0cd73d7e1f42e12593bf6024ba7607454f54.

### What does this changes

Reverts the the use of text-unidecode to unidecode

### What was wrong

text-unidecode is under Artistic license which is not FOSS compatible

### How this fixes it

This change reverts the commit that changes to text-unidecode

Fixes #727 
