### PR TITLE
Use repr for sample stringification

### DIFF
--- a/docs/writing-docs.rst
+++ b/docs/writing-docs.rst
@@ -2,7 +2,7 @@ Writing Documentation
 =====================
 
 Everything under :doc:`Standard Providers <providers>` and :doc:`Localized Providers <locales>`
-iss automatically generated using ``sphinx.ext.autodoc`` which pulls docstrings from provider
+is automatically generated using ``sphinx.ext.autodoc`` which pulls docstrings from provider
 methods during the ``sphinx-build`` process. This also means that the docstrings must be written
 in valid ``reStructuredText``.
 

--- a/faker/sphinx/docstring.py
+++ b/faker/sphinx/docstring.py
@@ -173,20 +173,7 @@ class ProviderMethodDocstring:
         return result.strip()
 
     def _stringify_result(self, value):
-        def _repl_whitespace(match):
-            value = match.group(0)
-            if value == '\r':
-                return '\\r'
-            elif value == '\n':
-                return '\\n'
-            elif value == '\t':
-                return '\\t'
-
-        if isinstance(value, str):
-            template = '"{}"' if '"' not in value and "'" in value else "'{}'"
-            return template.format(re.sub(r'[\r\n\t]', _repl_whitespace, value))
-        else:
-            return str(value)
+        return repr(value)
 
     def _generate_eval_scope(self):
         from collections import OrderedDict  # noqa: F401 Do not remove! The eval command needs this reference.

--- a/tests/sphinx/test_docstring.py
+++ b/tests/sphinx/test_docstring.py
@@ -83,35 +83,53 @@ class TestProviderMethodDocstring(unittest.TestCase):
         assert args[0] == '{path}:docstring of {name}: WARNING: Test Warning 2'.format(path=path, name=name)
 
     def test_stringify_results(self):
+
+        class TestObject:
+
+            def __repr__(self):
+                return 'abcdefg'
+
+        faker = Faker()
+        faker.seed_instance(0)
         docstring = ProviderMethodDocstring(
             app=MagicMock(), what='method',
             name='faker.providers.BaseProvider.bothify',
             obj=MagicMock, options=MagicMock(), lines=[],
         )
         results = [
-            '',                     # Empty string
-            '\'',                   # Single quote literal (escaped)
-            "'",                    # Single quote literal (unescaped)
-            '"',                    # Double quote literal (unescaped)
-            "\"",                   # Double quote literal (escaped)
-            'aa\taaaaa\r\n',        # String containing \t, \r, \n
-            b'abcdef',              # Bytes object
-            True,                   # Booleans
+            '',                             # Empty string
+            '\'',                           # Single quote literal (escaped)
+            "'",                            # Single quote literal (unescaped)
+            '"',                            # Double quote literal (unescaped)
+            "\"",                           # Double quote literal (escaped)
+            'aa\taaaaa\r\n',                # String containing \t, \r, \n
+            b'abcdef',                      # Bytes object
+            True,                           # Booleans
             False,
-            None,                   # None types
+            None,                           # None types
+            [1, 2, 3, 4, 5],                # Other non-primitives
+            (1, 2, 3, 4, 5),
+            {1: 2, 2: 3, 3: 4, 4: 5},
+            faker.uuid4(cast_to=None),
+            TestObject(),
         ]
         output = [docstring._stringify_result(result) for result in results]
         assert output == [
-            "''",                       # Ends up as '' when printed
-            '"\'"',                     # Ends up as "'" when printed
-            '"\'"',                     # Ends up as "'" when printed
-            '\'"\'',                    # Ends up as '"' when printed
-            '\'"\'',                    # Ends up as '"' when printed
-            "'aa\\taaaaa\\r\\n'",       # Ends up as 'aa\\taaaaa\\r\\n' when printed
-            "b'abcdef'",                # Ends up as b'abcdef' when printed
-            'True',                     # Ends up as True when printed
-            'False',
-            'None',                     # Ends up as None when printed
+            "''",                                               # Ends up as '' when printed
+            '"\'"',                                             # Ends up as "'" when printed
+            '"\'"',                                             # Ends up as "'" when printed
+            '\'"\'',                                            # Ends up as '"' when printed
+            '\'"\'',                                            # Ends up as '"' when printed
+            "'aa\\taaaaa\\r\\n'",                               # Ends up as 'aa\\taaaaa\\r\\n' when printed
+            "b'abcdef'",                                        # Ends up as b'abcdef' when printed
+            'True',                                             # Ends up as True when printed
+            'False',                                            # Ends up as False when printed
+            'None',                                             # Ends up as None when printed
+            '[1, 2, 3, 4, 5]',                                  # Ends up using object's __repr__
+            '(1, 2, 3, 4, 5)',
+            '{1: 2, 2: 3, 3: 4, 4: 5}',
+            "UUID('e3e70682-c209-4cac-a29f-6fbed82c07cd')",
+            'abcdefg',
         ]
 
     @mock.patch.object(ProviderMethodDocstring, '_log_warning')


### PR DESCRIPTION
Since #1164 was merged, the `uuid4` provider method now has an option to return a version 4 `UUID` object. The sample output in the  [docs](https://faker.readthedocs.io/en/master/providers/faker.providers.misc.html#faker.providers.misc.Provider.uuid4) does not look good/accurate though.

I do not know what had gotten into me as I attempted to reinvent the wheel to mimic Python interactive shell output, but I should have just used the builtin `repr` function for sample stringification. This PR is to correct that mistake and to properly mimic console output of non-primitives. This also fixes a very minor typo.
