### PR TITLE
Implements __dir__ method to Faker proxy

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -55,6 +55,14 @@ class Faker:
         self._locales = locales
         self._factories = list(self._factory_map.values())
 
+    def __dir__(self):
+        attributes = set(super(Faker, self).__dir__())
+        for factory in self.factories:
+            attributes |= {
+                attr for attr in dir(factory) if not attr.startswith('_')
+            }
+        return sorted(attributes)
+
     def __getitem__(self, locale):
         return self._factory_map[locale.replace('-', '_')]
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -299,3 +299,18 @@ class TestFakerProxyClass(unittest.TestCase):
         self.fake = Faker(['en_US', 'en_PH'])
         with self.assertRaises(AttributeError):
             self.fake.obviously_invalid_provider_method_a23f()
+
+    def test_dir_include_all_providers_attribute_in_list(self):
+        self.fake = Faker(['en_US', 'en_PH'])
+        expected = set(dir(Faker) + [
+            '_factories', '_locales', '_factory_map', '_weights',
+        ])
+        for factory in self.fake.factories:
+            expected |= {
+                attr for attr in dir(factory) if not attr.startswith('_')
+            }
+        expected = sorted(expected)
+
+        attributes = dir(self.fake)
+
+        assert attributes == expected


### PR DESCRIPTION
### What does this changes

Implements __dir__ magic method to Faker proxy. This allows when trying to list/show all methods of all providers in IPython, for example:

![image](https://user-images.githubusercontent.com/3184883/78265490-e0b6f280-74da-11ea-9f5b-672e01226355.png)