### PR TITLE
Bug fix for pyfloat going over max_value (issue #994)

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -60,7 +60,7 @@ class Provider(BaseProvider):
             if max_value is None:
                 max_value = min_value + self.random_int()
 
-            left_number = self.random_int(min_value, max_value)
+            left_number = self.random_int(min_value, max_value - 1)
         else:
             sign = '+' if positive else self.random_element(('+', '-'))
             left_number = self.random_number(left_digits)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -466,6 +466,16 @@ class FactoryTestCase(unittest.TestCase):
         with pytest.raises(ValueError):
             provider.pyfloat(left_digits=0, right_digits=0)
 
+    def test_pyfloat_in_range(self):
+        # tests for https://github.com/joke2k/faker/issues/994
+        factory = Faker()
+
+        factory.seed_instance(5)
+        result = factory.pyfloat(min_value=0, max_value=1)
+
+        assert result >= 0.0
+        assert result <= 1.0
+
     def test_negative_pyfloat(self):
         # tests for https://github.com/joke2k/faker/issues/813
         factory = Faker()


### PR DESCRIPTION
### What does this changes

When calling `pyfloat` with a `max_value`, it was possible for the `pyfloat` function to generate a random number within the range of `min_value <= x < (max_value + 1)` instead of the expected `min_value <= x <= max_value`.

### What was wrong

`pyfloat` was generating numbers above `max_value` sometimes.

### How this fixes it

Subtracts 1 from the `max_value` so that it doesn't go over by 1.  `left_number` was being inclusive when it should be exclusive for floating point numbers.

Fixes #994 
