### PR TITLE
Bump required version text-unidecode to 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "python-dateutil>=2.4",
         "six>=1.10",
-        "text-unidecode==1.2",
+        "text-unidecode==1.3",
     ],
     tests_require=[
         "validators>=0.13.0",


### PR DESCRIPTION


### What does this changes

Bumps to required version of text-unidecode to 1.3

### What was wrong

text-unidecode was previously licensed under the Artistic License v1 which is incompatible with the GPL

### How this fixes it

text-unidecode version 1.3 is licensed under the terms of both the GPLv2 (or later) and the Artistic License v1, thus removing this incompatibility.

Fixes #727 