### PR TITLE
fix master card number generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 .ropeproject
 .DS_Store
 .venv
+tags
 
 # IDE
 *.sw[po]

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ nosetests.xml
 .ropeproject
 .DS_Store
 .venv
-tags
 
 # IDE
 *.sw[po]

--- a/faker/providers/credit_card/__init__.py
+++ b/faker/providers/credit_card/__init__.py
@@ -29,7 +29,9 @@ class Provider(BaseProvider):
     # * https://creditcardjs.com/credit-card-type-detection
     prefix_maestro = ['5018', '5020', '5038', '56##', '57##', '58##',
                       '6304', '6759', '6761', '6762', '6763', '0604', '6390']
-    prefix_mastercard = ['51', '52', '53', '54', '55', '222%']
+    prefix_mastercard = ['51', '52', '53', '54', '55', '222%', '223', '224',
+                         '225', '226', '227', '228', '229', '23', '24', '25',
+                         '26', '270', '271', '2720']
     prefix_visa = ['4']
     prefix_amex = ['34', '37']
     prefix_discover = ['6011', '65']

--- a/tests/providers/test_credit_card.py
+++ b/tests/providers/test_credit_card.py
@@ -23,65 +23,69 @@ class MastercardGeneratorTestCase(unittest.TestCase):
 
 class VisaGeneratorTestCase(unittest.TestCase):
     def setUp(self):
+        self.base_provider = credit_card.Provider(faker.generator.Generator())
         self.factory = faker.Faker(locale='en_US')
         self.pattern = r'^4[0-9]{12}([0-9]{3}){0,2}$'
 
     def test_visa13(self):
         prefix_all = ['4']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 13)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 13)
             assert re.fullmatch(self.pattern, number)
 
     def test_visa16(self):
         prefix_all = ['4']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
             assert re.fullmatch(self.pattern, number)
 
     def test_visa19(self):
         prefix_all = ['4']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 19)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 19)
             assert re.fullmatch(self.pattern, number)
 
 
 class DiscoverGeneratorTestCase(unittest.TestCase):
     def setUp(self):
+        self.base_provider = credit_card.Provider(faker.generator.Generator())
         self.factory = faker.Faker(locale='en_US')
         self.pattern = r'^6(?:011|5[0-9]{2})[0-9]{12}$'
 
     def test_discover(self):
         prefix_all = ['6011', '65']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
             assert re.fullmatch(self.pattern, number)
 
 
 class DinersClubGeneratorTestCase(unittest.TestCase):
     def setUp(self):
+        self.base_provider = credit_card.Provider(faker.generator.Generator())
         self.factory = faker.Faker(locale='en_US')
         self.pattern = r'^3(?:0[0-5]|[68][0-9])[0-9]{11}$'
 
     def test_diners_club(self):
         prefix_all = ['300', '301', '302', '303', '304', '305', '36', '38']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 14)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 14)
             assert re.fullmatch(self.pattern, number)
 
 
 class JCBGeneratorTestCase(unittest.TestCase):
     def setUp(self):
+        self.base_provider = credit_card.Provider(faker.generator.Generator())
         self.factory = faker.Faker(locale='en_US')
         self.pattern = r'^(?:2131|1800|35\d{3})\d{11}$'
 
     def test_jcb16(self):
         prefix_all = ['35']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
             assert re.fullmatch(self.pattern, number)
 
     def test_jcb15(self):
         prefix_all = ['2131', '1800']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 15)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 15)
             assert re.fullmatch(self.pattern, number)

