### PR TITLE
Fix/master/swedish ssn

### DIFF
--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -71,7 +71,7 @@ class Provider(SsnProvider):
         first_digits = list(self.ORG_ID_DIGIT_1)
         random.shuffle(first_digits)
         onr_one = str(first_digits.pop())
-        onr_one += str(self.generator.random.randrange(0,9)).zfill(1)
+        onr_one += str(self.generator.random.randrange(0, 9)).zfill(1)
         onr_one += str(self.generator.random.randrange(20, 99))
         onr_one += str(self.generator.random.randrange(0, 99)).zfill(2)
         onr_two = str(self.generator.random.randrange(0, 999)).zfill(3)

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -49,6 +49,12 @@ class Provider(SsnProvider):
 
         return pnr
 
+    def org_id(self, long=False, dash=True):
+        if long:
+            return '16559035-1077'
+        else:
+            return '559035-1077'
+
     vat_id_formats = (
         'SE############',
     )

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -7,13 +7,16 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self, min_age=18, max_age=90):
+    def ssn(self, min_age=18, max_age=90, dash=True):
         """
         Returns a 10 digit Swedish SSN, "Personnummer".
 
         It consists of 10 digits in the form YYMMDD-SSGQ, where
         YYMMDD is the date of birth, SSS is a serial number
         and Q is a control character (Luhn checksum).
+
+        Specifying dash=False will give a purely numeric string, suitable
+        for writing direct to databases.
 
         http://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)
         """
@@ -39,7 +42,8 @@ class Provider(SsnProvider):
         pnr_date = birthday.strftime('%y%m%d')
         suffix = str(self.generator.random.randrange(0, 999)).zfill(3)
         luhn_checksum = str(_calculate_luhn(pnr_date + suffix))
-        pnr = '{0}-{1}{2}'.format(pnr_date, suffix, luhn_checksum)
+        hyphen = '-' if dash else ''
+        pnr = '{0}{1}{2}{3}'.format(pnr_date, hyphen, suffix, luhn_checksum)
 
         return pnr
 

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -26,6 +26,13 @@ class Provider(SsnProvider):
         check_digit = Provider._luhn_checksum(int(partial_number) * 10)
         return check_digit if check_digit == 0 else 10 - check_digit
 
+    @staticmethod
+    def _org_to_vat(org_id):
+        org_id = org_id.replace('-', '')
+        if len(org_id) == 10:
+            org_id = '16' + org_id
+        return 'SE{0}01'.format(org_id)
+
     def ssn(self, min_age=18, max_age=90, long=False, dash=True):
         """
         Returns a 10 or 12 (long=True) digit Swedish SSN, "Personnummer".
@@ -56,6 +63,11 @@ class Provider(SsnProvider):
     ORG_ID_DIGIT_1 = (1, 2, 3, 5, 6, 7, 8, 9)
 
     def org_id(self, long=False, dash=True):
+        """
+        Returns a 10 or 12 digit Organisation ID for a Swedish
+        company.
+        (In Swedish) https://sv.wikipedia.org/wiki/Organisationsnummer
+        """
         first_digits = list(self.ORG_ID_DIGIT_1)
         random.shuffle(first_digits)
         onr_one = str(first_digits.pop())
@@ -75,6 +87,12 @@ class Provider(SsnProvider):
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
         :return: A random Swedish VAT ID, based on a valid Org ID
         """
-        oid = self.org_id(dash=False)
-        vid = 'SE{0}01'.format(oid)
+        oid = self.org_id(long=True, dash=False)
+        vid = Provider._org_to_vat(oid)
         return vid
+
+    def org_and_vat_id(self, long=False, dash=True):
+        """Returns matching Org ID and VAT number"""
+        oid = self.org_id(long=long, dash=dash)
+        vid = Provider._org_to_vat(oid)
+        return oid, vid

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -3,9 +3,28 @@
 from __future__ import unicode_literals
 from .. import Provider as SsnProvider
 import datetime
+import random
 
 
 class Provider(SsnProvider):
+
+    @staticmethod
+    def _luhn_checksum(number):
+        def digits_of(n):
+            return [int(d) for d in str(n)]
+        digits = digits_of(number)
+        odd_digits = digits[-1::-2]
+        even_digits = digits[-2::-2]
+        checksum = 0
+        checksum += sum(odd_digits)
+        for d in even_digits:
+            checksum += sum(digits_of(d * 2))
+        return checksum % 10
+
+    @staticmethod
+    def _calculate_luhn(partial_number):
+        check_digit = Provider._luhn_checksum(int(partial_number) * 10)
+        return check_digit if check_digit == 0 else 10 - check_digit
 
     def ssn(self, min_age=18, max_age=90, long=False, dash=True):
         """
@@ -20,21 +39,6 @@ class Provider(SsnProvider):
 
         http://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)
         """
