### PR TITLE
Add identity number for tr_TR

### DIFF
--- a/faker/providers/ssn/tr_TR/__init__.py
+++ b/faker/providers/ssn/tr_TR/__init__.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from .. import Provider as BaseProvider
+
+
+class Provider(BaseProvider):
+    # Source:
+    # Turkey Republic National Number is identity number.
+    # Identity number contains 11 numbers,
+    # First number can't be zero
+    # Eleventh number is result of division after sum first number
+
+    def ssn(self):
+        """
+        :example '89340691651'
+        """
+        first_part = self.random_element((1, 2, 3, 4, 5, 6, 7, 8, 9))
+        middle_part = self.bothify('#########')
+        last_part = sum(list(map(lambda x: int(x), '{0}{1}'.format(first_part, middle_part)))) % 10
+        return '{}{}{}'.format(first_part, middle_part, last_part)

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -876,11 +876,12 @@ class TestTlPh(TestEnPh):
 
 
 class TestTrTr(unittest.TestCase):
-    num_sample_runs = 1000
+    num_sample_runs = 10
 
-    def setup_factory(self):
-        self.factory = Faker('tr_TR')
-        self.samples = [self.factory.ssn() for _ in range(self.num_sample_runs)]
+    def setUp(self):
+        self.fake = Faker('tr_TR')
+        self.samples = [self.fake.ssn() for _ in range(self.num_sample_runs)]
+        Faker.seed(0)
 
     def first_part_non_zero(self):
         for sample in self.samples:

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -873,3 +873,21 @@ class TestTlPh(TestEnPh):
     def setup_faker(self):
         self.fake = Faker('tl_PH')
         Faker.seed(0)
+
+
+class TestTrTr(unittest.TestCase):
+    num_sample_runs = 1000
+
+    def setup_factory(self):
+        self.factory = Faker('tr_TR')
+        self.samples = [self.factory.ssn() for _ in range(self.num_sample_runs)]
+
+    def first_part_non_zero(self):
+        for sample in self.samples:
+            assert sample[0] != 0
+
+    def compare_first_ten_and_last_part(self):
+        for sample in self.samples:
+            first_ten_number = sample[:-1]
+            last_part = sample[-1]
+            assert sum(list(map(lambda x: int(x), '{0}'.format(first_ten_number)))) % 10 == last_part


### PR DESCRIPTION
### What does this changes

Adds valid identity number generator for Turkish people. (ssn)

### What was wrong

When someone try to get turkish identity number, generator was create invalid identity number.

### How this fixes it

The government of Turkey use unique identity number for all citizen, these numbers creates with pattern. Pattern is: 

-  Identity number contains 11 numbers,
-  First number can't be zero
-  Eleventh number is result of division after sum first 10 number