### PR TITLE
Test Suite Housekeeping (Part 2)

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -108,9 +108,6 @@ class Faker(object):
         :return: A factory that supports the provider method
         """
 
-        if len(self._factories) == 1:
-            return self._factories[0]
-
         factories, weights = self._map_provider_method(method_name)
         if len(factories) == 0:
             msg = "No generator object has attribute '{}'".format(method_name)

--- a/tests/providers/test_barcode.py
+++ b/tests/providers/test_barcode.py
@@ -33,6 +33,12 @@ class TestBarcodeProvider(unittest.TestCase):
             assert (sum(ean8_digits) + 2 * sum(ean8_digits[::2])) % 10 == 0
             assert (sum(ean13_digits) + 2 * sum(ean13_digits[1::2])) % 10 == 0
 
+    def test_ean_bad_length(self):
+        bad_lengths = [l for l in range(1, 15) if l not in (8, 13)]
+        for length in bad_lengths:
+            with self.assertRaises(AssertionError):
+                self.fake.ean(length)
+
     def test_ean8(self):
         for _ in range(self.num_sample_runs):
             ean8 = self.fake.ean8()
@@ -125,6 +131,18 @@ class TestBarcodeProvider(unittest.TestCase):
             # What will be the same are their number system and check digits
             assert upc_e_safe[0] == upc_e_unsafe[0]
             assert upc_e_safe[-1] == upc_e_unsafe[-1]
+
+    def test_upc_a2e_bad_values(self):
+        from faker.providers.barcode import Provider
+        provider = Provider(self.fake)
+
+        # Invalid data type
+        with self.assertRaises(TypeError):
+            provider._convert_upc_a2e(12345678)
+
+        # Invalid string
+        with self.assertRaises(ValueError):
+            provider._convert_upc_a2e('abcdef')
 
     def test_upc_a2e2a(self):
         from faker.providers.barcode import Provider

--- a/tests/providers/test_color.py
+++ b/tests/providers/test_color.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 import random
 import re
@@ -279,7 +280,9 @@ class TestRandomColor(unittest.TestCase):
         self.random_color.generate(hue=62)
 
         # If we remove 62 from the yellow range, calling the previous function should fail
-        self.random_color.colormap['yellow']['hue_range'] = [47, 61]
+        colormap = copy.deepcopy(self.random_color.colormap)
+        colormap['yellow']['hue_range'] = [47, 61]
+        self.random_color.colormap = colormap
         with self.assertRaises(ValueError):
             self.random_color.generate(hue=62)
 

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -213,7 +213,7 @@ class TestZhCN(unittest.TestCase):
                 # But every level henceforth should return the mocked value
                 assert domain_parts[-1] == 'cn'
                 assert domain_parts[-2] in provider.second_level_domains
-                assert all([domain_part == 'li' for domain_part in domain_parts[:-2]])
+                assert all(domain_part == 'li' for domain_part in domain_parts[:-2])
 
                 # tld() method should only be called once, domain_word() will be called for each
                 # level after tld except the second, and recursive calls to domain_name() will be
@@ -239,7 +239,7 @@ class TestZhCN(unittest.TestCase):
                 # Same assertions as levels=2 for non cn tld and
                 # every level henceforth should return the mocked value
                 assert domain_parts[-1] == 'net'
-                assert all([domain_part == 'li' for domain_part in domain_parts[:-1]])
+                assert all(domain_part == 'li' for domain_part in domain_parts[:-1])
 
                 # tld() method should only be called once, domain_word() will be called for each
                 # level after tld, and recursive calls to domain_name() will be made for each

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -151,6 +151,107 @@ class TestZhCN(unittest.TestCase):
                                    'nx', 'qh', 'sc', 'sd', 'sh', 'sn',
                                    'sx', 'tj', 'xj', 'xz', 'yn', 'zj']
 
+    def test_domain_name_one_level_after_tld(self):
+        from faker.providers.internet.zh_CN import Provider
+        provider = Provider(self.fake)
+        for _ in range(100):
+            domain_name = self.fake.domain_name(levels=1)
+            domain_parts = domain_name.split('.')
+            assert len(domain_parts) == 2
+            assert domain_parts[-1] in provider.tlds.keys()
+            assert domain_parts[0] not in provider.second_level_domains
+
+    @mock.patch('faker.providers.internet.zh_CN.Provider.domain_word')
+    @mock.patch('faker.providers.internet.Provider.tld')
+    def test_domain_name_two_levels_after_cn_tld(self, mock_tld, mock_domain_word):
+        from faker.providers.internet.zh_CN import Provider
+        provider = Provider(self.fake)
+
+        # If tld() returns cn, second level name should be selected from second_level_domains
+        # and domain_word() will only be called once which will be used for the third level
+        mock_tld.return_value = 'cn'
+        mock_domain_word.return_value = 'li'
+        for _ in range(100):
+            mock_domain_word.reset_mock()
+            domain_name = self.fake.domain_name(levels=2)
+            domain_parts = domain_name.split('.')
+            assert len(domain_parts) == 3
+            assert domain_parts[-1] == 'cn'
+            assert domain_parts[-2] in provider.second_level_domains
+            assert domain_parts[0] == 'li'
+            assert mock_domain_word.call_count == 1
+
+    @mock.patch('faker.providers.internet.zh_CN.Provider.domain_word')
+    @mock.patch('faker.providers.internet.Provider.tld')
+    def test_domain_name_two_levels_after_non_cn_tld(self, mock_tld, mock_domain_word):
+        # If tld() does not return cn, domain_word() will be called twice
+        mock_domain_word.reset_mock()
+        mock_tld.return_value = 'net'
+        mock_domain_word.return_value = 'li'
+        domain_name = self.fake.domain_name(levels=2)
+        assert domain_name == 'li.li.net'
+        assert mock_domain_word.call_count == 2
+
+    @mock.patch('faker.providers.internet.zh_CN.Provider.domain_word')
+    @mock.patch('faker.providers.internet.Provider.tld')
+    def test_domain_name_more_than_two_levels_after_cn_tld(self, mock_tld, mock_domain_word):
+        from faker.providers.internet.zh_CN import Provider
+        provider = Provider(self.fake)
+
+        mock_tld.return_value = 'cn'
+        mock_domain_word.return_value = 'li'
+        for levels in range(3, 10):
+            with mock.patch('faker.providers.internet.zh_CN.Provider.domain_name',
+                            wraps=self.fake.domain_name) as mock_domain_name:
+                mock_tld.reset_mock()
+                mock_domain_word.reset_mock()
+                mock_domain_name.reset_mock()
+                domain_name = self.fake.domain_name(levels=levels)
+                domain_parts = domain_name.split('.')
+
+                # Same assertions as levels=2 for tld and second level if tld is cn
+                # But every level henceforth should return the mocked value
+                assert domain_parts[-1] == 'cn'
+                assert domain_parts[-2] in provider.second_level_domains
+                assert all([domain_part == 'li' for domain_part in domain_parts[:-2]])
+
+                # tld() method should only be called once, domain_word() will be called for each
+                # level after tld except the second, and recursive calls to domain_name() will be
+                # made for each level starting from the third level after tld
+                assert mock_tld.call_count == 1
+                assert mock_domain_word.call_count == levels - 1
+                assert mock_domain_name.call_count == levels - 2
+
+    @mock.patch('faker.providers.internet.zh_CN.Provider.domain_word')
+    @mock.patch('faker.providers.internet.Provider.tld')
+    def test_domain_name_more_than_two_levels_after_non_cn_tld(self, mock_tld, mock_domain_word):
+        mock_tld.return_value = 'net'
+        mock_domain_word.return_value = 'li'
+        for levels in range(3, 10):
+            with mock.patch('faker.providers.internet.zh_CN.Provider.domain_name',
+                            wraps=self.fake.domain_name) as mock_domain_name:
+                mock_tld.reset_mock()
+                mock_domain_word.reset_mock()
+                mock_domain_name.reset_mock()
+                domain_name = self.fake.domain_name(levels=levels)
+                domain_parts = domain_name.split('.')
+
+                # Same assertions as levels=2 for non cn tld and
+                # every level henceforth should return the mocked value
+                assert domain_parts[-1] == 'net'
+                assert all([domain_part == 'li' for domain_part in domain_parts[:-1]])
+
+                # tld() method should only be called once, domain_word() will be called for each
+                # level after tld, and recursive calls to domain_name() will be made for each
+                # level starting from the third level after tld
+                assert mock_tld.call_count == 1
+                assert mock_domain_word.call_count == levels
+                assert mock_domain_name.call_count == levels - 2
+
+    def test_domain_name_bad_level(self):
+        with self.assertRaises(ValueError):
+            self.fake.domain_name(levels=0)
+
 
 class TestZhTW(unittest.TestCase):
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -300,3 +300,8 @@ class TestFakerProxyClass(unittest.TestCase):
             mock_select_factory.reset_mock()
             mock_choices_fn.reset_mock()
             mock_random_choice.reset_mock()
+
+    def test_multiple_locale_factory_selection_unsupported_method(self):
+        self.fake = Faker(['en_US', 'en_PH'])
+        with self.assertRaises(AttributeError):
+            self.fake.obviously_invalid_provider_method_a23f()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=py{27,35,36,37,38,py,py3},32bit,flake8,checkmanifest
 skip_missing_interpreters = true
 
 [testenv]
-deps = coverage
+deps = coverage==4.5.4
 commands =
     coverage run --source=faker setup.py test
     coverage report


### PR DESCRIPTION
Just another wave of housekeeping, but this time focuses on improving tests and test coverage. I did not tackle some files like `build_docs` and `cli` because of implied plans of deprecating them as discussed in #1078 and #1083. Part 3 will probably be the clean up for Python 3 only release as discussed in #1063.