### PR TITLE
When creating a custom provider, class name does not need to be Provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,13 +273,13 @@ How to create a Provider
     # first, import a similar Provider or use the default one
     from faker.providers import BaseProvider
 
-    # create new provider class. Note that the class name _must_ be ``Provider``.
-    class Provider(BaseProvider):
+    # create new provider class
+    class MyProvider(BaseProvider):
         def foo(self):
             return 'bar'
 
     # then add new provider to faker instance
-    fake.add_provider(Provider)
+    fake.add_provider(MyProvider)
 
     # now you can use:
     fake.foo()


### PR DESCRIPTION
### What does this changes

In the README, when creating a provider we no longer indicate that it is required to name the class `Provider`.

### What was wrong

In the README, it is indicated that when creating a custom provider we must name the class `Provider`. 

Must of [community providers](https://faker.readthedocs.io/en/master/communityproviders.html) does not follow this rule for example.

### How this fixes it

This is a revert of commit [190b4a2](https://github.com/joke2k/faker/commit/190b4a2d60246e05cd0018a98f563adf09a33a91).
