### PR TITLE
Hide "Edit on Github" links in autogenerated pages

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,7 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+  {% if not meta or meta.get('github_url') != 'hide' %}
+  {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/faker/build_docs.py
+++ b/faker/build_docs.py
@@ -61,9 +61,11 @@ def write_docs(*args, **kwargs):
         provider_name = doc.get_provider_name(provider)
         fname = os.path.join(DOCS_ROOT, 'providers', '%s.rst' % provider_name)
         with open(fname, 'wb') as fh:
+            write(fh, ':github_url: hide\n\n')
             write_provider(fh, doc, provider, fakers)
 
     with open(os.path.join(DOCS_ROOT, 'providers.rst'), 'wb') as fh:
+        write(fh, ':github_url: hide\n\n')
         write(fh, 'Providers\n')
         write(fh, '=========\n')
         write(fh, '.. toctree::\n')
@@ -75,7 +77,7 @@ def write_docs(*args, **kwargs):
     for lang in AVAILABLE_LOCALES:
         fname = os.path.join(DOCS_ROOT, 'locales', '%s.rst' % lang)
         with open(fname, 'wb') as fh:
-            write(fh, '\n')
+            write(fh, ':github_url: hide\n\n')
             title = 'Language {0}\n'.format(lang)
             write(fh, title)
             write(fh, '=' * len(title))
@@ -89,6 +91,7 @@ def write_docs(*args, **kwargs):
                 write_provider(fh, d, p, fs)
 
     with open(os.path.join(DOCS_ROOT, 'locales.rst'), 'wb') as fh:
+        write(fh, ':github_url: hide\n\n')
         write(fh, 'Locales\n')
         write(fh, '=======\n')
         write(fh, '.. toctree::\n')


### PR DESCRIPTION
### What does this change

This removes the "Edit on Github" links found in the autogenerated docs under providers and locales without affecting pages with actual sources in Github.

### What was wrong

The docs imply that the source .rst files will be available in Github, but clicking on those links will lead to a 404.

### How this fixes it

Basically, we set the `github_url` file-level metadata to a certain value (in this case `hide`), and then we extend the default `breadcrumbs.html` template of `sphinx_rtd_theme` to check for that value. If the value of `github_url` is set to `hide`, we skip the default template processing for that `block`, effectively disabling the link for that page. Otherwise, it would proceed as it normally would. Reference material used can be found [here](https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html) and [here](https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html#confval-github_url), and see it in action [here](https://maleficefakertest.readthedocs.io/en/issue-264/index.html).

Fixes #264 