### PR TITLE
Run isort as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,5 @@ jobs:
       - image: circleci/python:latest-node-browsers
     steps:
       - checkout
-      - run: pip install --user virtualenv
-      - run: virtualenv faker
-      - run: source faker/bin/activate && pip install tox
-      - run: source faker/bin/activate && tox
+      - run: pip install --user tox
+      - run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       env: TOXENV=flake8
     - python: 3.7
       env: TOXENV=checkmanifest
+    - env: TOXENV=isort
     - python: 2.7
       env: TOXENV=py27
     - python: 3.5

--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -1,5 +1,5 @@
-from faker.generator import Generator  # noqa F401
 from faker.factory import Factory  # noqa F401
+from faker.generator import Generator  # noqa F401
 from faker.proxy import Faker  # noqa F401
 
 VERSION = '3.0.0'

--- a/faker/factory.py
+++ b/faker/factory.py
@@ -8,8 +8,8 @@ import sys
 
 from importlib import import_module
 
-from faker import Generator
 from faker.config import AVAILABLE_LOCALES, DEFAULT_LOCALE, PROVIDERS
+from faker.generator import Generator
 from faker.utils.loading import list_module
 
 logger = logging.getLogger(__name__)

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import random as random_module
 import re
+
 import six
 
 _re_token = re.compile(r'\{\{(\s?)(\w+)(\s?)\}\}')

--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-from .. import BaseProvider
-from .. import date_time
+from .. import BaseProvider, date_time
 
 localized = True
 

--- a/faker/providers/address/cs_CZ/__init__.py
+++ b/faker/providers/address/cs_CZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/de/__init__.py
+++ b/faker/providers/address/de/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/de_AT/__init__.py
+++ b/faker/providers/address/de_AT/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from ..de import Provider as AddressProvider
 
 

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from ..de import Provider as AddressProvider
 
 

--- a/faker/providers/address/en/__init__.py
+++ b/faker/providers/address/en/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/en_CA/__init__.py
+++ b/faker/providers/address/en_CA/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
+
 import re
+
 from ..en import Provider as AddressProvider
 
 

--- a/faker/providers/address/en_GB/__init__.py
+++ b/faker/providers/address/en_GB/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from ..en import Provider as AddressProvider

--- a/faker/providers/address/en_NZ/__init__.py
+++ b/faker/providers/address/en_NZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ..en import Provider as AddressProvider
 
 

--- a/faker/providers/address/en_PH/__init__.py
+++ b/faker/providers/address/en_PH/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 from string import ascii_uppercase
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from ..en import Provider as AddressProvider

--- a/faker/providers/address/es/__init__.py
+++ b/faker/providers/address/es/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/es_ES/__init__.py
+++ b/faker/providers/address/es_ES/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from ..es import Provider as AddressProvider
 
 

--- a/faker/providers/address/es_MX/__init__.py
+++ b/faker/providers/address/es_MX/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from ..es import Provider as AddressProvider

--- a/faker/providers/address/fa_IR/__init__.py
+++ b/faker/providers/address/fa_IR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/fi_FI/__init__.py
+++ b/faker/providers/address/fi_FI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/fr_CH/__init__.py
+++ b/faker/providers/address/fr_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/hi_IN/__init__.py
+++ b/faker/providers/address/hi_IN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/hr_HR/__init__.py
+++ b/faker/providers/address/hr_HR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/hu_HU/__init__.py
+++ b/faker/providers/address/hu_HU/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as AddressProvider

--- a/faker/providers/address/hy_AM/__init__.py
+++ b/faker/providers/address/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/id_ID/__init__.py
+++ b/faker/providers/address/id_ID/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/it_IT/__init__.py
+++ b/faker/providers/address/it_IT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/nl_BE/__init__.py
+++ b/faker/providers/address/nl_BE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/nl_NL/__init__.py
+++ b/faker/providers/address/nl_NL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/pl_PL/__init__.py
+++ b/faker/providers/address/pl_PL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/pt_PT/__init__.py
+++ b/faker/providers/address/pt_PT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/ru_RU/__init__.py
+++ b/faker/providers/address/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/sl_SI/__init__.py
+++ b/faker/providers/address/sl_SI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/ta_IN/__init__.py
+++ b/faker/providers/address/ta_IN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/zh_CN/__init__.py
+++ b/faker/providers/address/zh_CN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/address/zh_TW/__init__.py
+++ b/faker/providers/address/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AddressProvider
 
 

--- a/faker/providers/automotive/__init__.py
+++ b/faker/providers/automotive/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 
-from .. import BaseProvider
-from string import ascii_uppercase
 import re
+
+from string import ascii_uppercase
+
+from .. import BaseProvider
 
 localized = True
 

--- a/faker/providers/automotive/ar_JO/__init__.py
+++ b/faker/providers/automotive/ar_JO/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/ar_PS/__init__.py
+++ b/faker/providers/automotive/ar_PS/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/de_DE/__init__.py
+++ b/faker/providers/automotive/de_DE/__init__.py
@@ -2,8 +2,10 @@
 
 
 from __future__ import unicode_literals
-from .. import Provider as AutomotiveProvider
+
 import string
+
+from .. import Provider as AutomotiveProvider
 
 
 class Provider(AutomotiveProvider):

--- a/faker/providers/automotive/en_CA/__init__.py
+++ b/faker/providers/automotive/en_CA/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/en_GB/__init__.py
+++ b/faker/providers/automotive/en_GB/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/en_NZ/__init__.py
+++ b/faker/providers/automotive/en_NZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/en_PH/__init__.py
+++ b/faker/providers/automotive/en_PH/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from string import ascii_uppercase
+
 from ... import BaseProvider
 
 