--- a/tests/providers/test_credit_card.py
+++ b/tests/providers/test_credit_card.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+
+import re
+import unittest
+
+import faker
+from faker.providers import credit_card
+
+
+class MastercardGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = faker.Faker(locale='en_US')
+        self.pattern = r'^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$'
+
+    def test_mastercard(self):
+        prefix_all = ['51', '52', '53', '54', '55', '222%', '223', '224', '225',
+                      '226', '227', '228', '229', '23', '24', '25', '26', '270',
+                      '271', '2720']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            assert re.fullmatch(self.pattern, number)
+
+
+class VisaGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = faker.Faker(locale='en_US')
+        self.pattern = r'^4[0-9]{12}([0-9]{3}){0,2}$'
+
+    def test_visa13(self):
+        prefix_all = ['4']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 13)
+            assert re.fullmatch(self.pattern, number)
+
+    def test_visa16(self):
+        prefix_all = ['4']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            assert re.fullmatch(self.pattern, number)
+
+    def test_visa19(self):
+        prefix_all = ['4']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 19)
+            assert re.fullmatch(self.pattern, number)
+
+
+class DiscoverGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = faker.Faker(locale='en_US')
+        self.pattern = r'^6(?:011|5[0-9]{2})[0-9]{12}$'
+
+    def test_discover(self):
+        prefix_all = ['6011', '65']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            assert re.fullmatch(self.pattern, number)
+
+
+class DinersClubGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = faker.Faker(locale='en_US')
+        self.pattern = r'^3(?:0[0-5]|[68][0-9])[0-9]{11}$'
+
+    def test_diners_club(self):
+        prefix_all = ['300', '301', '302', '303', '304', '305', '36', '38']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 14)
+            assert re.fullmatch(self.pattern, number)
+
+
+class JCBGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = faker.Faker(locale='en_US')
+        self.pattern = r'^(?:2131|1800|35\d{3})\d{11}$'
+
+    def test_jcb16(self):
+        prefix_all = ['35']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            assert re.fullmatch(self.pattern, number)
+
+    def test_jcb15(self):
+        prefix_all = ['2131', '1800']
+        for prefix in prefix_all:
+            number = credit_card.Provider._generate_number(self.factory, prefix, 15)
+            assert re.fullmatch(self.pattern, number)

--- a/tests/providers/test_credit_card.py
+++ b/tests/providers/test_credit_card.py
@@ -9,6 +9,7 @@ from faker.providers import credit_card
 
 class MastercardGeneratorTestCase(unittest.TestCase):
     def setUp(self):
+        self.base_provider = credit_card.Provider(faker.generator.Generator())
         self.factory = faker.Faker(locale='en_US')
         self.pattern = r'^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$'
 
@@ -17,7 +18,7 @@ class MastercardGeneratorTestCase(unittest.TestCase):
                       '226', '227', '228', '229', '23', '24', '25', '26', '270',
                       '271', '2720']
         for prefix in prefix_all:
-            number = credit_card.Provider._generate_number(self.factory, prefix, 16)
+            number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
             assert re.match(self.pattern, number)
 
 

--- a/tests/providers/test_credit_card.py
+++ b/tests/providers/test_credit_card.py
@@ -18,7 +18,7 @@ class MastercardGeneratorTestCase(unittest.TestCase):
                       '271', '2720']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.factory, prefix, 16)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
 
 class VisaGeneratorTestCase(unittest.TestCase):
@@ -31,19 +31,19 @@ class VisaGeneratorTestCase(unittest.TestCase):
         prefix_all = ['4']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 13)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
     def test_visa16(self):
         prefix_all = ['4']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
     def test_visa19(self):
         prefix_all = ['4']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 19)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
 
 class DiscoverGeneratorTestCase(unittest.TestCase):
@@ -56,7 +56,7 @@ class DiscoverGeneratorTestCase(unittest.TestCase):
         prefix_all = ['6011', '65']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
 
 class DinersClubGeneratorTestCase(unittest.TestCase):
@@ -69,7 +69,7 @@ class DinersClubGeneratorTestCase(unittest.TestCase):
         prefix_all = ['300', '301', '302', '303', '304', '305', '36', '38']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 14)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
 
 class JCBGeneratorTestCase(unittest.TestCase):
@@ -82,10 +82,10 @@ class JCBGeneratorTestCase(unittest.TestCase):
         prefix_all = ['35']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 16)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)
 
     def test_jcb15(self):
         prefix_all = ['2131', '1800']
         for prefix in prefix_all:
             number = credit_card.Provider._generate_number(self.base_provider, prefix, 15)
-            assert re.fullmatch(self.pattern, number)
+            assert re.match(self.pattern, number)


### PR DESCRIPTION
### What does this changes

Add test case for:
* visa13
* visa16
* visa19
* mastercard
* discover
* jcb15
* jcb16
* diners

### What was wrong

Faker.credit_card_number with card_type='mastercard' generate 2610440153652, it conclict with regex ^(5[1-5][0-9]{14}|2(22[1-9][0-9]{12}|2[3-9][0-9]{13}|[3-6][0-9]{14}|7[0-1][0-9]{13}|720[0-9]{12}))$
Wiki: [Payment card number(https://en.wikipedia.org/wiki/Payment_card_number#Issuer_identification_number_(IIN))

### How this fixes it

Add new prefix code into master card prefix

Fixes #...
