### PR TITLE
Optimize IPv4 address generation

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -10,6 +10,7 @@ from ipaddress import ip_address, ip_network, IPV4LENGTH, IPV6LENGTH
 # from faker.generator import random
 # from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import lowercase, slugify, slugify_unicode
+from faker.utils.distribution import choices_distribution
 
 
 localized = True
@@ -29,12 +30,6 @@ class _IPv4Constants:
         'c': ip_network('192.0.0.0/3'),
     }
 
-    _linklocal_network = ip_network('169.254.0.0/16')
-
-    _loopback_network = ip_network('127.0.0.0/8')
-
-    _multicast_network = ip_network('224.0.0.0/4')
-
     # Three common private networks from class A, B and CIDR
     # to generate private addresses from.
     _private_networks = [
@@ -49,8 +44,8 @@ class _IPv4Constants:
     _excluded_networks = [
         ip_network('0.0.0.0/8'),
         ip_network('100.64.0.0/10'),
-        ip_network('127.0.0.0/8'),
-        ip_network('169.254.0.0/16'),
+        ip_network('127.0.0.0/8'),  # loopback network
+        ip_network('169.254.0.0/16'),  # linklocal network
         ip_network('192.0.0.0/24'),
         ip_network('192.0.2.0/24'),
         ip_network('192.31.196.0/24'),
@@ -60,12 +55,9 @@ class _IPv4Constants:
         ip_network('198.18.0.0/15'),
         ip_network('198.51.100.0/24'),
         ip_network('203.0.113.0/24'),
+        ip_network('224.0.0.0/4'),  # multicast network
         ip_network('240.0.0.0/4'),
         ip_network('255.255.255.255/32'),
-    ] + [
-        _linklocal_network,
-        _loopback_network,
-        _multicast_network,
     ]
 
 
@@ -251,14 +243,123 @@ class Provider(BaseProvider):
 
         return self.generator.parse(pattern)
 
-    def _random_ipv4_address_from_subnet(self, subnet, network=False):
+    def _get_all_networks_and_weights(self, address_class=None):
+        """
+        Produces a 2-tuple of valid IPv4 networks and corresponding relative weights
+
+        :param address_class: IPv4 address class (a, b, or c)
+        """
+        # If `address_class` has an unexpected value, use the whole IPv4 pool
+        if address_class in _IPv4Constants._network_classes.keys():
+            networks_attr = '_cached_all_class_{}_networks'.format(address_class)
+            all_networks = [_IPv4Constants._network_classes[address_class]]
+        else:
+            networks_attr = '_cached_all_networks'
+            all_networks = [ip_network('0.0.0.0/0')]
+
+        # Return cached network and weight data if available
+        weights_attr = '{}_weights'.format(networks_attr)
+        if hasattr(self, networks_attr) and hasattr(self, weights_attr):
+            return getattr(self, networks_attr), getattr(self, weights_attr)
+
+        # Otherwise, compute for list of networks (excluding special networks)
+        all_networks = self._exclude_ipv4_networks(
+            all_networks,
+            _IPv4Constants._excluded_networks,
+        )
+
+        # Then compute for list of corresponding relative weights
+        weights = [network.num_addresses for network in all_networks]
+
+        # Then cache and return results
+        setattr(self, networks_attr, all_networks)
+        setattr(self, weights_attr, weights)
+        return all_networks, weights
+
+    def _get_private_networks_and_weights(self, address_class=None):
+        """
+        Produces an OrderedDict of valid private IPv4 networks and corresponding relative weights
+
+        :param address_class: IPv4 address class (a, b, or c)
+        """
+        # If `address_class` has an unexpected value, choose a valid value at random
+        if address_class not in _IPv4Constants._network_classes.keys():
+            address_class = self.ipv4_network_class()
+
+        # Return cached network and weight data if available for a specific address class
+        networks_attr = '_cached_private_class_{}_networks'.format(address_class)
+        weights_attr = '{}_weights'.format(networks_attr)
+        if hasattr(self, networks_attr) and hasattr(self, weights_attr):
+            return getattr(self, networks_attr), getattr(self, weights_attr)
+
+        # Otherwise, compute for list of private networks (excluding special networks)
+        supernet = _IPv4Constants._network_classes[address_class]
+        private_networks = [
+            subnet for subnet in _IPv4Constants._private_networks
+            if subnet.overlaps(supernet)
+        ]
+        private_networks = self._exclude_ipv4_networks(
+            private_networks,
+            _IPv4Constants._excluded_networks,
+        )
+
+        # Then compute for list of corresponding relative weights
+        weights = [network.num_addresses for network in private_networks]
+
+        # Then cache and return results
+        setattr(self, networks_attr, private_networks)
+        setattr(self, weights_attr, weights)
+        return private_networks, weights
+
+    def _get_public_networks_and_weights(self, address_class=None):
+        """
+        Produces a 2-tuple of valid public IPv4 networks and corresponding relative weights
+
+        :param address_class: IPv4 address class (a, b, or c)
+        """
+        # If `address_class` has an unexpected value, choose a valid value at random
+        if address_class not in _IPv4Constants._network_classes.keys():
+            address_class = self.ipv4_network_class()
+
+        # Return cached network and weight data if available for a specific address class
+        networks_attr = '_cached_public_class_{}_networks'.format(address_class)
+        weights_attr = '{}_weights'.format(networks_attr)
+        if hasattr(self, networks_attr) and hasattr(self, weights_attr):
+            return getattr(self, networks_attr), getattr(self, weights_attr)
+
+        # Otherwise, compute for list of public networks (excluding private and special networks)
+        public_networks = [_IPv4Constants._network_classes[address_class]]
+        public_networks = self._exclude_ipv4_networks(
+            public_networks,
+            _IPv4Constants._private_networks +
+            _IPv4Constants._excluded_networks,
+        )
+
+        # Then compute for list of corresponding relative weights
+        weights = [network.num_addresses for network in public_networks]
+
+        # Then cache and return results
+        setattr(self, networks_attr, public_networks)
+        setattr(self, weights_attr, weights)
+        return public_networks, weights
+
+    def _random_ipv4_address_from_subnets(self, subnets, weights=None, network=False):
         """
         Produces a random IPv4 address or network with a valid CIDR
-        from within a given subnet.
+        from within the given subnets using a distribution described
+        by weights.
 
-        :param subnet: IPv4Network to choose from within
+        :param subnets: List of IPv4Networks to choose from within
+        :param weights: List of weights corresponding to the individual IPv4Networks
         :param network: Return a network address, and not an IP address
+        :return:
         """
+        # If the weights argument has an invalid value, default to equal distribution
+        try:
+            subnet = choices_distribution(subnets, weights, random=self.generator.random, length=1)[0]
+        except (AssertionError, TypeError):
+            subnet = self.generator.random.choice(subnets)
+
         address = str(
             subnet[self.generator.random.randint(
                 0, subnet.num_addresses - 1,
@@ -283,6 +384,7 @@ class Provider(BaseProvider):
         :param networks_to_exclude: List of IPv4 networks to exclude
         :returns: Flat list of IPv4 networks
         """
+        networks_to_exclude.sort(key=lambda x: x.prefixlen)
         for network_to_exclude in networks_to_exclude:
             def _exclude_ipv4_network(network):
                 """
@@ -327,7 +429,7 @@ class Provider(BaseProvider):
 
     def ipv4(self, network=False, address_class=None, private=None):
         """
-        Produce a random IPv4 address or network with a valid CIDR.
+        Returns a random IPv4 address or network with a valid CIDR.
 
         :param network: Network address
         :param address_class: IPv4 address class (a, b, or c)
@@ -340,25 +442,9 @@ class Provider(BaseProvider):
         elif private is False:
             return self.ipv4_public(address_class=address_class,
                                     network=network)
-
-        # if neither private nor public is required explicitly,
-        # generate from whole requested address space
-        if address_class:
-            all_networks = [_IPv4Constants._network_classes[address_class]]
         else:
-            # if no address class is choosen, use whole IPv4 pool
-            all_networks = [ip_network('0.0.0.0/0')]
-
-        # exclude special networks
-        all_networks = self._exclude_ipv4_networks(
-            all_networks,
-            _IPv4Constants._excluded_networks,
-        )
-
-        # choose random network from the list
-        random_network = self.generator.random.choice(all_networks)
-
-        return self._random_ipv4_address_from_subnet(random_network, network)
+            all_networks, weights = self._get_all_networks_and_weights(address_class=address_class)
+            return self._random_ipv4_address_from_subnets(all_networks, weights=weights, network=network)
 
     def ipv4_private(self, network=False, address_class=None):
         """
@@ -368,26 +454,8 @@ class Provider(BaseProvider):
         :param address_class: IPv4 address class (a, b, or c)
         :returns: Private IPv4
         """
-        # compute private networks from given class
-        supernet = _IPv4Constants._network_classes[
-            address_class or self.ipv4_network_class()
-        ]
-
-        private_networks = [
-            subnet for subnet in _IPv4Constants._private_networks
-            if subnet.overlaps(supernet)
-        ]
-
-        # exclude special networks
-        private_networks = self._exclude_ipv4_networks(
-            private_networks,
-            _IPv4Constants._excluded_networks,
-        )
-
-        # choose random private network from the list
-        private_network = self.generator.random.choice(private_networks)
-
-        return self._random_ipv4_address_from_subnet(private_network, network)
+        private_networks, weights = self._get_private_networks_and_weights(address_class=address_class)
+        return self._random_ipv4_address_from_subnets(private_networks, weights=weights, network=network)
 
     def ipv4_public(self, network=False, address_class=None):
         """
@@ -397,22 +465,8 @@ class Provider(BaseProvider):
         :param address_class: IPv4 address class (a, b, or c)
         :returns: Public IPv4
         """
-        # compute public networks
-        public_networks = [_IPv4Constants._network_classes[
-            address_class or self.ipv4_network_class()
-        ]]
-
-        # exclude private and excluded special networks
-        public_networks = self._exclude_ipv4_networks(
-            public_networks,
-            _IPv4Constants._private_networks +
-            _IPv4Constants._excluded_networks,
-        )
-
-        # choose random public network from the list
-        public_network = self.generator.random.choice(public_networks)
-
-        return self._random_ipv4_address_from_subnet(public_network, network)
+        public_networks, weights = self._get_public_networks_and_weights(address_class=address_class)
+        return self._random_ipv4_address_from_subnets(public_networks, weights=weights, network=network)
 
     def ipv6(self, network=False):
         """Produce a random IPv6 address or network with a valid CIDR"""


### PR DESCRIPTION
### What does this change

Reduce IPv4 address generation time by around 33%. Using the master branch, the command below ran for 17.811s, and with the changes, it ran for 11.458s, a 6.353s reduction.

`time python -c 'import faker; fake = faker.Faker(); [fake.ipv4() for _ in range(1000)]'`

### What was wrong

Slow according to some reports

### How this fixes it

Short of using a totally different algorithm in the `_exclude_ipv4_networks` method (which I think is already pretty good), there are still some ways to speed the current algorithm up. One way is to remove the duplicates and the concatenation performed in the decalaration of `_excluded_networks`.   Another is to sort `networks_to_exclude` to exclude larger networks first i.e. networks with smaller prefix lengths. With how `_exclude_ipv4_networks` is written, when larger networks are excluded first, the resulting list of networks to check in the next iteration is guaranteed to be smaller, and that in turn leads to fewer overall operations.

### Other notes

Admittedly, there is a better way, and that is to generate the network lists only once per provider instantiation, and we can make probably do some sort of lazy loading to only create the relevant network list when needed. The bulk of the execution time is in the generation of the network lists, and we can make subsequent runs faster but with higher memory usage. If that is an acceptable approach, I can update this pull request.

Fixes #845 