-        def _luhn_checksum(number):
-            def digits_of(n):
-                return [int(d) for d in str(n)]
-            digits = digits_of(number)
-            odd_digits = digits[-1::-2]
-            even_digits = digits[-2::-2]
-            checksum = 0
-            checksum += sum(odd_digits)
-            for d in even_digits:
-                checksum += sum(digits_of(d * 2))
-            return checksum % 10
-
-        def _calculate_luhn(partial_number):
-            check_digit = _luhn_checksum(int(partial_number) * 10)
-            return check_digit if check_digit == 0 else 10 - check_digit
 
         age = datetime.timedelta(
             days=self.generator.random.randrange(min_age * 365, max_age * 365))
@@ -43,26 +47,34 @@ class Provider(SsnProvider):
         pnr_date = birthday.strftime('{}%m%d'.format(yr_fmt))
         chk_date = pnr_date[2:] if long else pnr_date
         suffix = str(self.generator.random.randrange(0, 999)).zfill(3)
-        luhn_checksum = str(_calculate_luhn(chk_date + suffix))
+        luhn_checksum = str(Provider._calculate_luhn(chk_date + suffix))
         hyphen = '-' if dash else ''
         pnr = '{0}{1}{2}{3}'.format(pnr_date, hyphen, suffix, luhn_checksum)
 
         return pnr
 
-    def org_id(self, long=False, dash=True):
-        if long:
-            return '16559035-1077'
-        else:
-            return '559035-1077'
+    ORG_ID_DIGIT_1 = (1, 2, 3, 5, 6, 7, 8, 9)
 
-    vat_id_formats = (
-        'SE############',
-    )
+    def org_id(self, long=False, dash=True):
+        first_digits = list(self.ORG_ID_DIGIT_1)
+        random.shuffle(first_digits)
+        onr_one = str(first_digits.pop())
+        onr_one += str(self.generator.random.randrange(0,9)).zfill(1)
+        onr_one += str(self.generator.random.randrange(20, 99))
+        onr_one += str(self.generator.random.randrange(0, 99)).zfill(2)
+        onr_two = str(self.generator.random.randrange(0, 999)).zfill(3)
+        luhn_checksum = str(Provider._calculate_luhn(onr_one + onr_two))
+        prefix = '16' if long else ''
+        hyphen = '-' if dash else ''
+
+        org_id = '{0}{1}{2}{3}{4}'.format(prefix, onr_one, hyphen, onr_two, luhn_checksum)
+        return org_id
 
     def vat_id(self):
         """
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
-        :return: A random Swedish VAT ID
+        :return: A random Swedish VAT ID, based on a valid Org ID
         """
-
-        return self.bothify(self.random_element(self.vat_id_formats))
+        oid = self.org_id(dash=False)
+        vid = 'SE{0}01'.format(oid)
+        return vid

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -7,11 +7,11 @@ import datetime
 
 class Provider(SsnProvider):
 
