### PR TITLE
EsMX Unit Tests + few little fixes

### DIFF
--- a/faker/providers/address/es_MX/__init__.py
+++ b/faker/providers/address/es_MX/__init__.py
@@ -7,8 +7,8 @@ from ..es import Provider as AddressProvider
 
 class Provider(AddressProvider):
     city_prefixes = ('Sur', 'Norte')
-    city_adjetives = ('Nueva', 'Vieja')
-    city_suffixies = ('de la Montaña', 'los bajos', 'los altos')
+    city_adjectives = ('Nueva', 'Vieja')
+    city_suffixes = ('de la Montaña', 'los bajos', 'los altos')
     street_prefixes = (
         'Ampliación', 'Andador', 'Avenida', 'Boulevard', 'Calle', 'Callejón',
         'Calzada', 'Cerrada', 'Circuito', 'Circunvalación', 'Continuación',
@@ -75,7 +75,7 @@ class Provider(AddressProvider):
     ))
 
     city_formats = (
-        '{{city_adjetive}} {{country}}',
+        '{{city_adjective}} {{country}}',
         'San {{first_name}} {{city_suffix}}',
     )
     street_name_formats = (
@@ -97,10 +97,10 @@ class Provider(AddressProvider):
         return self.random_element(self.city_prefixes)
 
     def city_suffix(self):
-        return self.random_element(self.city_suffixies)
+        return self.random_element(self.city_suffixes)
 
-    def city_adjetive(self):
-        return self.random_element(self.city_adjetives)
+    def city_adjective(self):
+        return self.random_element(self.city_adjectives)
 
     def street_prefix(self):
         """

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -16,6 +16,7 @@ from faker.providers.address.en_AU import Provider as EnAuProvider
 from faker.providers.address.en_CA import Provider as EnCaProvider
 from faker.providers.address.en_US import Provider as EnUsProvider
 from faker.providers.address.es_ES import Provider as EsEsProvider
+from faker.providers.address.es_MX import Provider as EsMxProvider
 from faker.providers.address.fr_FR import Provider as FrFrProvider
 from faker.providers.address.fi_FI import Provider as FiProvider
 from faker.providers.address.hy_AM import Provider as HyAmProvider
@@ -439,6 +440,45 @@ class TestEsES(unittest.TestCase):
     def test_secondary_address(self):
         secondary_address = self.factory.secondary_address()
         assert isinstance(secondary_address, string_types)
+
+
+class TestEsMX(unittest.TestCase):
+    """ Tests the addresses in the es_MX locale """
+
+    def setUp(self):
+        self.factory = Faker('es_MX')
+
+    def test_city_prefix(self):
+        city_prefix = self.factory.city_prefix()
+        assert isinstance(city_prefix, string_types)
+        assert city_prefix in EsMxProvider.city_prefixes
+
+    def test_city_suffix(self):
+        city_suffix = self.factory.city_suffix()
+        assert isinstance(city_suffix, string_types)
+        assert city_suffix in EsMxProvider.city_suffixes
+
+    def test_city_adjective(self):
+        city_adjective = self.factory.city_adjective()
+        assert isinstance(city_adjective, string_types)
+        assert city_adjective in EsMxProvider.city_adjectives
+
+    def test_street_prefix(self):
+        street_prefix = self.factory.street_prefix()
+        assert isinstance(street_prefix, string_types)
+        assert street_prefix in EsMxProvider.street_prefixes
+
+    def test_secondary_address(self):
+        secondary_address = self.factory.secondary_address()
+        assert isinstance(secondary_address, string_types)
+
+    def test_state(self):
+        state = self.factory.state()
+        assert isinstance(state, string_types)
+
+    def test_state_abbr(self):
+        state_abbr = self.factory.state_abbr()
+        assert isinstance(state_abbr, string_types)
 
 
 class TestFaIR(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

- Adds unit tests for EsMX address provider
- Fixes couple of typos I caught when unit testing the module

### What was wrong

First of all, EsMX address provider required unit tests. Second, there was couple of typos which were caught:

- adjetives -> adjectives
- suffixies -> suffixes

### How this fixes it

- Adds the unit tests
- Fixes the typos in the module

All unit tests and flake8 lint passed locally. 
