### PR TITLE
Fix float test

### DIFF
--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -54,7 +54,7 @@ class TestPyfloat(unittest.TestCase):
 
         result = self.factory.pyfloat(right_digits=expected_right_digits)
 
-        right_digits = len(str(result).split('.')[1])
+        right_digits = len(('%r' % result).split('.')[1])
         self.assertGreaterEqual(expected_right_digits, right_digits)
 
     def test_positive(self):


### PR DESCRIPTION
### What does this changes

Fix casting float to string in a test.

### What was wrong

On python 2.7, simply calling `str()` on a big float will render it to a string in scientific notation

### How this fixes it

Using `%r` will render the float the way we expect it.