### PR TITLE
Add provider for German day_of_week and month_name

### DIFF
--- a/faker/providers/date_time/de_DE/__init__.py
+++ b/faker/providers/date_time/de_DE/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "Sonntag",
+        "1": "Montag",
+        "2": "Dienstag",
+        "3": "Mittwoch",
+        "4": "Donnerstag",
+        "5": "Freitag",
+        "6": "Samstag",
+    }
+
+    MONTH_NAMES = {
+        "01": "Januar",
+        "02": "Februar",
+        "03": "März",
+        "04": "April",
+        "05": "Mai",
+        "06": "Juni",
+        "07": "Juli",
+        "08": "August",
+        "09": "September",
+        "10": "Oktober",
+        "11": "November",
+        "12": "Dezember",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -18,6 +18,7 @@ from faker.providers.date_time import Provider as DatetimeProvider
 from faker.providers.date_time import change_year
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
+from faker.providers.date_time.de_DE import Provider as DeDeProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
 from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ru_RU import Provider as RuProvider
@@ -516,6 +517,21 @@ class TestDateTime(unittest.TestCase):
         # 0 is an invalid year, so it should still raise a ValueError
         with self.assertRaises(ValueError):
             change_year(today, -today.year)
+
+
+class TestDeDe(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('de_DE')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in DeDeProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in DeDeProvider.MONTH_NAMES.values()
 
 
 class TestPlPL(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

Add `day_of_week` and `month_name` to date_time/de_DE

### What was wrong

It was missing

### How this fixes it

Add the seven days of the week and twelve months of a year in standard German.
