### PR TITLE
add Birth Number to czech locale #1099

### DIFF
--- a/faker/providers/ssn/cs_CZ/__init__.py
+++ b/faker/providers/ssn/cs_CZ/__init__.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from .. import Provider as BaseProvider
 
 
@@ -32,12 +34,9 @@ class Provider(BaseProvider):
         else:
             sn = self.random_number(3, True)
         number = int('{}{}{}{}'.format(year, month, day, sn))
-        while number % 11 != 0:
-            number += 1
-        else:
-            number = str(number)
-            if year == '00':
-                number = '00' + number
-            elif year[0] == '0':
-                number = '0' + number
-            return '{}/{}'.format(number[:6], number[6::])
+        birth_number = str(ceil(number / 11) * 11)
+        if year == '00':
+            birth_number = '00' + birth_number
+        elif year[0] == '0':
+            birth_number = '0' + birth_number
+        return '{}/{}'.format(birth_number[:6], birth_number[6::])

--- a/faker/providers/ssn/cs_CZ/__init__.py
+++ b/faker/providers/ssn/cs_CZ/__init__.py
@@ -8,6 +8,8 @@ class Provider(BaseProvider):
         'CZ##########',
     )
 
+    national_id_months = ['%.2d' % i for i in range(1, 13)] + ['%.2d' % i for i in range(51, 63)]
+
     def vat_id(self):
         """
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
@@ -15,3 +17,27 @@ class Provider(BaseProvider):
         """
 
         return self.bothify(self.random_element(self.vat_id_formats))
+
+    def birth_number(self):
+        """
+        Birth Number (Czech/Slovak: rodné číslo (RČ))
+        https://en.wikipedia.org/wiki/National_identification_number#Czech_Republic_and_Slovakia
+        """
+        birthdate = self.generator.date_of_birth()
+        year = '%.2d' % (birthdate.year % 100)
+        month = self.random_element(self.national_id_months)
+        day = '%.2d' % birthdate.day
+        if birthdate.year > 1953:
+            sn = self.random_number(4, True)
+        else:
+            sn = self.random_number(3, True)
+        number = int('{}{}{}{}'.format(year, month, day, sn))
+        while number % 11 != 0:
+            number += 1
+        else:
+            number = str(number)
+            if year == '00':
+                number = '00' + number
+            elif year[0] == '0':
+                number = '0' + number
+            return '{}/{}'.format(number[:6], number[6::])

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -153,6 +153,13 @@ class TestCsCZ(unittest.TestCase):
         for _ in range(100):
             assert re.search(r'^CZ\d{8,10}$', self.fake.vat_id())
 
+    def test_birth_number(self):
+        for _ in range(100):
+            birth_number = self.fake.birth_number()
+            assert len(birth_number) in [10, 11]
+            assert birth_number[6] == "/"
+            assert int(birth_number.replace("/", "")) % 11 == 0
+
 
 class TestDeAT(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this changes

Adds `birth_number` functionality to Czech locale, which is National Identification Number used by Czech Republic and Slovakia as requested in #1099 

Source: https://en.wikipedia.org/wiki/National_identification_number#Czech_Republic_and_Slovakia


### What was wrong

Added functionality

### How this fixes it

Generates a birth number (who's whole number is divisible by 11) that adheres to the following formats
```
######/###
######/####
```
depending on if you were born before or after Jan 1, 1954

Fixes #1099 
