### PR TITLE
Adds support for Indian Aadhaar numbers (#1133)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,7 @@ Included localized providers:
 -  `en\_AU <https://faker.readthedocs.io/en/master/locales/en_AU.html>`__ - English (Australia)
 -  `en\_CA <https://faker.readthedocs.io/en/master/locales/en_CA.html>`__ - English (Canada)
 -  `en\_GB <https://faker.readthedocs.io/en/master/locales/en_GB.html>`__ - English (Great Britain)
+-  `en\_IN <https://faker.readthedocs.io/en/master/locales/en_IN.html>`__ - English (India)
 -  `en\_NZ <https://faker.readthedocs.io/en/master/locales/en_NZ.html>`__ - English (New Zealand)
 -  `en\_US <https://faker.readthedocs.io/en/master/locales/en_US.html>`__ - English (United States)
 -  `es\_ES <https://faker.readthedocs.io/en/master/locales/es_ES.html>`__ - Spanish (Spain)

--- a/faker/providers/ssn/en_IN/__init__.py
+++ b/faker/providers/ssn/en_IN/__init__.py
@@ -1,0 +1,28 @@
+from faker.utils import checksums
+
+from .. import Provider as BaseProvider
+
+
+class Provider(BaseProvider):
+    """
+    Faker provider for Indian Identifiers
+    """
+
+    aadhaar_id_formats = (
+        '%##########',
+    )
+
+    def aadhaar_id(self):
+        """
+        Aadhaar is a 12 digit person identifier generated for residents of
+        India.
+        Details: https://en.wikipedia.org/wiki/Aadhaar
+        Official Website: https://uidai.gov.in/my-aadhaar/about-your-aadhaar.html
+        """
+        
+        aadhaar_digits = self.numerify(self.random_element(self.aadhaar_id_formats))
+        checksum = checksums.calculate_luhn(aadhaar_digits)
+
+        aadhaar_number = '{}{}'.format(aadhaar_digits,checksum)
+
+        return aadhaar_number

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -1,28 +1,12 @@
 import datetime
 import random
 
+from faker.utils.checksums import calculate_luhn, luhn_checksum
+
 from .. import Provider as SsnProvider
 
 
 class Provider(SsnProvider):
-
-    @staticmethod
-    def _luhn_checksum(number):
-        def digits_of(n):
-            return [int(d) for d in str(n)]
-        digits = digits_of(number)
-        odd_digits = digits[-1::-2]
-        even_digits = digits[-2::-2]
-        checksum = 0
-        checksum += sum(odd_digits)
-        for d in even_digits:
-            checksum += sum(digits_of(d * 2))
-        return checksum % 10
-
-    @staticmethod
-    def _calculate_luhn(partial_number):
-        check_digit = Provider._luhn_checksum(int(partial_number) * 10)
-        return check_digit if check_digit == 0 else 10 - check_digit
 
     @staticmethod
     def _org_to_vat(org_id):
@@ -52,7 +36,7 @@ class Provider(SsnProvider):
         pnr_date = birthday.strftime('{}%m%d'.format(yr_fmt))
         chk_date = pnr_date[2:] if long else pnr_date
         suffix = str(self.generator.random.randrange(0, 999)).zfill(3)
-        luhn_checksum = str(Provider._calculate_luhn(chk_date + suffix))
+        luhn_checksum = str(calculate_luhn(chk_date + suffix))
         hyphen = '-' if dash else ''
         pnr = '{}{}{}{}'.format(pnr_date, hyphen, suffix, luhn_checksum)
 
@@ -73,7 +57,7 @@ class Provider(SsnProvider):
         onr_one += str(self.generator.random.randrange(20, 99))
         onr_one += str(self.generator.random.randrange(0, 99)).zfill(2)
         onr_two = str(self.generator.random.randrange(0, 999)).zfill(3)
-        luhn_checksum = str(Provider._calculate_luhn(onr_one + onr_two))
+        luhn_checksum = str(calculate_luhn(onr_one + onr_two))
         prefix = '16' if long else ''
         hyphen = '-' if dash else ''
 

--- a/faker/utils/checksums.py
+++ b/faker/utils/checksums.py
@@ -1,0 +1,20 @@
+def luhn_checksum(number):
+    def digits_of(n):
+        return [int(d) for d in str(n)]
+
+    digits = digits_of(number)
+    odd_digits = digits[-1::-2]
+    even_digits = digits[-2::-2]
+    checksum = 0
+    checksum += sum(odd_digits)
+    for d in even_digits:
+        checksum += sum(digits_of(d * 2))
+    return checksum % 10
+
+
+def calculate_luhn(partial_number):
+    """
+    Generates the Checksum using Luhn's algorithm
+    """
+    check_digit = luhn_checksum(int(partial_number) * 10)
+    return check_digit if check_digit == 0 else 10 - check_digit

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -900,3 +900,14 @@ class TestTrTr(unittest.TestCase):
             first_ten_number = sample[:-1]
             last_part = sample[-1]
             assert sum(list(map(lambda x: int(x), '{}'.format(first_ten_number)))) % 10 == last_part
+
+
+
+class TestEnIn(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker('en_IN')
+        Faker.seed(0)
+
+    def check_length(self):
+        aadhar_id = self.fake.aadhar_id()
+        assert len(aadhar_id) == 12

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -6,6 +6,7 @@ from importlib import import_module
 
 from faker.config import META_PROVIDERS_MODULES, PROVIDERS
 from faker.generator import random
+from faker.utils.checksums import calculate_luhn, luhn_checksum
 from faker.utils.datasets import add_dicts
 from faker.utils.distribution import choices_distribution, choices_distribution_unique
 from faker.utils.loading import find_available_locales, find_available_providers
@@ -92,3 +93,26 @@ class UtilsTestCase(unittest.TestCase):
             'faker.providers.user_agent',
         ]))
         assert providers == expected_providers
+
+    def test_luhn_checksum(self):
+        """
+        Tests if a valid checksum is generated
+        Example from wiki: https://en.wikipedia.org/wiki/Luhn_algorithm
+        """
+        check_digit = calculate_luhn("7992739871")
+        assert check_digit == 3
+
+    def test_valid_luhn(self):
+        """
+        Tests if the number has a valid check digit
+        Example from wiki https://en.wikipedia.org/wiki/Luhn_algorithm
+        """
+        assert luhn_checksum("79927398713") == 0
+
+    def test_invalid_luhn(self):
+        """
+        Tests a number with an invalid check digit
+        Example from wiki https://en.wikipedia.org/wiki/Luhn_algorithm
+        """
+        assert luhn_checksum("79927398714") != 0
+


### PR DESCRIPTION

### What does this changes
Adds support for Indian [aadhaar](https://en.wikipedia.org/wiki/Aadhaar) numbers . 

Brief summary of the changes:

Aadhaar number generation has been added within the en_IN locale which is Indian English. This locale is the most commonly used one in India. The locale did not exist previously in Faker.

As we needed to use a Luhn  check - moved an existing implementation from the sv_SE ssn provider to utils along with additional tests


