### PR TITLE
Fix Faker.random_number intermittent exceptions #1074

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -151,10 +151,15 @@ class BaseProvider(object):
             fixed length number
         """
         if digits is None:
-            digits = self.random_digit()
+            digits = self.random_digit_not_null()
+        if digits < 0:
+            raise ValueError("The digit parameter must be greater than or equal to 0.")
         if fix_len:
-            return self.generator.random.randint(
-                pow(10, digits - 1), pow(10, digits) - 1)
+            if digits > 0:
+                return self.generator.random.randint(
+                    pow(10, digits - 1), pow(10, digits) - 1)
+            else:
+                raise ValueError("A number of fixed length cannot have less than 1 digit in it.")
         else:
             return self.generator.random.randint(0, pow(10, digits) - 1)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -910,6 +910,14 @@ class FactoryTestCase(unittest.TestCase):
         number = provider.random_number(10, True)
         assert len(str(number)) == 10
 
+        # Digits parameter < 0
+        with self.assertRaises(ValueError):
+            number = provider.random_number(-1, True)
+
+        # Digits parameter < 1 with fix_len=True
+        with self.assertRaises(ValueError):
+            number = provider.random_number(0, True)
+
     def test_instance_seed_chain(self):
         factory = Factory.create()
 


### PR DESCRIPTION
### What does this change

Uses `self.random_digit_not_null()` instead of `self.random_digit()` to generate a random max length of digits when none are passed to `self.random_number()` method.

Also, raise more aptly worded / obvious ValueError when digits param is less than 1 and fix_len param is set to True.

### What was wrong

The use of `self.random_digit()` to generate a random max length of digits in a random number gives it a 10% chance of equaling 0 and failing with a ValueError when fix_len is set to True.

### How this fixes it

Setting `digits = self.random_digit_not_null()` will always generate a number between 1 and 9 instead of 0 and 9, resolving the case where a user specifies `fix_len=True` and doesn't specify a digits param.


Fixes https://github.com/joke2k/faker/issues/1074
