### PR TITLE
Remove unnecessary "exclude" from flake8 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,5 @@ jobs:
       - image: circleci/python:latest-node-browsers
     steps:
       - checkout
-      - run: pip install --user virtualenv
-      - run: virtualenv faker
-      - run: source faker/bin/activate && pip install tox
-      - run: source faker/bin/activate && tox
+      - run: pip install --user tox
+      - run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,3 @@ commands = ./build32bit.sh
 
 [flake8]
 max-line-length = 120
-exclude = faker/lib,faker/bin,.eggs,docs


### PR DESCRIPTION
These directories either don't exist, aren't linted, or are
automatically excluded. There is no need to specify these.