--- a/faker/providers/automotive/en_US/__init__.py
+++ b/faker/providers/automotive/en_US/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/hu_HU/__init__.py
+++ b/faker/providers/automotive/hu_HU/__init__.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/id_ID/__init__.py
+++ b/faker/providers/automotive/id_ID/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/pl_PL/__init__.py
+++ b/faker/providers/automotive/pl_PL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/ru_RU/__init__.py
+++ b/faker/providers/automotive/ru_RU/__init__.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/automotive/sv_SE/__init__.py
+++ b/faker/providers/automotive/sv_SE/__init__.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import unicode_literals
+
 from .. import Provider as AutomotiveProvider
 
 

--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
-from .. import BaseProvider
-import string
-from string import ascii_uppercase
 import re
+import string
+
+from string import ascii_uppercase
+
+from .. import BaseProvider
 
 localized = True
 default_locale = 'en_GB'

--- a/faker/providers/barcode/__init__.py
+++ b/faker/providers/barcode/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import re
+
 from six import string_types
 
 from .. import BaseProvider

--- a/faker/providers/color/__init__.py
+++ b/faker/providers/color/__init__.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
-from .color import RandomColor
 from .. import BaseProvider
+from .color import RandomColor
 
 localized = True
 

--- a/faker/providers/color/ar_PS/__init__.py
+++ b/faker/providers/color/ar_PS/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as ColorProvider

--- a/faker/providers/color/color.py
+++ b/faker/providers/color/color.py
@@ -14,7 +14,6 @@ import sys
 
 import six
 
