### PR TITLE
Fix occasional errors in isbn provider

### DIFF
--- a/faker/providers/isbn/__init__.py
+++ b/faker/providers/isbn/__init__.py
@@ -52,7 +52,7 @@ class Provider(BaseProvider):
         :returns: A (registrant, publication) tuple of strings.
         """
         for rule in rules:
-            if rule.min <= reg_pub <= rule.max:
+            if rule.min <= reg_pub[:-1] <= rule.max:
                 reg_len = rule.registrant_length
                 break
         else:

--- a/tests/providers/test_isbn.py
+++ b/tests/providers/test_isbn.py
@@ -43,8 +43,13 @@ class TestProvider(unittest.TestCase):
     def test_reg_pub_separation(self):
         r1 = RegistrantRule('0000000', '0000001', 1)
         r2 = RegistrantRule('0000002', '0000003', 2)
-        assert self.prov._registrant_publication('0000000', [r1, r2]) == ('0', '000000')
-        assert self.prov._registrant_publication('0000002', [r1, r2]) == ('00', '00002')
+        assert self.prov._registrant_publication('00000000', [r1, r2]) == ('0', '0000000')
+        assert self.prov._registrant_publication('00000010', [r1, r2]) == ('0', '0000010')
+        assert self.prov._registrant_publication('00000019', [r1, r2]) == ('0', '0000019')
+        assert self.prov._registrant_publication('00000020', [r1, r2]) == ('00', '000020')
+        assert self.prov._registrant_publication('00000030', [r1, r2]) == ('00', '000030')
+        assert self.prov._registrant_publication('00000031', [r1, r2]) == ('00', '000031')
+        assert self.prov._registrant_publication('00000039', [r1, r2]) == ('00', '000039')
 
     def test_rule_not_found(self):
         with pytest.raises(Exception):


### PR DESCRIPTION
### What does this changes

This will fix errors that may pop up when generating ISBN's. 

### What was wrong

The problem lies [here](https://github.com/joke2k/faker/blob/fd041439e5096290ee33cf2eb9f2576f3506c985/faker/providers/isbn/__init__.py#L55). The values for `rule.min` and `rule.max` are 7-digit strings, while the value of `reg_pub` is an 8-digit string. The line is comparing the values of strings, so if `rule.max` is `0000009`, any 8 digit string that starts with `0000009` will automatically be invalid, triggering the exception.

An interesting side effect of this string comparison is that a string of any length, as long as it starts with 6 zeroes and then any number from 0 to 8, will pass the check e.g. `0000008123456789foobar`.

### How this fixes it

Just compare the first 7 digits of `reg_pub`.

Fixes #655
