### PR TITLE
Fix pyfloat out of min/max range

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -61,9 +61,9 @@ class Provider(BaseProvider):
         sign = ''
         if (min_value is not None) or (max_value is not None):
             if max_value is not None and max_value < 0:
-                max_value += 1 # as the random_int will be generated up to max_value - 1
+                max_value += 1  # as the random_int will be generated up to max_value - 1
             if min_value is not None and min_value < 0:
-                min_value += 1 # as we then append digits after the left_number
+                min_value += 1  # as we then append digits after the left_number
             left_number = self._safe_random_int(min_value, max_value)
         else:
             sign = '+' if positive else self.random_element(('+', '-'))

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -60,6 +60,10 @@ class Provider(BaseProvider):
             self.random_int(0, sys.float_info.dig - left_digits))
         sign = ''
         if (min_value is not None) or (max_value is not None):
+            if max_value < 0:
+                max_value += 1 # as the random_int will be generated up to max_value - 1
+            if min_value < 0:
+                min_value += 1 # as we then append digits after the left_number
             left_number = self._safe_random_int(min_value, max_value)
         else:
             sign = '+' if positive else self.random_element(('+', '-'))

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -60,9 +60,9 @@ class Provider(BaseProvider):
             self.random_int(0, sys.float_info.dig - left_digits))
         sign = ''
         if (min_value is not None) or (max_value is not None):
-            if max_value < 0:
+            if max_value is not None and max_value < 0:
                 max_value += 1 # as the random_int will be generated up to max_value - 1
-            if min_value < 0:
+            if min_value is not None and min_value < 0:
                 min_value += 1 # as we then append digits after the left_number
             left_number = self._safe_random_int(min_value, max_value)
         else:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -476,13 +476,19 @@ class FactoryTestCase(unittest.TestCase):
 
         for i in range(20):
             for min_value,max_value in [
-                (0,1),
-                (-1,1),
+                (0, 1),
+                (-1, 1),
+                (None, -5),
+                (-5, None),
+                (None, 5),
+                (5, None),
             ]:
                 factory.seed_instance(i)
                 result = factory.pyfloat(min_value=min_value, max_value=max_value)
-                assert result >= min_value
-                assert result <= max_value
+                if min_value is not None:
+                    assert result >= min_value
+                if max_value is not None:
+                    assert result <= max_value
 
     def test_negative_pyfloat(self):
         # tests for https://github.com/joke2k/faker/issues/813

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -475,7 +475,7 @@ class FactoryTestCase(unittest.TestCase):
         factory = Faker()
 
         for i in range(20):
-            for min_value,max_value in [
+            for min_value, max_value in [
                 (0, 1),
                 (-1, 1),
                 (None, -5),

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -474,11 +474,15 @@ class FactoryTestCase(unittest.TestCase):
         # tests for https://github.com/joke2k/faker/issues/994
         factory = Faker()
 
-        factory.seed_instance(5)
-        result = factory.pyfloat(min_value=0, max_value=1)
-
-        assert result >= 0.0
-        assert result <= 1.0
+        for i in range(20):
+            for min_value,max_value in [
+                (0,1),
+                (-1,1),
+            ]:
+                factory.seed_instance(i)
+                result = factory.pyfloat(min_value=min_value, max_value=max_value)
+                assert result >= min_value
+                assert result <= max_value
 
     def test_negative_pyfloat(self):
         # tests for https://github.com/joke2k/faker/issues/813


### PR DESCRIPTION
Ensure that pyfloat stays within range defined by min max

### What does this changes

Add tests, and shift min and max when they are negative

### What was wrong

When min was lower than 0, former code generated values between [min-1; max], so did for max

### How this fixes it

 * When the min is lower than `0`, we increase it of one (`-6` -> `-5`) as digits are appended later
 * When the max is lower than `0`, we increase it of one (`-6` -> `-5`) as the number before the comma is generated up to `max - 1`