### PR TITLE
Add provider methods for dsv files

### DIFF
--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -1,12 +1,19 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+import csv
 import io
+import itertools
 import tarfile
 import unittest
 import uuid
 import zipfile
 import six
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from faker import Faker
 
@@ -354,3 +361,152 @@ class TestMisc(unittest.TestCase):
                     uncompressed_size=uncompressed_size, num_files=num_files,
                     min_file_size=min_file_size, compression=compression,
                 )
+
+    def test_dsv_with_invalid_values(self):
+        with self.assertRaises(ValueError):
+            self.factory.dsv(num_rows='1')
+
+        with self.assertRaises(ValueError):
+            self.factory.dsv(num_rows=0)
+
+        with self.assertRaises(TypeError):
+            self.factory.dsv(header=None, data_columns=1)
+
+        with self.assertRaises(TypeError):
+            self.factory.dsv(header=1, data_columns=['???'])
+
+        with self.assertRaises(ValueError):
+            self.factory.dsv(header=['Column 1', 'Column 2'], data_columns=['???'])
+
+    def test_dsv_no_header(self):
+        Faker.seed(0)
+        data_columns = ['????', '?????']
+        for _ in range(10):
+            num_rows = self.factory.random.randint(1, 1000)
+            dsv = self.factory.dsv(header=None, data_columns=data_columns, num_rows=num_rows)
+            reader = csv.reader(six.StringIO(dsv), dialect='faker-csv')
+
+            # Verify each row has correct number of columns
+            for row in reader:
+                assert len(row) == len(data_columns)
+
+            # Verify correct number of lines read
+            assert reader.line_num == num_rows
+
+    def test_dsv_with_valid_header(self):
+        Faker.seed(0)
+        header = ['Column 1', 'Column 2']
+        data_columns = ['????', '?????']
+        for _ in range(10):
+            num_rows = self.factory.random.randint(1, 1000)
+            dsv = self.factory.dsv(header=header, data_columns=data_columns, num_rows=num_rows)
+            reader = csv.reader(six.StringIO(dsv), dialect='faker-csv')
+
+            # Verify each row has correct number of columns
+            for row in reader:
+                assert len(row) == len(data_columns)
+
+            # Verify correct number of lines read (additional header row)
+            assert reader.line_num == num_rows + 1
+
+    def test_dsv_with_row_ids(self):
+        Faker.seed(0)
+        data_columns = ['????', '?????']
+        for _ in range(10):
+            counter = 0
+            num_rows = self.factory.random.randint(1, 1000)
+            dsv = self.factory.dsv(
+                header=None, data_columns=data_columns,
+                num_rows=num_rows, include_row_ids=True,
+            )
+            reader = csv.reader(six.StringIO(dsv), dialect='faker-csv')
+
+            # Verify each row has correct number of columns
+            # and row ids increment correctly
+            for row in reader:
+                assert len(row) == len(data_columns) + 1
+                counter += 1
+                assert row[0] == str(counter)
+
+            # Verify correct number of lines read
+            assert reader.line_num == num_rows
+
+    def test_dsv_data_columns(self):
+        num_rows = 10
+        data_columns = ['{{name}}', '#??-####', '{{address}}', '{{phone_number}}']
+        with patch.object(self.factory['en_US'], 'pystr_format') as mock_pystr_format:
+            mock_pystr_format.assert_not_called()
+            self.factory.dsv(data_columns=data_columns, num_rows=num_rows)
+
+            # pystr_format will be called for each data column and each row
+            calls = mock_pystr_format.call_args_list
+            assert len(calls) == num_rows * len(data_columns)
+
+            # Elements in data_columns will be used in sequence per row generation cycle
+            column_cycle = itertools.cycle(data_columns)
+            for args, kwargs in calls:
+                assert args[0] == next(column_cycle)
+                assert kwargs == {}
+
+    def test_dsv_csvwriter_kwargs(self):
+        data_keys = ['header', 'data_columns', 'num_rows', 'include_row_ids']
+        test_kwargs = {
+            'dialect': 'excel',
+            'header': ['Column 1', 'Column 2'],
+            'data_columns': ['????', '?????'],
+            'num_rows': 5,
+            'include_row_ids': True,
+            'delimiter': ';',
+            'invalid_kwarg': 'invalid_value',
+        }
+        with patch('faker.providers.misc.csv.writer') as mock_writer:
+            mock_writer.assert_not_called()
+            self.factory.dsv(**test_kwargs)
+            assert mock_writer.call_count == 1
+
+            # Remove all data generation kwargs
+            for key in data_keys:
+                del test_kwargs[key]
+
+            # Verify csv.writer was called with the remaining kwargs
+            for args, kwargs in mock_writer.call_args_list:
+                assert kwargs == test_kwargs
+
+    def test_csv_helper_method(self):
+        kwargs = {
+            'header': ['Column 1', 'Column 2'],
+            'data_columns': ['????', '?????'],
+            'num_rows': 5,
+            'include_row_ids': True,
+        }
+        with patch('faker.providers.misc.Provider.dsv') as mock_dsv:
+            mock_dsv.assert_not_called()
+            self.factory.csv(**kwargs)
+            kwargs['delimiter'] = ','
+            mock_dsv.assert_called_once_with(**kwargs)
+
+    def test_tsv_helper_method(self):
+        kwargs = {
+            'header': ['Column 1', 'Column 2'],
+            'data_columns': ['????', '?????'],
+            'num_rows': 5,
+            'include_row_ids': True,
+        }
+        with patch('faker.providers.misc.Provider.dsv') as mock_dsv:
+            mock_dsv.assert_not_called()
+            self.factory.tsv(**kwargs)
+            kwargs['delimiter'] = '\t'
+            mock_dsv.assert_called_once_with(**kwargs)
+
+    def test_psv_helper_method(self):
+        kwargs = {
+            'header': ['Column 1', 'Column 2'],
+            'data_columns': ['????', '?????'],
+            'num_rows': 5,
+            'include_row_ids': True,
+        }
+        with patch('faker.providers.misc.Provider.dsv') as mock_dsv:
+            mock_dsv.assert_not_called()
+            self.factory.psv(**kwargs)
+            kwargs['delimiter'] = '|'
+            mock_dsv.assert_called_once_with(**kwargs)


### PR DESCRIPTION
### What does this change

Allows generation of delimiter-separated values with a mostly same API to `csv.writer`

Related to #603 