### PR TITLE
fix randomize_nb_elements max param

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -284,7 +284,7 @@ class BaseProvider(object):
         nb = int(number * self.generator.random.randint(_min, _max) / 100)
         if min is not None and nb < min:
             nb = min
-        if max is not None and nb > min:
+        if max is not None and nb > max:
             nb = max
         return nb
 

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -30,6 +30,9 @@ class BaseProviderTestCase(unittest.TestCase):
 
         assert self.provider.randomize_nb_elements(le=True, ge=True) == 10
 
+        assert self.provider.randomize_nb_elements(min=42) == 42
+        assert self.provider.randomize_nb_elements(max=1) == 1
+
         number = 9999
         random_times = 100
         lower_bound = int(number * 0.6)


### PR DESCRIPTION
### What does this changes
The `max` argument for randomize_nb_elements is undocumented (and only the min is every used internally)....but it does exist and is broken :)

### What was wrong

Tiny typo/copy-paste error, `> min` instead of `>max`
