### PR TITLE
Synchronize cs_CZ and sk_SK address provider and split postcodes

### DIFF
--- a/faker/providers/address/cs_CZ/__init__.py
+++ b/faker/providers/address/cs_CZ/__init__.py
@@ -11,8 +11,8 @@ class Provider(AddressProvider):
 
     building_number_formats = ('%', '%#', '%##')
 
-    street_suffixes_long = ('náměstí', )
-    street_suffixes_short = ('nám.', )
+    street_suffixes_long = ('ulice', 'třída', 'nábřeží', 'náměstí')
+    street_suffixes_short = ('ul.', 'tř.', 'nábř.', 'nám.')
 
     postcode_formats = (
         "1## ##",

--- a/faker/providers/address/cs_CZ/__init__.py
+++ b/faker/providers/address/cs_CZ/__init__.py
@@ -9,7 +9,7 @@ class Provider(AddressProvider):
     street_address_formats = ('{{street_name}} {{building_number}}', )
     address_formats = ('{{street_address}}\n{{postcode}} {{city}}', )
 
-    building_number_formats = ('###', '##', '#', '#/#')
+    building_number_formats = ('%', '%#', '%##')
 
     street_suffixes_long = ('náměstí', )
     street_suffixes_short = ('nám.', )

--- a/faker/providers/address/cs_CZ/__init__.py
+++ b/faker/providers/address/cs_CZ/__init__.py
@@ -14,7 +14,15 @@ class Provider(AddressProvider):
     street_suffixes_long = ('náměstí', )
     street_suffixes_short = ('nám.', )
 
-    postcode_formats = ('### ##', )
+    postcode_formats = (
+        "1## ##",
+        "2## ##",
+        "3## ##",
+        "4## ##",
+        "5## ##",
+        "6## ##",
+        "7## ##",
+    )
 
     cities = (
         'Abertamy', 'Adamov', 'Andělská Hora', 'Bakov nad Jizerou', 'Bavorov',
@@ -754,9 +762,6 @@ class Provider(AddressProvider):
 
     def state(self):
         return self.random_element(self.states)
-
-    def postcode(self):
-        return self.bothify(self.random_element(self.postcode_formats))
 
     def city_with_postcode(self):
         return self.postcode() + " " + self.random_element(self.cities)

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -8,7 +8,7 @@ class Provider(AddressProvider):
     street_address_formats = ('{{street_name}} {{building_number}}', )
     address_formats = ('{{street_address}}\n{{postcode}} {{city}}', )
 
-    building_number_formats = ('####', '###', '##', '#', '#/#')
+    building_number_formats = ('%', '%#', '%##')
 
     street_suffixes_long = ('ulica', )
     street_suffixes_short = ('ul.', )

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -1157,3 +1157,6 @@ class Provider(AddressProvider):
 
     def state(self):
         return self.random_element(self.states)
+
+    def city_with_postcode(self):
+        return self.postcode() + " " + self.random_element(self.cities)

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -10,8 +10,8 @@ class Provider(AddressProvider):
 
     building_number_formats = ('%', '%#', '%##')
 
-    street_suffixes_long = ('ulica', )
-    street_suffixes_short = ('ul.', )
+    street_suffixes_long = ('ulica', 'trieda', 'nábrežie', 'námestie')
+    street_suffixes_short = ('ul.', 'tr.', 'nábr.', 'nám.')
 
     postcode_formats = (
         "8## ##",

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -13,7 +13,11 @@ class Provider(AddressProvider):
     street_suffixes_long = ('ulica', )
     street_suffixes_short = ('ul.', )
 
-    postcode_formats = ('### ##', )
+    postcode_formats = (
+        "8## ##",
+        "9## ##",
+        "0## ##",
+    )
 
     cities = (
         'Ábelová', 'Abovce', 'Abrahám', 'Abrahámovce', 'Abrahámovce',

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -33,6 +33,7 @@ from faker.providers.address.no_NO import Provider as NoNoAddressProvider
 from faker.providers.address.pt_BR import Provider as PtBrAddressProvider
 from faker.providers.address.pt_PT import Provider as PtPtAddressProvider
 from faker.providers.address.ru_RU import Provider as RuRuAddressProvider
+from faker.providers.address.sk_SK import Provider as SkSkAddressProvider
 from faker.providers.address.ta_IN import Provider as TaInAddressProvider
 from faker.providers.address.th_TH import Provider as ThThAddressProvider
 from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
@@ -1507,3 +1508,51 @@ class TestEnIn:
             state = faker.state()
             assert isinstance(state, str)
             assert state in EnInAddressProvider.states
+
+
+class TestSkSk:
+    """Test sk_SK address provider methods"""
+
+    def test_street_suffix_short(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_suffix_short = faker.street_suffix_short()
+            assert isinstance(street_suffix_short, str)
+            assert street_suffix_short in SkSkAddressProvider.street_suffixes_short
+
+    def test_street_suffix_long(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_suffix_long = faker.street_suffix_long()
+            assert isinstance(street_suffix_long, str)
+            assert street_suffix_long in SkSkAddressProvider.street_suffixes_long
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city = faker.city_name()
+            assert isinstance(city, str)
+            assert city in SkSkAddressProvider.cities
+
+    def test_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_name = faker.street_name()
+            assert isinstance(street_name, str)
+            assert street_name in SkSkAddressProvider.streets
+
+    def test_state(self, faker, num_samples):
+        for _ in range(num_samples):
+            state = faker.state()
+            assert isinstance(state, str)
+            assert state in SkSkAddressProvider.states
+
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            assert re.fullmatch(r'\d{3} \d{2}', postcode)
+
+    def test_city_with_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_with_postcode = faker.city_with_postcode()
+            assert isinstance(city_with_postcode, str)
+            match = re.fullmatch(r'\d{3} \d{2} (?P<city>.*)',
+                                 city_with_postcode)
+            assert match.group('city') in SkSkAddressProvider.cities


### PR DESCRIPTION
Both address providers should now behave similarly.
The common Czechoslovak postcode system was split in 1993 and both countries CZ and SK kept their parts: CZ starts with 1 to 7, SK with 8 to 0. The standard `postcode()` method may be used to format it.
The `building_number` has been changed to a meaningful 1 to 3 digits number not starting with a zero.
Added more `street_suffixes`.