-
 COLOR_MAP = {
     'monochrome': {
         'hue_range': [0, 0],

--- a/faker/providers/color/fr_FR/__init__.py
+++ b/faker/providers/color/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as ColorProvider

--- a/faker/providers/color/hy_AM/__init__.py
+++ b/faker/providers/color/hy_AM/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as ColorProvider
 
 

--- a/faker/providers/color/pt_BR/__init__.py
+++ b/faker/providers/color/pt_BR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as ColorProvider

--- a/faker/providers/color/ru_RU/__init__.py
+++ b/faker/providers/color/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as ColorProvider

--- a/faker/providers/color/th_TH/__init__.py
+++ b/faker/providers/color/th_TH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as ColorProvider

--- a/faker/providers/company/__init__.py
+++ b/faker/providers/company/__init__.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from .. import BaseProvider
 
+from .. import BaseProvider
 
 localized = True
 

--- a/faker/providers/company/bg_BG/__init__.py
+++ b/faker/providers/company/bg_BG/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/cs_CZ/__init__.py
+++ b/faker/providers/company/cs_CZ/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/de_DE/__init__.py
+++ b/faker/providers/company/de_DE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/en_PH/__init__.py
+++ b/faker/providers/company/en_PH/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/en_US/__init__.py
+++ b/faker/providers/company/en_US/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/es_MX/__init__.py
+++ b/faker/providers/company/es_MX/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/fa_IR/__init__.py
+++ b/faker/providers/company/fa_IR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/fi_FI/__init__.py
+++ b/faker/providers/company/fi_FI/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/fil_PH/__init__.py
+++ b/faker/providers/company/fil_PH/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from ..en_PH import Provider as EnPhProvider
 
 

--- a/faker/providers/company/fr_CH/__init__.py
+++ b/faker/providers/company/fr_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ..fr_FR import Provider as CompanyProvider
 
 

--- a/faker/providers/company/fr_FR/__init__.py
+++ b/faker/providers/company/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/hr_HR/__init__.py
+++ b/faker/providers/company/hr_HR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/hu_HU/__init__.py
+++ b/faker/providers/company/hu_HU/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/hy_AM/__init__.py
+++ b/faker/providers/company/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/id_ID/__init__.py
+++ b/faker/providers/company/id_ID/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/it_IT/__init__.py
+++ b/faker/providers/company/it_IT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/ja_JP/__init__.py
+++ b/faker/providers/company/ja_JP/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/ko_KR/__init__.py
+++ b/faker/providers/company/ko_KR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/nl_NL/__init__.py
+++ b/faker/providers/company/nl_NL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/no_NO/__init__.py
+++ b/faker/providers/company/no_NO/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/pl_PL/__init__.py
+++ b/faker/providers/company/pl_PL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/pt_BR/__init__.py
+++ b/faker/providers/company/pt_BR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/pt_PT/__init__.py
+++ b/faker/providers/company/pt_PT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/ru_RU/__init__.py
+++ b/faker/providers/company/ru_RU/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from faker.utils.datetime_safe import datetime
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/sk_SK/__init__.py
+++ b/faker/providers/company/sk_SK/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/sl_SI/__init__.py
+++ b/faker/providers/company/sl_SI/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/sv_SE/__init__.py
+++ b/faker/providers/company/sv_SE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/zh_CN/__init__.py
+++ b/faker/providers/company/zh_CN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/company/zh_TW/__init__.py
+++ b/faker/providers/company/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as CompanyProvider
 
 

--- a/faker/providers/credit_card/__init__.py
+++ b/faker/providers/credit_card/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import BaseProvider

--- a/faker/providers/credit_card/fa_IR/__init__.py
+++ b/faker/providers/credit_card/fa_IR/__init__.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 
-from .. import Provider as CreditCardProvider
-from .. import CreditCard
 from collections import OrderedDict
+
+from .. import CreditCard
+from .. import Provider as CreditCardProvider
 
 
 class Provider(CreditCardProvider):

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import re
 
 from calendar import timegm
-from datetime import timedelta, MAXYEAR
+from datetime import MAXYEAR, timedelta
 
 from dateutil import relativedelta
 from dateutil.tz import tzlocal, tzutc

--- a/faker/providers/date_time/ar_AA/__init__.py
+++ b/faker/providers/date_time/ar_AA/__init__.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/ar_EG/__init__.py
+++ b/faker/providers/date_time/ar_EG/__init__.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-
 from ..ar_AA import Provider as ArabicDateTimeProvider
 
 

--- a/faker/providers/date_time/en_PH/__init__.py
+++ b/faker/providers/date_time/en_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/fil_PH/__init__.py
+++ b/faker/providers/date_time/fil_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/hi_IN/__init__.py
+++ b/faker/providers/date_time/hi_IN/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/hu_HU/__init__.py
+++ b/faker/providers/date_time/hu_HU/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/hy_AM/__init__.py
+++ b/faker/providers/date_time/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/id_ID/__init__.py
+++ b/faker/providers/date_time/id_ID/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/date_time/ta_IN/__init__.py
+++ b/faker/providers/date_time/ta_IN/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as DateTimeProvider
 
 

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import string
+
 from collections import OrderedDict
 
 from .. import BaseProvider

--- a/faker/providers/geo/de_AT/__init__.py
+++ b/faker/providers/geo/de_AT/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as GeoProvider
 
 

--- a/faker/providers/geo/pt_PT/__init__.py
+++ b/faker/providers/geo/pt_PT/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as GeoProvider
 
 

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -1,17 +1,16 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+from ipaddress import IPV4LENGTH, IPV6LENGTH, ip_address, ip_network
+
 from text_unidecode import unidecode
-
-from .. import BaseProvider
-
-from ipaddress import ip_address, ip_network, IPV4LENGTH, IPV6LENGTH
 
 # from faker.generator import random
 # from faker.providers.lorem.la import Provider as Lorem
 from faker.utils.decorators import lowercase, slugify, slugify_unicode
 from faker.utils.distribution import choices_distribution
 
+from .. import BaseProvider
 
 localized = True
 

--- a/faker/providers/internet/ar_AA/__init__.py
+++ b/faker/providers/internet/ar_AA/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/bg_BG/__init__.py
+++ b/faker/providers/internet/bg_BG/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/bs_BA/__init__.py
+++ b/faker/providers/internet/bs_BA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/cs_CZ/__init__.py
+++ b/faker/providers/internet/cs_CZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/de_AT/__init__.py
+++ b/faker/providers/internet/de_AT/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/de_DE/__init__.py
+++ b/faker/providers/internet/de_DE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/el_GR/__init__.py
+++ b/faker/providers/internet/el_GR/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as InternetProvider
 
 import re
+
 from faker.utils.decorators import slugify_domain
+
+from .. import Provider as InternetProvider
 
 
 class Provider(InternetProvider):

--- a/faker/providers/internet/en_AU/__init__.py
+++ b/faker/providers/internet/en_AU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/en_NZ/__init__.py
+++ b/faker/providers/internet/en_NZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/en_PH/__init__.py
+++ b/faker/providers/internet/en_PH/__init__.py
@@ -1,7 +1,10 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from faker.utils.decorators import lowercase, slugify
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/en_US/__init__.py
+++ b/faker/providers/internet/en_US/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/fa_IR/__init__.py
+++ b/faker/providers/internet/fa_IR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/internet/fi_FI/__init__.py
+++ b/faker/providers/internet/fi_FI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/fr_CH/__init__.py
+++ b/faker/providers/internet/fr_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/fr_FR/__init__.py
+++ b/faker/providers/internet/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/hr_HR/__init__.py
+++ b/faker/providers/internet/hr_HR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/hu_HU/__init__.py
+++ b/faker/providers/internet/hu_HU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/id_ID/__init__.py
+++ b/faker/providers/internet/id_ID/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/it_IT/__init__.py
+++ b/faker/providers/internet/it_IT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/ja_JP/__init__.py
+++ b/faker/providers/internet/ja_JP/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as InternetProvider
+
 from faker.utils.decorators import slugify
+
+from .. import Provider as InternetProvider
 
 
 class Provider(InternetProvider):

--- a/faker/providers/internet/ko_KR/__init__.py
+++ b/faker/providers/internet/ko_KR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/no_NO/__init__.py
+++ b/faker/providers/internet/no_NO/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/pt_BR/__init__.py
+++ b/faker/providers/internet/pt_BR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/pt_PT/__init__.py
+++ b/faker/providers/internet/pt_PT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/ru_RU/__init__.py
+++ b/faker/providers/internet/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/sk_SK/__init__.py
+++ b/faker/providers/internet/sk_SK/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/sl_SI/__init__.py
+++ b/faker/providers/internet/sl_SI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/sv_SE/__init__.py
+++ b/faker/providers/internet/sv_SE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as InternetProvider
 
 

--- a/faker/providers/internet/zh_CN/__init__.py
+++ b/faker/providers/internet/zh_CN/__init__.py
@@ -1,8 +1,11 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
-from .. import Provider as InternetProvider
+
 from faker.utils.decorators import slugify
+
+from .. import Provider as InternetProvider
 
 
 class Provider(InternetProvider):

--- a/faker/providers/internet/zh_TW/__init__.py
+++ b/faker/providers/internet/zh_TW/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as InternetProvider
+
 from faker.utils.decorators import slugify
+
+from .. import Provider as InternetProvider
 
 
 class Provider(InternetProvider):

--- a/faker/providers/isbn/__init__.py
+++ b/faker/providers/isbn/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import BaseProvider
 from .isbn import ISBN, ISBN10, ISBN13
 from .rules import RULES

--- a/faker/providers/job/ar_AA/__init__.py
+++ b/faker/providers/job/ar_AA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/bs_BA/__init__.py
+++ b/faker/providers/job/bs_BA/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
+
 
 """
 Data is provided by the official list of professions from

--- a/faker/providers/job/de_DE/__init__.py
+++ b/faker/providers/job/de_DE/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/el_GR/__init__.py
+++ b/faker/providers/job/el_GR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/fa_IR/__init__.py
+++ b/faker/providers/job/fa_IR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/fi_FI/__init__.py
+++ b/faker/providers/job/fi_FI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/fr_CH/__init__.py
+++ b/faker/providers/job/fr_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 # Source: SEFRI

--- a/faker/providers/job/fr_FR/__init__.py
+++ b/faker/providers/job/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 # Source: ONISEP

--- a/faker/providers/job/hr_HR/__init__.py
+++ b/faker/providers/job/hr_HR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/hu_HU/__init__.py
+++ b/faker/providers/job/hu_HU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import BaseProvider
 
 

--- a/faker/providers/job/hy_AM/__init__.py
+++ b/faker/providers/job/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/ja_JP/__init__.py
+++ b/faker/providers/job/ja_JP/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/ko_KR/__init__.py
+++ b/faker/providers/job/ko_KR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/pl_PL/__init__.py
+++ b/faker/providers/job/pl_PL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/pt_BR/__init__.py
+++ b/faker/providers/job/pt_BR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 # Source: Gist

--- a/faker/providers/job/pt_PT/__init__.py
+++ b/faker/providers/job/pt_PT/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as BaseProvider
 
+from .. import Provider as BaseProvider
 
 # source: https://bit.ly/32nqRv7
 

--- a/faker/providers/job/ru_RU/__init__.py
+++ b/faker/providers/job/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 # Russian jobs taken from the Wikipedia page

--- a/faker/providers/job/th_TH/__init__.py
+++ b/faker/providers/job/th_TH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/uk_UA/__init__.py
+++ b/faker/providers/job/uk_UA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/zh_CN/__init__.py
+++ b/faker/providers/job/zh_CN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/job/zh_TW/__init__.py
+++ b/faker/providers/job/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/lorem/ar_AA/__init__.py
+++ b/faker/providers/lorem/ar_AA/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/el_GR/__init__.py
+++ b/faker/providers/lorem/el_GR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/en_PH/__init__.py
+++ b/faker/providers/lorem/en_PH/__init__.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from ..la import Provider as LoremProvider
+
 from ..en_US import Provider as EnUsProvider
+from ..la import Provider as LoremProvider
 
 
 class Provider(LoremProvider):

--- a/faker/providers/lorem/en_US/__init__.py
+++ b/faker/providers/lorem/en_US/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/fil_PH/__init__.py
+++ b/faker/providers/lorem/fil_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/fr_FR/__init__.py
+++ b/faker/providers/lorem/fr_FR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/he_IL/__init__.py
+++ b/faker/providers/lorem/he_IL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/hy_AM/__init__.py
+++ b/faker/providers/lorem/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/la/__init__.py
+++ b/faker/providers/lorem/la/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/pl_PL/__init__.py
+++ b/faker/providers/lorem/pl_PL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/ru_RU/__init__.py
+++ b/faker/providers/lorem/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/th_TH/__init__.py
+++ b/faker/providers/lorem/th_TH/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/zh_CN/__init__.py
+++ b/faker/providers/lorem/zh_CN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/lorem/zh_TW/__init__.py
+++ b/faker/providers/lorem/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as LoremProvider
 
 

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -1,19 +1,19 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 import csv
 import hashlib
 import io
 import string
+import sys
 import tarfile
 import uuid
-import sys
 import zipfile
 
 import six
 
 from .. import BaseProvider
-
 
 localized = True
 

--- a/faker/providers/misc/en_PH/__init__.py
+++ b/faker/providers/misc/en_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as MiscProvider
 
 

--- a/faker/providers/person/__init__.py
+++ b/faker/providers/person/__init__.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from .. import BaseProvider
 
-
 localized = True
 
 

--- a/faker/providers/person/ar_AA/__init__.py
+++ b/faker/providers/person/ar_AA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ar_PS/__init__.py
+++ b/faker/providers/person/ar_PS/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ..ar_AA import Provider as ArabicPersonProvider
 
 

--- a/faker/providers/person/ar_SA/__init__.py
+++ b/faker/providers/person/ar_SA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ..ar_AA import Provider as ArabicPersonProvider
 
 

--- a/faker/providers/person/bg_BG/__init__.py
+++ b/faker/providers/person/bg_BG/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/cs_CZ/__init__.py
+++ b/faker/providers/person/cs_CZ/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/de_AT/__init__.py
+++ b/faker/providers/person/de_AT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/de_CH/__init__.py
+++ b/faker/providers/person/de_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/de_DE/__init__.py
+++ b/faker/providers/person/de_DE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/dk_DK/__init__.py
+++ b/faker/providers/person/dk_DK/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/el_GR/__init__.py
+++ b/faker/providers/person/el_GR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/en/__init__.py
+++ b/faker/providers/person/en/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/en_GB/__init__.py
+++ b/faker/providers/person/en_GB/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/en_NZ/__init__.py
+++ b/faker/providers/person/en_NZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/en_TH/__init__.py
+++ b/faker/providers/person/en_TH/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/en_US/__init__.py
+++ b/faker/providers/person/en_US/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/es_CA/__init__.py
+++ b/faker/providers/person/es_CA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ..es_ES import Provider as PersonProvider
 
 

--- a/faker/providers/person/es_ES/__init__.py
+++ b/faker/providers/person/es_ES/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/es_MX/__init__.py
+++ b/faker/providers/person/es_MX/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/fa_IR/__init__.py
+++ b/faker/providers/person/fa_IR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/fi_FI/__init__.py
+++ b/faker/providers/person/fi_FI/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as PersonProvider
+
 from collections import OrderedDict
+
+from .. import Provider as PersonProvider
 
 
 class Provider(PersonProvider):

--- a/faker/providers/person/fr_CH/__init__.py
+++ b/faker/providers/person/fr_CH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/fr_FR/__init__.py
+++ b/faker/providers/person/fr_FR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/he_IL/__init__.py
+++ b/faker/providers/person/he_IL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/hi_IN/__init__.py
+++ b/faker/providers/person/hi_IN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/hr_HR/__init__.py
+++ b/faker/providers/person/hr_HR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/hu_HU/__init__.py
+++ b/faker/providers/person/hu_HU/__init__.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from collections import OrderedDict
-from .. import Provider as PersonProvider
 
+from collections import OrderedDict
+
+from .. import Provider as PersonProvider
 
 # Data source
 #

--- a/faker/providers/person/hy_AM/__init__.py
+++ b/faker/providers/person/hy_AM/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/id_ID/__init__.py
+++ b/faker/providers/person/id_ID/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/it_IT/__init__.py
+++ b/faker/providers/person/it_IT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ja_JP/__init__.py
+++ b/faker/providers/person/ja_JP/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ko_KR/__init__.py
+++ b/faker/providers/person/ko_KR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/lt_LT/__init__.py
+++ b/faker/providers/person/lt_LT/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/lv_LV/__init__.py
+++ b/faker/providers/person/lv_LV/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ne_NP/__init__.py
+++ b/faker/providers/person/ne_NP/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/nl_NL/__init__.py
+++ b/faker/providers/person/nl_NL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/no_NO/__init__.py
+++ b/faker/providers/person/no_NO/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/pl_PL/__init__.py
+++ b/faker/providers/person/pl_PL/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/pt_BR/__init__.py
+++ b/faker/providers/person/pt_BR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/pt_PT/__init__.py
+++ b/faker/providers/person/pt_PT/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ro_RO/__init__.py
+++ b/faker/providers/person/ro_RO/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/ru_RU/__init__.py
+++ b/faker/providers/person/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 from .. import Provider as PersonProvider

--- a/faker/providers/person/sl_SI/__init__.py
+++ b/faker/providers/person/sl_SI/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/sv_SE/__init__.py
+++ b/faker/providers/person/sv_SE/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as PersonProvider
 
 # Data source

--- a/faker/providers/person/ta_IN/__init__.py
+++ b/faker/providers/person/ta_IN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/th_TH/__init__.py
+++ b/faker/providers/person/th_TH/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/tr_TR/__init__.py
+++ b/faker/providers/person/tr_TR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/zh_CN/__init__.py
+++ b/faker/providers/person/zh_CN/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/person/zh_TW/__init__.py
+++ b/faker/providers/person/zh_TW/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from collections import OrderedDict
+
 from .. import Provider as PersonProvider
 
 

--- a/faker/providers/phone_number/ar_JO/__init__.py
+++ b/faker/providers/phone_number/ar_JO/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ar_PS/__init__.py
+++ b/faker/providers/phone_number/ar_PS/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/bg_BG/__init__.py
+++ b/faker/providers/phone_number/bg_BG/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/bs_BA/__init__.py
+++ b/faker/providers/phone_number/bs_BA/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/cs_CZ/__init__.py
+++ b/faker/providers/phone_number/cs_CZ/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/de_DE/__init__.py
+++ b/faker/providers/phone_number/de_DE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/dk_DK/__init__.py
+++ b/faker/providers/phone_number/dk_DK/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/el_GR/__init__.py
+++ b/faker/providers/phone_number/el_GR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/en_AU/__init__.py
+++ b/faker/providers/phone_number/en_AU/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/en_CA/__init__.py
+++ b/faker/providers/phone_number/en_CA/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/en_GB/__init__.py
+++ b/faker/providers/phone_number/en_GB/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/en_NZ/__init__.py
+++ b/faker/providers/phone_number/en_NZ/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/en_PH/__init__.py
+++ b/faker/providers/phone_number/en_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ... import BaseProvider
 
 

--- a/faker/providers/phone_number/en_US/__init__.py
+++ b/faker/providers/phone_number/en_US/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/es_ES/__init__.py
+++ b/faker/providers/phone_number/es_ES/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/es_MX/__init__.py
+++ b/faker/providers/phone_number/es_MX/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/fa_IR/__init__.py
+++ b/faker/providers/phone_number/fa_IR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/fi_FI/__init__.py
+++ b/faker/providers/phone_number/fi_FI/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/fr_CH/__init__.py
+++ b/faker/providers/phone_number/fr_CH/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/fr_FR/__init__.py
+++ b/faker/providers/phone_number/fr_FR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/he_IL/__init__.py
+++ b/faker/providers/phone_number/he_IL/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/hi_IN/__init__.py
+++ b/faker/providers/phone_number/hi_IN/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/hr_HR/__init__.py
+++ b/faker/providers/phone_number/hr_HR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/hu_HU/__init__.py
+++ b/faker/providers/phone_number/hu_HU/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/hy_AM/__init__.py
+++ b/faker/providers/phone_number/hy_AM/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/id_ID/__init__.py
+++ b/faker/providers/phone_number/id_ID/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/it_IT/__init__.py
+++ b/faker/providers/phone_number/it_IT/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ja_JP/__init__.py
+++ b/faker/providers/phone_number/ja_JP/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ko_KR/__init__.py
+++ b/faker/providers/phone_number/ko_KR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/lt_LT/__init__.py
+++ b/faker/providers/phone_number/lt_LT/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/lv_LV/__init__.py
+++ b/faker/providers/phone_number/lv_LV/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ne_NP/__init__.py
+++ b/faker/providers/phone_number/ne_NP/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/nl_BE/__init__.py
+++ b/faker/providers/phone_number/nl_BE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/nl_NL/__init__.py
+++ b/faker/providers/phone_number/nl_NL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/no_NO/__init__.py
+++ b/faker/providers/phone_number/no_NO/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/pl_PL/__init__.py
+++ b/faker/providers/phone_number/pl_PL/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/pt_PT/__init__.py
+++ b/faker/providers/phone_number/pt_PT/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ru_RU/__init__.py
+++ b/faker/providers/phone_number/ru_RU/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/sk_SK/__init__.py
+++ b/faker/providers/phone_number/sk_SK/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/sl_SI/__init__.py
+++ b/faker/providers/phone_number/sl_SI/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/sv_SE/__init__.py
+++ b/faker/providers/phone_number/sv_SE/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/ta_IN/__init__.py
+++ b/faker/providers/phone_number/ta_IN/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/th_TH/__init__.py
+++ b/faker/providers/phone_number/th_TH/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/tr_TR/__init__.py
+++ b/faker/providers/phone_number/tr_TR/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/tw_GH/__init__.py
+++ b/faker/providers/phone_number/tw_GH/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/uk_UA/__init__.py
+++ b/faker/providers/phone_number/uk_UA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/zh_CN/__init__.py
+++ b/faker/providers/phone_number/zh_CN/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 

--- a/faker/providers/phone_number/zh_TW/__init__.py
+++ b/faker/providers/phone_number/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as PhoneNumberProvider
 
 # phone number from https://en.wikipedia.org/wiki/Telephone_numbers_in_Taiwan

--- a/faker/providers/profile/__init__.py
+++ b/faker/providers/profile/__init__.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 
-from .. import BaseProvider
 import itertools
+
+from .. import BaseProvider
 
 
 class Provider(BaseProvider):

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import unicode_literals
 
-from decimal import Decimal
 import string
 import sys
+
+from decimal import Decimal
 
 import six
 

--- a/faker/providers/ssn/en_CA/__init__.py
+++ b/faker/providers/ssn/en_CA/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/en_GB/__init__.py
+++ b/faker/providers/ssn/en_GB/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/ssn/en_PH/__init__.py
+++ b/faker/providers/ssn/en_PH/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from ... import BaseProvider
 
 

--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -14,7 +14,6 @@ import string
 
 from .. import Provider as BaseProvider
 
-
 ALPHABET = string.ascii_uppercase
 ALPHANUMERIC = string.digits + ALPHABET
 VOWELS = "AEIOU"

--- a/faker/providers/ssn/et_EE/__init__.py
+++ b/faker/providers/ssn/et_EE/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 import datetime
 import operator
+
+from .. import Provider as SsnProvider
 
 
 def checksum(digits):

--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 import datetime
+
+from .. import Provider as SsnProvider
 
 
 class Provider(SsnProvider):

--- a/faker/providers/ssn/fr_CH/__init__.py
+++ b/faker/providers/ssn/fr_CH/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/he_IL/__init__.py
+++ b/faker/providers/ssn/he_IL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/hr_HR/__init__.py
+++ b/faker/providers/ssn/hr_HR/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/hu_HU/__init__.py
+++ b/faker/providers/ssn/hu_HU/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 from functools import reduce
 from math import fmod
+
+from .. import Provider as SsnProvider
 
 
 def zfix(d):

--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -2,9 +2,10 @@
 """it_IT ssn provider (yields italian fiscal codes)"""
 
 from __future__ import unicode_literals
-from string import ascii_uppercase, digits
-from .. import Provider as SsnProvider
 
+from string import ascii_uppercase, digits
+
+from .. import Provider as SsnProvider
 
 ALPHANUMERICS = sorted(digits + ascii_uppercase)
 ALPHANUMERICS_DICT = {char: index for index, char in enumerate(ALPHANUMERICS)}

--- a/faker/providers/ssn/ko_KR/__init__.py
+++ b/faker/providers/ssn/ko_KR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/nl_BE/__init__.py
+++ b/faker/providers/ssn/nl_BE/__init__.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
+
 
 """
 For more info on rijksregisternummer, see https://nl.wikipedia.org/wiki/Rijksregisternummer

--- a/faker/providers/ssn/nl_NL/__init__.py
+++ b/faker/providers/ssn/nl_NL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/no_NO/__init__.py
+++ b/faker/providers/ssn/no_NO/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 import datetime
 import operator
+
+from .. import Provider as SsnProvider
 
 
 def checksum(digits, scale):

--- a/faker/providers/ssn/pl_PL/__init__.py
+++ b/faker/providers/ssn/pl_PL/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/ru_RU/__init__.py
+++ b/faker/providers/ssn/ru_RU/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 import datetime
 import random
+
+from .. import Provider as SsnProvider
 
 
 class Provider(SsnProvider):

--- a/faker/providers/ssn/tr_TR/__init__.py
+++ b/faker/providers/ssn/tr_TR/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as BaseProvider
 
 

--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
-from .. import Provider as SsnProvider
+
 import datetime
+
+from .. import Provider as SsnProvider
 
 
 class Provider(SsnProvider):

--- a/faker/providers/ssn/zh_TW/__init__.py
+++ b/faker/providers/ssn/zh_TW/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 from .. import Provider as SsnProvider
 
 

--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import string
+
 from datetime import datetime
 
 from .. import BaseProvider

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -2,9 +2,11 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from collections import OrderedDict
 import random
 import re
+
+from collections import OrderedDict
+
 import six
 
 from faker.config import DEFAULT_LOCALE

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -1,4 +1,5 @@
 import unittest
+
 from faker import Faker
 
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -5,25 +5,25 @@ from __future__ import unicode_literals
 import re
 import unittest
 
-from ukpostcodeparser.parser import parse_uk_postcode
+from six import string_types
 
 from faker import Faker
 from faker.providers.address.de_AT import Provider as DeAtProvider
 from faker.providers.address.de_DE import Provider as DeProvider
-from faker.providers.address.fa_IR import Provider as IrProvider
 from faker.providers.address.el_GR import Provider as GrProvider
 from faker.providers.address.en_AU import Provider as EnAuProvider
 from faker.providers.address.en_CA import Provider as EnCaProvider
 from faker.providers.address.en_US import Provider as EnUsProvider
 from faker.providers.address.es_ES import Provider as EsEsProvider
 from faker.providers.address.es_MX import Provider as EsMxProvider
-from faker.providers.address.fr_FR import Provider as FrFrProvider
+from faker.providers.address.fa_IR import Provider as IrProvider
 from faker.providers.address.fi_FI import Provider as FiProvider
+from faker.providers.address.fr_FR import Provider as FrFrProvider
 from faker.providers.address.hy_AM import Provider as HyAmProvider
-from faker.providers.address.pt_PT import Provider as PtPtProvider
 from faker.providers.address.ja_JP import Provider as JaProvider
 from faker.providers.address.ne_NP import Provider as NeProvider
-from six import string_types
+from faker.providers.address.pt_PT import Provider as PtPtProvider
+from ukpostcodeparser.parser import parse_uk_postcode
 
 
 class TestBaseProvider(unittest.TestCase):

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 import re
 import unittest
 
-from faker import Faker
 from six import string_types
+
+from faker import Faker
 
 
 class TestPtBR(unittest.TestCase):

--- a/tests/providers/test_color.py
+++ b/tests/providers/test_color.py
@@ -1,14 +1,17 @@
 import copy
-import unittest
 import random
 import re
-from re import search
-from faker import Faker
+import unittest
 
+from re import search
+
+import six
+
+from six import string_types
+
+from faker import Faker
 from faker.providers.color import RandomColor
 from faker.providers.color.hy_AM import Provider as HyAmProvider
-import six
-from six import string_types
 
 
 class TestColor(unittest.TestCase):

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -12,9 +12,8 @@ from faker.providers.company import ru_RU as ru
 from faker.providers.company.hy_AM import Provider as HyAmProvider
 from faker.providers.company.ja_JP import Provider as JaProvider
 from faker.providers.company.nl_NL import Provider as NlProvider
-from faker.providers.company.pl_PL import (
-    company_vat_checksum, regon_checksum, local_regon_checksum, Provider as PlProvider,
-)
+from faker.providers.company.pl_PL import Provider as PlProvider
+from faker.providers.company.pl_PL import company_vat_checksum, local_regon_checksum, regon_checksum
 from faker.providers.company.pt_BR import company_id_checksum
 from faker.utils.datetime_safe import datetime
 

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -1,24 +1,27 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from datetime import date, datetime, timedelta, tzinfo
-from datetime import time as datetime_time
 import os
 import platform
-import pytest
 import random
 import sys
 import time
 import unittest
 
+from datetime import date, datetime
+from datetime import time as datetime_time
+from datetime import timedelta, tzinfo
+
 import six
+
+import pytest
 
 from faker import Faker
 from faker.providers.date_time import Provider as DatetimeProvider
-from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
+from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ta_IN import Provider as TaInProvider
 
 

--- a/tests/providers/test_file.py
+++ b/tests/providers/test_file.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-import unittest
 import re
+import unittest
 
 from faker import Faker
 

--- a/tests/providers/test_geo.py
+++ b/tests/providers/test_geo.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 
 import re
 import unittest
+
 from decimal import Decimal
+
 from six import string_types
 
 from faker import Faker

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -2,21 +2,24 @@
 
 from __future__ import unicode_literals
 
+import unittest
+
 from itertools import cycle
 
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-import pytest
 import six
 
-from validators import email as validate_email, domain as validate_domain
+import pytest
 
 from faker import Faker
 from faker.providers.person.ja_JP import Provider as JaProvider
 from faker.utils import text
+from validators import domain as validate_domain
+from validators import email as validate_email
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestInternetProvider(unittest.TestCase):

--- a/tests/providers/test_isbn.py
+++ b/tests/providers/test_isbn.py
@@ -1,8 +1,10 @@
 import unittest
-from faker.providers.isbn.en_US import Provider as ISBNProvider
-from faker.providers.isbn import ISBN10, ISBN13
-from faker.providers.isbn.rules import RegistrantRule
+
 import pytest
+
+from faker.providers.isbn import ISBN10, ISBN13
+from faker.providers.isbn.en_US import Provider as ISBNProvider
+from faker.providers.isbn.rules import RegistrantRule
 
 
 class TestISBN10(unittest.TestCase):

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+
 import csv
 import io
 import itertools
@@ -8,14 +9,15 @@ import tarfile
 import unittest
 import uuid
 import zipfile
+
 import six
+
+from faker import Faker
 
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
-
-from faker import Faker
 
 
 class TestMisc(unittest.TestCase):

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -2,29 +2,29 @@
 
 from __future__ import unicode_literals
 
+import datetime
 import re
 import unittest
-import datetime
+
 import six
+
+from faker import Faker
+from faker.providers.person.ar_AA import Provider as ArProvider
+from faker.providers.person.cs_CZ import Provider as CsCZProvider
+from faker.providers.person.fi_FI import Provider as FiProvider
+from faker.providers.person.hy_AM import Provider as HyAmProvider
+from faker.providers.person.ne_NP import Provider as NeProvider
+from faker.providers.person.pl_PL import Provider as PlPLProvider
+from faker.providers.person.pl_PL import checksum_identity_card_number as pl_checksum_identity_card_number
+from faker.providers.person.sv_SE import Provider as SvSEProvider
+from faker.providers.person.ta_IN import Provider as TaINProvider
+from faker.providers.person.zh_CN import Provider as ZhCNProvider
+from faker.providers.person.zh_TW import Provider as ZhTWProvider
 
 try:
     from unittest import mock
 except ImportError:
     import mock
-
-from faker import Faker
-from faker.providers.person.ar_AA import Provider as ArProvider
-from faker.providers.person.fi_FI import Provider as FiProvider
-from faker.providers.person.hy_AM import Provider as HyAmProvider
-from faker.providers.person.ne_NP import Provider as NeProvider
-from faker.providers.person.sv_SE import Provider as SvSEProvider
-from faker.providers.person.cs_CZ import Provider as CsCZProvider
-from faker.providers.person.pl_PL import Provider as PlPLProvider
-from faker.providers.person.pl_PL import (
-    checksum_identity_card_number as pl_checksum_identity_card_number)
-from faker.providers.person.zh_CN import Provider as ZhCNProvider
-from faker.providers.person.zh_TW import Provider as ZhTWProvider
-from faker.providers.person.ta_IN import Provider as TaINProvider
 
 
 class TestAr(unittest.TestCase):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -1,12 +1,13 @@
 #  -*- coding: utf-8 -*-
 
 import unittest
+
+from faker import Faker
+
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
-
-from faker import Faker
 
 
 class TestPyint(unittest.TestCase):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -4,24 +4,29 @@ from __future__ import unicode_literals
 
 import re
 import unittest
+
 from datetime import datetime
 from itertools import cycle
 
 import freezegun
 import pytest
 import random2
-from validators.i18n.es import es_cif as is_cif, es_nif as is_nif, es_nie as is_nie
 
 from faker import Faker
 from faker.providers.ssn.en_CA import checksum as ca_checksum
+from faker.providers.ssn.es_MX import curp_checksum as mx_curp_checksum
+from faker.providers.ssn.es_MX import ssn_checksum as mx_ssn_checksum
 from faker.providers.ssn.et_EE import checksum as et_checksum
 from faker.providers.ssn.fi_FI import Provider as fi_Provider
 from faker.providers.ssn.hr_HR import checksum as hr_checksum
-from faker.providers.ssn.no_NO import checksum as no_checksum, Provider as no_Provider
-from faker.providers.ssn.pl_PL import checksum as pl_checksum, calculate_month as pl_calculate_mouth
+from faker.providers.ssn.no_NO import Provider as no_Provider
+from faker.providers.ssn.no_NO import checksum as no_checksum
+from faker.providers.ssn.pl_PL import calculate_month as pl_calculate_mouth
+from faker.providers.ssn.pl_PL import checksum as pl_checksum
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
-from faker.providers.ssn.es_MX import (ssn_checksum as mx_ssn_checksum,
-                                       curp_checksum as mx_curp_checksum)
+from validators.i18n.es import es_cif as is_cif
+from validators.i18n.es import es_nie as is_nie
+from validators.i18n.es import es_nif as is_nif
 
 
 class TestSvSE(unittest.TestCase):

--- a/tests/providers/test_user_agent.py
+++ b/tests/providers/test_user_agent.py
@@ -2,8 +2,8 @@
 
 from __future__ import unicode_literals
 
-import unittest
 import re
+import unittest
 
 from faker import Faker
 from faker.providers.user_agent import Provider as UaProvider

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -6,21 +6,23 @@ import re
 import string
 import sys
 import unittest
-try:
-    from unittest.mock import patch, PropertyMock
-except ImportError:
-    from mock import patch, PropertyMock
 
 from collections import OrderedDict
 from ipaddress import ip_address, ip_network
 
-import pytest
 import six
+
+import pytest
 
 from faker import Faker, Generator
 from faker.factory import Factory
 from faker.generator import random
 from faker.utils import decorators, text
+
+try:
+    from unittest.mock import patch, PropertyMock
+except ImportError:
+    from mock import patch, PropertyMock
 
 
 class BarProvider(object):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -2,16 +2,18 @@
 
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 import unittest
-try:
-    from unittest.mock import patch, PropertyMock
-except ImportError:
-    from mock import patch, PropertyMock
+
+from collections import OrderedDict
 
 from faker import Faker
 from faker.config import DEFAULT_LOCALE
 from faker.generator import Generator
+
+try:
+    from unittest.mock import patch, PropertyMock
+except ImportError:
+    from mock import patch, PropertyMock
 
 
 class TestFakerProxyClass(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,35,36,37,38,py,py3},32bit,flake8,checkmanifest
+envlist=py{27,35,36,37,38,py,py3},32bit,flake8,checkmanifest,isort
 skip_missing_interpreters = true
 
 [testenv]
@@ -23,6 +23,12 @@ deps =
     check-manifest
 commands =
     check-manifest
+
+[testenv:isort]
+deps =
+    isort
+commands =
+    {envpython} -m isort --check-only --diff
 
 [testenv:32bit]
 basepython = python


### PR DESCRIPTION
isort was already configured in commit
93c937505a4009fcd95aa5e84ee44831330d59ff. Now include isort in the tox
matrix and run it during CI.

Fix faker/factory.py to avoid the circular dependency.

Fix isort early to reduce changes when dropping Python 2 support.

Refs #1063