### PR TITLE
Decrease zip and tar dummy length

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -50,6 +50,11 @@ class Documentor(object):
 
             if name == 'binary':
                 faker_kwargs['length'] = 1024
+            elif name in ['zip', 'tar']:
+                faker_kwargs.update({
+                    'uncompressed_size': 1024,
+                    'min_file_size': 512,
+                })
 
             if with_args:
                 # retrieve all parameter


### PR DESCRIPTION
### What does this change

This will decrease the zip and tar dummy sample lengths.

### What was wrong

The zip and tar dummy samples in the [docs](https://faker.readthedocs.io/en/master/providers/faker.providers.misc.html) are still horribly long (visually), even at only the 64KiB default.

### How this fixes it

This uses the same technique in #529 where the default size is changed for the specific methods.

Note:
The tar output is still noticeably longer than the zip output even with this fix, but I am afraid there is nothing I can do about it (short of writing a custom tar implementation). The `tarfile` module of the standard library is [hardcoded](https://github.com/python/cpython/blob/e9df88e8e9ce8e5a6be30dd1d06bc76b8e9f0fdc/Lib/tarfile.py#L1767) to use a blocking factor of 20, i.e. (`tar -b20`). This means the minimum size will always be 20 * 512 bytes = 10KiB regardless of how small the uncompressed total file sizes are. You can view the sample docs [here](https://maleficefakertest.readthedocs.io/en/ziptar-docfix/providers/faker.providers.misc.html).