### PR TITLE
Remove 'setup_requires=["pytest-runner"]' from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     platforms=["any"],
     zip_safe=zip_safe,
     python_requires=">=3.4",
-    setup_requires=["pytest-runner"],
     install_requires=[
         "python-dateutil>=2.4",
         "text-unidecode==1.3",


### PR DESCRIPTION
Was removed in 6c4fde452829f539e27432a07de7ca7ba4289712 and mistakenly
reintroduced in 6e4a09eb381b3a6fa055c0b47f61dee1c13d9754. Probably a bad
rebase/merge.