-    def ssn(self, min_age=18, max_age=90, dash=True):
+    def ssn(self, min_age=18, max_age=90, long=False, dash=True):
         """
-        Returns a 10 digit Swedish SSN, "Personnummer".
+        Returns a 10 or 12 (long=True) digit Swedish SSN, "Personnummer".
 
-        It consists of 10 digits in the form YYMMDD-SSGQ, where
+        It consists of 10 digits in the form (CC)YYMMDD-SSSQ, where
         YYMMDD is the date of birth, SSS is a serial number
         and Q is a control character (Luhn checksum).
 
@@ -39,9 +39,11 @@ class Provider(SsnProvider):
         age = datetime.timedelta(
             days=self.generator.random.randrange(min_age * 365, max_age * 365))
         birthday = datetime.datetime.now() - age
-        pnr_date = birthday.strftime('%y%m%d')
+        yr_fmt = '%Y' if long else '%y'
+        pnr_date = birthday.strftime('{}%m%d'.format(yr_fmt))
+        chk_date = pnr_date[2:] if long else pnr_date
         suffix = str(self.generator.random.randrange(0, 999)).zfill(3)
-        luhn_checksum = str(_calculate_luhn(pnr_date + suffix))
+        luhn_checksum = str(_calculate_luhn(chk_date + suffix))
         hyphen = '-' if dash else ''
         pnr = '{0}{1}{2}{3}'.format(pnr_date, hyphen, suffix, luhn_checksum)
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -98,16 +98,33 @@ class TestSvSE(unittest.TestCase):
             assert self.ssn_checksum(org_id) is True
 
     def test_org_id_short_no_dash(self):
-        raise NotImplementedError("org short no dash not inplemented")
+        for _ in range(100):
+            org_id = self.factory.org_id(dash=False)
+            assert re.search(r'\d{10}', org_id)
+            assert int(org_id[2:4]) >= 20
+            assert self.ssn_checksum(org_id) is True
 
     def test_org_id_long_with_dash(self):
-        raise NotImplementedError("org long with dash not inplemented")
+        for _ in range(100):
+            org_id = self.factory.org_id(long=True)
+            assert re.search(r'\d{8}-\d{4}', org_id)
+            assert int(org_id[4:6]) >= 20
+            assert self.ssn_checksum(org_id) is True
+
 
     def test_org_id_long_no_dash(self):
-        raise NotImplementedError("org long no dash not inplemented")
+        for _ in range(100):
+            org_id = self.factory.org_id(long=True, dash=False)
+            assert re.search(r'\d{12}', org_id)
+            assert int(org_id[4:6]) >= 20
+            assert self.ssn_checksum(org_id) is True
 
     def test_vat_id(self):
-        raise NotImplementedError("Test for VAT (MOMS) ID not implemented")
+        for _ in range(100):
+            vat_id = self.factory.vat_id()
+            assert re.search(r'SE\d{12}', vat_id)
+            assert int(vat_id[2]) in (1, 2, 3, 5, 6, 7, 8, 9)
+            assert int(vat_id[4:6]) >= 20
 
 
 class TestBgBG(unittest.TestCase):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -34,15 +34,16 @@ class TestSvSE(unittest.TestCase):
 
     def ssn_checksum(self, ssn):
         """Validates the checksum digit and returns a Boolean"""
+        ssn = ssn.replace('-', '')
         if len(ssn) == 12:
             ssn = ssn[2:12]
         if len(ssn) != 10:
             return False
 
-        mult_factors = cycle([1, 2])
-        final_sum = sum(self.partial_sum(int(char), mf) for char, mf in zip(ssn, mult_factors))
-        checksum = int(ssn[-1])
-        return checksum == int(ssn[-1])
+        mult_factors = cycle([2, 1])
+        final_sum = sum(self.partial_sum(int(char), mf) for char, mf in zip(ssn[:9], mult_factors))
+        chksum = -final_sum % 10
+        return chksum == int(ssn[-1])
 
     def validate_date_string(self, date_str):
         date_len = len(date_str)
@@ -65,6 +66,13 @@ class TestSvSE(unittest.TestCase):
         for _ in range(100):
             pers_id = self.factory.ssn()
             assert re.search(r'\d{6}-\d{4}', pers_id)
+            assert self.validate_date_string(pers_id[:6]) is True
+            assert self.ssn_checksum('19710820-2792') is True
+
+    def test_pers_id_short_no_dash(self):
+        for _ in range(100):
+            pers_id = self.factory.ssn(dash=False)
+            assert re.search(r'\d{6}\d{4}', pers_id)
             assert self.validate_date_string(pers_id[:6]) is True
             assert self.ssn_checksum(pers_id) is True
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -36,7 +36,7 @@ class TestSvSE(unittest.TestCase):
         """Validates the checksum digit and returns a Boolean"""
         ssn = ssn.replace('-', '')
         if len(ssn) == 12:
-            ssn = ssn[2:12]
+            ssn = ssn[2:]
         if len(ssn) != 10:
             return False
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -67,13 +67,27 @@ class TestSvSE(unittest.TestCase):
             pers_id = self.factory.ssn()
             assert re.search(r'\d{6}-\d{4}', pers_id)
             assert self.validate_date_string(pers_id[:6]) is True
-            assert self.ssn_checksum('19710820-2792') is True
+            assert self.ssn_checksum(pers_id) is True
 
     def test_pers_id_short_no_dash(self):
         for _ in range(100):
             pers_id = self.factory.ssn(dash=False)
-            assert re.search(r'\d{6}\d{4}', pers_id)
+            assert re.search(r'\d{10}', pers_id)
             assert self.validate_date_string(pers_id[:6]) is True
+            assert self.ssn_checksum(pers_id) is True
+
+    def test_pers_id_long_with_dash(self):
+        for _ in range(100):
+            pers_id = self.factory.ssn(long=True)
+            assert re.search(r'\d{8}-\d{4}', pers_id)
+            assert self.validate_date_string(pers_id[:8]) is True
+            assert self.ssn_checksum(pers_id) is True
+
+    def test_pers_id_long_no_dash(self):
+        for _ in range(100):
+            pers_id = self.factory.ssn(long=True, dash=False)
+            assert re.search(r'\d{12}', pers_id)
+            assert self.validate_date_string(pers_id[:8]) is True
             assert self.ssn_checksum(pers_id) is True
 
     def test_org_id(self):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -97,6 +97,15 @@ class TestSvSE(unittest.TestCase):
             assert int(org_id[2:4]) >= 20
             assert self.ssn_checksum(org_id) is True
 
+    def test_org_id_short_no_dash(self):
+        raise NotImplementedError("org short no dash not inplemented")
+
+    def test_org_id_long_with_dash(self):
+        raise NotImplementedError("org long with dash not inplemented")
+
+    def test_org_id_long_no_dash(self):
+        raise NotImplementedError("org long no dash not inplemented")
+
     def test_vat_id(self):
         raise NotImplementedError("Test for VAT (MOMS) ID not implemented")
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -111,7 +111,6 @@ class TestSvSE(unittest.TestCase):
             assert int(org_id[4:6]) >= 20
             assert self.ssn_checksum(org_id) is True
 
-
     def test_org_id_long_no_dash(self):
         for _ in range(100):
             org_id = self.factory.org_id(long=True, dash=False)
@@ -124,8 +123,13 @@ class TestSvSE(unittest.TestCase):
             vat_id = self.factory.vat_id()
             assert re.search(r'SE\d{12}', vat_id)
             assert int(vat_id[2]) in (1, 2, 3, 5, 6, 7, 8, 9)
-            assert int(vat_id[4:6]) >= 20
+            assert int(vat_id[6:8]) >= 20
 
+    def test_org_and_vat_id(self):
+        for _ in range(100):
+            oid, vid = self.factory.org_and_vat_id()
+            assert oid.replace('-','')[-10:] == vid[4:-2]
+            assert re.search(r'SE\d{12}', vid)
 
 class TestBgBG(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -90,8 +90,12 @@ class TestSvSE(unittest.TestCase):
             assert self.validate_date_string(pers_id[:8]) is True
             assert self.ssn_checksum(pers_id) is True
 
-    def test_org_id(self):
-        raise NotImplementedError("Test for organisation ID validation not implemented")
+    def test_org_id_short_with_dash(self):
+        for _ in range(100):
+            org_id = self.factory.org_id()
+            assert re.search(r'\d{6}-\d{4}', org_id)
+            assert int(org_id[2:4]) >= 20
+            assert self.ssn_checksum(org_id) is True
 
     def test_vat_id(self):
         raise NotImplementedError("Test for VAT (MOMS) ID not implemented")

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -23,6 +23,24 @@ from faker.providers.ssn.es_MX import (ssn_checksum as mx_ssn_checksum,
                                        curp_checksum as mx_curp_checksum)
 
 
+class TestSvSE(unittest.TestCase):
+    def setUp(self):
+        self.factory = Faker('sv_SE')
+
+    def ssn_checksum(ssn):
+        """Validates the checksum digit and returns a Boolean"""
+        pass
+
+    def test_pers_id(self):
+        raise NotImplementedError("Test for pers ID validation not implemented")
+
+    def test_org_id(self):
+        raise NotImplementedError("Test for organisation ID validation not implemented")
+
+    def test_vat_id(self):
+        raise NotImplementedError("Test for VAT (MOMS) ID not implemented")
+
+
 class TestBgBG(unittest.TestCase):
     def setUp(self):
         self.factory = Faker('bg_BG')

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -128,8 +128,9 @@ class TestSvSE(unittest.TestCase):
     def test_org_and_vat_id(self):
         for _ in range(100):
             oid, vid = self.factory.org_and_vat_id()
-            assert oid.replace('-','')[-10:] == vid[4:-2]
+            assert oid.replace('-', '')[-10:] == vid[4:-2]
             assert re.search(r'SE\d{12}', vid)
+
 
 class TestBgBG(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this changes

Changes to Swedish SSN and VAT routines. 

`ssn` now allows 2 parms - `long` (default `False`) and `dash` (default `True`)
`long=True` returns a 12 digit Personal number, including the century, instead of a 10 digit number
`dash=False` returns the Personal number without the hyphen

Default behaviour remains as is.

new method `org_id` returns a valid Swedish organisation number. The format is the similar to Personal number, but the rules for the numeric values are different. This allows the same `long` and `dash` parameters as `ssn`, with the same defaults.

`vat_id` has been amended to use the `org_id` functionality to generate the core number, and base the VAT (MOMS) ID on that. 

A new method `org_and_vat_id` returns a consistent organisation number and VAT ID (as is the case in reality). The `long` and `dash` parameters can be passed here too, but will only affect the org ID, not the VAT number.

### What was wrong

SSN was not incorrect, it has just been extended to be more flexible. 
Org ID was missing. 
VAT number was invalid format and  did not pass validation checks (except occasionally by accident)

### How this fixes it

See above


Closes #1005 