### PR TITLE
Fix #1051

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.python-version
 .idea
 .projectile
 .ropeproject

--- a/faker/providers/phone_number/ar_PS/__init__.py
+++ b/faker/providers/phone_number/ar_PS/__init__.py
@@ -7,85 +7,85 @@ class Provider(PhoneNumberProvider):
     # https://en.wikipedia.org/wiki/Telephone_numbers_in_the_State_of_Palestine
 
     cellphone_formats = (
-        '{{country_code}} {{provider_code}} ### ####',
-        '{{country_code}}{{provider_code}}#######',
+        '{{area_code}} {{provider_code}} ### ####',
+        '{{area_code}}{{provider_code}}#######',
         '0{{provider_code}} ### ####',
         '0{{provider_code}}#######',
     )
 
     telephone_formats = (
-        '{{country_code}} 4 24# ####',
-        '{{country_code}}424#####',
+        '{{area_code}} 4 24# ####',
+        '{{area_code}}424#####',
         '04 24# ####',
         '0424#####',
 
-        '{{country_code}} 9 25# ####',
-        '{{country_code}}925#####',
+        '{{area_code}} 9 25# ####',
+        '{{area_code}}925#####',
         '09 25# ####',
         '0925#####',
 
-        '{{country_code}} 4 26# ####',
-        '{{country_code}}426#####',
+        '{{area_code}} 4 26# ####',
+        '{{area_code}}426#####',
         '04 26# ####',
         '0426#####',
 
-        '{{country_code}} 4 23# ####',
-        '{{country_code}}423#####',
+        '{{area_code}} 4 23# ####',
+        '{{area_code}}423#####',
         '04 23# ####',
         '0423#####',
 
-        '{{country_code}} 4 29# ####',
-        '{{country_code}}429#####',
+        '{{area_code}} 4 29# ####',
+        '{{area_code}}429#####',
         '04 29# ####',
         '0429#####',
 
-        '{{country_code}} 2 29# ####',
-        '{{country_code}}229#####',
+        '{{area_code}} 2 29# ####',
+        '{{area_code}}229#####',
         '02 29# ####',
         '0229#####',
 
-        '{{country_code}} 2 23# ####',
-        '{{country_code}}223#####',
+        '{{area_code}} 2 23# ####',
+        '{{area_code}}223#####',
         '02 23# ####',
         '0223#####',
 
-        '{{country_code}} 2 22# ####',
-        '{{country_code}}222#####',
+        '{{area_code}} 2 22# ####',
+        '{{area_code}}222#####',
         '02 22# ####',
         '0222#####',
 
-        '{{country_code}} 2 27# ####',
-        '{{country_code}}227#####',
+        '{{area_code}} 2 27# ####',
+        '{{area_code}}227#####',
         '02 27# ####',
         '0227#####',
 
-        '{{country_code}} 8 20# ####',
-        '{{country_code}}820#####',
+        '{{area_code}} 8 20# ####',
+        '{{area_code}}820#####',
         '08 20# ####',
         '0820#####',
 
-        '{{country_code}} 8 21# ####',
-        '{{country_code}}821#####',
+        '{{area_code}} 8 21# ####',
+        '{{area_code}}821#####',
         '08 21# ####',
         '0821#####',
 
-        '{{country_code}} 8 24# ####',
-        '{{country_code}}824#####',
+        '{{area_code}} 8 24# ####',
+        '{{area_code}}824#####',
         '08 24# ####',
         '0824#####',
 
-        '{{country_code}} 8 25# ####',
-        '{{country_code}}825#####',
+        '{{area_code}} 8 25# ####',
+        '{{area_code}}825#####',
         '08 25# ####',
         '0825#####',
 
-        '{{country_code}} 8 26# ####',
-        '{{country_code}}826#####',
+        '{{area_code}} 8 26# ####',
+        '{{area_code}}826#####',
         '08 26# ####',
         '0826#####',
 
-        '{{country_code}} 8 28# ####',
-        '{{country_code}}828#####',
+        '{{area_code}} 8 28# ####',
+        '{{area_code}}828#####',
         '08 28# ####',
         '0828#####',
 
@@ -115,7 +115,7 @@ class Provider(PhoneNumberProvider):
             '56',
         ])
 
-    def country_code(self):
+    def area_code(self):
         return self.random_element([
             '00972',
             '+972',


### PR DESCRIPTION
### What does this changes

Fixes https://github.com/joke2k/faker/issues/1051

This also adds an entry to .gitignore for pyenv users who take advantage of `pyenv-virtualenv`

### What was wrong

The use of method name `country_code` in `faker/providers/phone_number/ar_PS/__init__.py` was overriding the functionality of `address.country_code` when locale `ar_PS` is specified.

### How this fixes it

Renaming to `area_code` removes the conflict, causing the error seen in https://github.com/joke2k/faker/issues/1051, while ensuring that all phone_number localization for `ar_PS` continues to work.

Fixes https://github.com/joke2k/faker/issues/1051
