### PR TITLE
Remove parenthesis from German city name

### DIFF
--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -71,7 +71,7 @@ class Provider(AddressProvider):
         'Kötzting', 'Leipziger Land', 'Lemgo', 'Lichtenfels', 'Lippstadt',
         'Lobenstein', 'Luckau', 'Luckenwalde', 'Ludwigsburg', 'Ludwigslust',
         'Lörrach', 'Lübben', 'Lübeck', 'Lübz', 'Lüdenscheid', 'Lüdinghausen',
-        'Lüneburg', 'Magdeburg', 'Main-Höchst)', 'Mainburg', 'Malchin',
+        'Lüneburg', 'Magdeburg', 'Main-Höchst', 'Mainburg', 'Malchin',
         'Mallersdorf', 'Marienberg', 'Marktheidenfeld', 'Mayen', 'Meiningen',
         'Meißen', 'Melle', 'Mellrichstadt', 'Melsungen', 'Meppen', 'Merseburg',
         'Mettmann', 'Miesbach', 'Miltenberg', 'Mittweida', 'Moers', 'Monschau',


### PR DESCRIPTION
### What does this changes

There was a random parenthesis in one of the German city names that didn't belong.

### What was wrong

There was a city called "Main-Höchst)"

### How this fixes it

Removed paren, change it to be just "Main-Höchst"
