### PR TITLE
Add provider for Slovak birth_number

### DIFF
--- a/faker/providers/ssn/sk_SK/__init__.py
+++ b/faker/providers/ssn/sk_SK/__init__.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from .. import Provider as BaseProvider
 
 
@@ -10,6 +12,8 @@ class Provider(BaseProvider):
         'SK##########',
     )
 
+    national_id_months = ['%.2d' % i for i in range(1, 13)] + ['%.2d' % i for i in range(51, 63)]
+
     def vat_id(self):
         """
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
@@ -17,3 +21,24 @@ class Provider(BaseProvider):
         """
 
         return self.bothify(self.random_element(self.vat_id_formats))
+
+    def birth_number(self):
+        """
+        Birth Number (Czech/Slovak: rodné číslo (RČ))
+        https://en.wikipedia.org/wiki/National_identification_number#Czech_Republic_and_Slovakia
+        """
+        birthdate = self.generator.date_of_birth()
+        year = '%.2d' % (birthdate.year % 100)
+        month = self.random_element(self.national_id_months)
+        day = '%.2d' % birthdate.day
+        if birthdate.year > 1953:
+            sn = self.random_number(4, True)
+        else:
+            sn = self.random_number(3, True)
+        number = int('{}{}{}{}'.format(year, month, day, sn))
+        birth_number = str(ceil(number / 11) * 11)
+        if year == '00':
+            birth_number = '00' + birth_number
+        elif year[0] == '0':
+            birth_number = '0' + birth_number
+        return '{}/{}'.format(birth_number[:6], birth_number[6::])

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -162,6 +162,23 @@ class TestCsCZ(unittest.TestCase):
             assert int(birth_number.replace("/", "")) % 11 == 0
 
 
+class TestSkSK(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker('sk_SK')
+        Faker.seed(0)
+
+    def test_vat_id(self):
+        for _ in range(100):
+            assert re.search(r'^SK\d{10}$', self.fake.vat_id())
+
+    def test_birth_number(self):
+        for _ in range(100):
+            birth_number = self.fake.birth_number()
+            assert len(birth_number) in [10, 11]
+            assert birth_number[6] == "/"
+            assert int(birth_number.replace("/", "")) % 11 == 0
+
+
 class TestDeAT(unittest.TestCase):
     def setUp(self):
         self.fake = Faker('de_AT')


### PR DESCRIPTION
### What does this changes

Add `birth_number()` to `ssn/sk_SK`

### What was wrong

The Slovak version was missing.

### How this fixes it

Copy it from `cs_CZ` because they are the same (Wikipedia article linked in the method mentions both countries that were Czechoslovakia prior to 1993). Add tests.
