### PR TITLE
#1131 Fixes issue where pydict provider was not returing the correct …

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -163,7 +163,7 @@ class Provider(BaseProvider):
             nb_elements = self.randomize_nb_elements(nb_elements, min=1)
 
         return dict(zip(
-            self.generator.words(nb_elements),
+            self.generator.words(nb_elements, unique=True),
             self._pyiterable(nb_elements, False, *value_types),
         ))
 


### PR DESCRIPTION
…number of elements.

### What does this changes

Changes python provider pydict word generator call

### What was wrong

Word generator was not returning unique words causing the returned dict to not equal the number of elements defined by nb_elements

### How this fixes it

Add unique=True to the words call to ensure no duplicate words are returned

Fixes #1131 
