### PR TITLE
Formatting option for Brazilian postcodes

### DIFF
--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -295,6 +295,12 @@ class Provider(AddressProvider):
         :example 'Serra'
         """
         return self.random_element(self.bairros)
+    
+    def postcode(self, formatted=True):
+        postcode_raw_formats = ('########', )
+        postcode_all_formats = postcode_raw_formats + ( '#####-###', )
+        template = postcode_all_formats if formatted else postcode_raw_formats
+        return self.bothify(self.random_element(template))
 
     # aliases
     def neighborhood(self):

--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -100,7 +100,7 @@ class Provider(AddressProvider):
     building_number_formats = ('%', '%#', '%#', '%#', '%##')
 
     postcode_raw_formats = ('########', )
-    postcode_all_formats = postcode_raw_formats + ( '#####-###', )
+    postcode_all_formats = postcode_raw_formats + ('#####-###', )
 
     bairros = (
         'Aarão Reis', 'Acaba Mundo', 'Acaiaca', 'Ademar Maldonado', 'Aeroporto', 'Aguas Claras', 'Alípio De Melo',
@@ -296,7 +296,7 @@ class Provider(AddressProvider):
         :example 'Serra'
         """
         return self.random_element(self.bairros)
-    
+
     def postcode(self, formatted=True):
         """
         Randomly returns a postcode.
@@ -304,7 +304,7 @@ class Provider(AddressProvider):
         :example formatted: '41224-212' '83992-291' '12324322'
         :example raw: '43920231' '34239530'
         """
-        template = postcode_all_formats if formatted else postcode_raw_formats
+        template = self.postcode_all_formats if formatted else self.postcode_raw_formats
         return self.bothify(self.random_element(template))
 
     # aliases

--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -99,7 +99,8 @@ class Provider(AddressProvider):
 
     building_number_formats = ('%', '%#', '%#', '%#', '%##')
 
-    postcode_formats = ('########', '#####-###')
+    postcode_raw_formats = ('########', )
+    postcode_all_formats = postcode_raw_formats + ( '#####-###', )
 
     bairros = (
         'Aarão Reis', 'Acaba Mundo', 'Acaiaca', 'Ademar Maldonado', 'Aeroporto', 'Aguas Claras', 'Alípio De Melo',
@@ -297,8 +298,12 @@ class Provider(AddressProvider):
         return self.random_element(self.bairros)
     
     def postcode(self, formatted=True):
-        postcode_raw_formats = ('########', )
-        postcode_all_formats = postcode_raw_formats + ( '#####-###', )
+        """
+        Randomly returns a postcode.
+        :param formatted: True to allow formatted postcodes, else False (default True)
+        :example formatted: '41224-212' '83992-291' '12324322'
+        :example raw: '43920231' '34239530'
+        """
         template = postcode_all_formats if formatted else postcode_raw_formats
         return self.bothify(self.random_element(template))
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1028,7 +1028,7 @@ class TestPtBr(unittest.TestCase):
 
         address = self.fake.address()
         assert isinstance(address, str)
-    
+
     def test_raw_postcode(self):
         for _ in range(100):
             postcode = self.fake.postcode(formatted=False)
@@ -1040,7 +1040,6 @@ class TestPtBr(unittest.TestCase):
             postcode = self.fake.postcode()
             assert isinstance(postcode, str)
             assert re.match(r'^\d{5}-?\d{3}$', postcode)
-        
 
 
 class TestPtPT(unittest.TestCase):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1028,6 +1028,19 @@ class TestPtBr(unittest.TestCase):
 
         address = self.fake.address()
         assert isinstance(address, str)
+    
+    def test_raw_postcode(self):
+        for _ in range(100):
+            postcode = self.fake.postcode(formatted=False)
+            assert isinstance(postcode, str)
+            assert re.match(r'^\d{8}$', postcode)
+
+    def test_formatted_postcode(self):
+        for _ in range(100):
+            postcode = self.fake.postcode()
+            assert isinstance(postcode, str)
+            assert re.match(r'^\d{5}-?\d{3}$', postcode)
+        
 
 
 class TestPtPT(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Adds the ability to get raw Brazilian postcodes, i.e without the '-' by setting the new option `formatted` to `false`

### What was wrong

Previously the provided returned formatted and non-formatted postcodes at random.

### How this fixes it

Added an option to the provider to only use the raw template format

Fixes #1086 
