### PR TITLE
Add support for token-based string generation

### DIFF
--- a/faker/generator.py
+++ b/faker/generator.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import random as random_module
 import re
+import six
 
 _re_token = re.compile(r'\{\{(\s?)(\w+)(\s?)\}\}')
 random = random_module.Random()
@@ -108,5 +109,5 @@ class Generator(object):
 
     def __format_token(self, matches):
         formatter = list(matches.groups())
-        formatter[1] = str(self.format(formatter[1]))
+        formatter[1] = six.text_type(self.format(formatter[1]))
         return ''.join(formatter)

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -108,5 +108,5 @@ class Generator(object):
 
     def __format_token(self, matches):
         formatter = list(matches.groups())
-        formatter[1] = self.format(formatter[1])
+        formatter[1] = str(self.format(formatter[1]))
         return ''.join(formatter)

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
+import string
 import sys
 
 import six
@@ -31,6 +32,9 @@ class Provider(BaseProvider):
                     length=self.generator.random.randint(min_chars, max_chars),
                 ),
             )
+
+    def pystr_format(self, string_format='?#-###{{random_int}}{{random_letter}}', letters=string.ascii_letters):
+        return self.bothify(self.generator.parse(string_format), letters=letters)
 
     def pyfloat(self, left_digits=None, right_digits=None, positive=False,
                 min_value=None, max_value=None):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -1,6 +1,11 @@
 #  -*- coding: utf-8 -*-
 
+from importlib import import_module
 import unittest
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from faker import Faker
 
@@ -87,3 +92,19 @@ class TestPyfloat(unittest.TestCase):
 
         message = str(raises.exception)
         self.assertEqual(message, expected_message)
+
+
+class TestPystrFormat(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = Faker(includes=['tests.mymodule.en_US'])
+
+    def test_formatter_invocation(self):
+        with patch.object(self.factory, 'foo') as mock_foo:
+            with patch('faker.providers.BaseProvider.bothify',
+                       wraps=self.factory.bothify) as mock_bothify:
+                mock_foo.return_value = 'barbar'
+                value = self.factory.pystr_format('{{foo}}?#?{{foo}}?#?{{foo}}', letters='abcde')
+                assert value.count('barbar') == 3
+                assert mock_foo.call_count == 3
+                mock_bothify.assert_called_once_with('barbar?#?barbar?#?barbar', letters='abcde')

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -1,6 +1,5 @@
 #  -*- coding: utf-8 -*-
 
-from importlib import import_module
 import unittest
 try:
     from unittest.mock import patch


### PR DESCRIPTION
### What does this change

Strings may now be generated from numerify, lexify, and provider method tokens, e.g. `{{address}} {{random_int}}????###`

### What was wrong

There was none.

Fixes #362 fixes #550  
