### PR TITLE
Replace deprecated 'setup.py test' with tox/pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	coverage run --source=faker --omit=faker/build_docs.py setup.py test
+	tox -e py
 
 isort:
 	isort -rc --atomic .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,5 @@ test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
   - "%PYTHON%/Scripts/pip.exe freeze"
   - "%PYTHON%/python.exe --version"
-  - "%PYTHON%/Scripts/pip.exe install -U setuptools"
-  - "%PYTHON%/Scripts/pip.exe install \"importlib-metadata>=0.12\""
-  - "%PYTHON%/python.exe setup.py test"
+  - "%PYTHON%/Scripts/pip.exe install tox"
+  - "%PYTHON%/python.exe -m tox -e py"

--- a/build32bit.sh
+++ b/build32bit.sh
@@ -12,5 +12,5 @@ docker run -v ${PWD}:/code -e INSTALL_REQUIREMENTS=${INSTALL_REQUIREMENTS} i386/
     && locale-gen en_US.UTF-8 \
     && export LANG='en_US.UTF-8' \
     && cd /code \
-    && coverage run --source=faker setup.py test \
+    && tox -e py \
     && coverage report"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ license_file = LICENSE.txt
 [pep8]
 max-line-length = 80
 
-[aliases]
-test=pytest
-
 [tool:pytest]
 addopts = --verbose
 python_files = tests/*.py

--- a/setup.py
+++ b/setup.py
@@ -59,25 +59,12 @@ setup(
     license='MIT License',
     packages=find_packages(exclude=["docs", "tests", "tests.*"]),
     platforms=["any"],
-    test_suite='tests',
     zip_safe=zip_safe,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    setup_requires=["pytest-runner"],
     install_requires=[
         "python-dateutil>=2.4",
         "six>=1.10",
         "text-unidecode==1.3",
-    ],
-    tests_require=[
-        "validators>=0.13.0",
-        "ukpostcodeparser>=1.1.1",
-        "mock ; python_version < '3.3'",
-        "pytest>=3.8.0,<3.9",
-        "more-itertools<6.0.0 ; python_version < '3.0'",
-        # restricted because they may drop python2 support in future versions
-        # https://github.com/joke2k/faker/issues/970
-        "random2<1.1",
-        "freezegun<0.4",
     ],
     extras_require={
         ':python_version<"3.3"': [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=py{27,35,36,37,38,py,py3},32bit,flake8,checkmanifest
 skip_missing_interpreters = true
 
 [testenv]
-deps = coverage==4.5.4
+deps = coverage
 commands =
     coverage run --source=faker setup.py test
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,19 @@ envlist=py{27,35,36,37,38,py,py3},32bit,flake8,checkmanifest
 skip_missing_interpreters = true
 
 [testenv]
-deps = coverage
+deps =
+    coverage
+    freezegun<0.4
+    mock; python_version<"3.3"
+    more-itertools<6.0.0; python_version<"3.0"
+    pytest>=3.8.0,<3.9
+    # restricted because they may drop python2 support in future versions
+    # https://github.com/joke2k/faker/issues/970
+    random2<1.1
+    ukpostcodeparser>=1.1.1
+    validators>=0.13.0
 commands =
-    coverage run --source=faker setup.py test
+    coverage run --source=faker -m pytest
     coverage report
 
 [testenv:flake8]


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now, run the pytest command from tox
as recommended by setuptools.

https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0