### PR TITLE
Create separate docs on base provider methods

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -22,7 +22,6 @@ class Documentor(object):
         self.already_generated = []
 
     def get_formatters(self, locale=None, excludes=None, **kwargs):
-
         self.max_name_len = 0
         self.already_generated = [] if excludes is None else excludes[:]
         formatters = []


### PR DESCRIPTION
### What does this change

Create separate docs on base provider methods

### What was wrong

Base provider methods are always documented under the 1st provider module which is currently `address`. This is not only "unsemantic" but it can also give the impression that the base provider methods are not documented.

### How this fixes it

This patch will write a new source file just for the base provider, and then exclude the base provider methods for subsequent provider modules. See it in action [here](https://maleficefakertest.readthedocs.io/en/issue-832/providers.html).

Fixes #642, fixes #832 .
