### PR TITLE
Fix Python3.5 appveyor build failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,5 +44,6 @@ test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
   - "%PYTHON%/Scripts/pip.exe freeze"
   - "%PYTHON%/python.exe --version"
+  - "%PYTHON%/Scripts/pip.exe install -U setuptools"
   - "%PYTHON%/Scripts/pip.exe install \"importlib-metadata>=0.12\""
   - "%PYTHON%/python.exe setup.py test"


### PR DESCRIPTION
### What does this change

Fix all the Windows Python 3.5 build failures in appveyor

### What was wrong

The Windows Python 3.5 builds started failing after `python-dateutils` package released `2.8.1`. In the `2.8.1` release, many of the package metadata were moved from `setup.py` to other files like `setup.cfg`. This kind of setup is only supported by newer versions of `setuptools`, and unfortunately, the version bundled with the Windows Python 3.5 images is `28.8.0` which is more than 3 years old.

### How this fixes it

Just upgrade `setuptools` as part of the build process.
