### PR TITLE
providers.misc.uuid with `cast_to=None` case to return `UUID` object

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -92,6 +92,9 @@ class Provider(BaseProvider):
         By default, ``cast_to`` is set to ``str``.
 
         May be called with ``cast_to=None`` to return a full-fledged ``UUID``.
+
+        :sample:
+        :sample: cast_to=None
         """
         # Based on http://stackoverflow.com/q/41186818
         generated_uuid = uuid.UUID(int=self.generator.random.getrandbits(128), version=4)

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -87,12 +87,17 @@ class Provider(BaseProvider):
         return res.hexdigest()
 
     def uuid4(self, cast_to=str):
-        """Generate a random UUID4 object and cast it to another type using a callable ``cast_to``.
+        """Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
 
         By default, ``cast_to`` is set to ``str``.
+
+        May be called with ``cast_to=None`` to return a full-fledged ``UUID``.
         """
         # Based on http://stackoverflow.com/q/41186818
-        return cast_to(uuid.UUID(int=self.generator.random.getrandbits(128), version=4))
+        generated_uuid = uuid.UUID(int=self.generator.random.getrandbits(128), version=4)
+        if cast_to is not None:
+            generated_uuid = cast_to(generated_uuid)
+        return generated_uuid
 
     def password(
             self,

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -17,7 +17,7 @@ class TestMisc(unittest.TestCase):
         self.fake = Faker()
         Faker.seed(0)
 
-    def test_uuid4(self):
+    def test_uuid4_str(self):
         uuid4 = self.fake.uuid4()
         assert uuid4
         assert isinstance(uuid4, str)
@@ -28,7 +28,7 @@ class TestMisc(unittest.TestCase):
         assert isinstance(uuid4, int)
 
     def test_uuid4_uuid_object(self):
-        uuid4 = self.fake.uuid4(cast_to=lambda x: x)
+        uuid4 = self.fake.uuid4(cast_to=None)
         assert uuid4
         assert isinstance(uuid4, uuid.UUID)
 


### PR DESCRIPTION
### What does this changes

providers.misc.uuid now doesn't have to always cast to another type.

### What was wrong

providers.misc.uuid would always cast to another type.

### How this fixes it

Added None arg verification.

Fixes #1163 
