### PR TITLE
Add date_time providers for cs_CZ, de_AT, es_ES, it_IT, sk_SK, tr_TR

### DIFF
--- a/faker/providers/date_time/cs_CZ/__init__.py
+++ b/faker/providers/date_time/cs_CZ/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "neděle",
+        "1": "pondělí",
+        "2": "úterý",
+        "3": "středa",
+        "4": "čtvrtek",
+        "5": "pátek",
+        "6": "sobota",
+    }
+
+    MONTH_NAMES = {
+        "01": "leden",
+        "02": "únor",
+        "03": "březen",
+        "04": "duben",
+        "05": "květen",
+        "06": "červen",
+        "07": "červenec",
+        "08": "srpen",
+        "09": "září",
+        "10": "říjen",
+        "11": "listopad",
+        "12": "prosinec",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/faker/providers/date_time/de_AT/__init__.py
+++ b/faker/providers/date_time/de_AT/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "Sonntag",
+        "1": "Montag",
+        "2": "Dienstag",
+        "3": "Mittwoch",
+        "4": "Donnerstag",
+        "5": "Freitag",
+        "6": "Samstag",
+    }
+
+    MONTH_NAMES = {
+        "01": "Jänner",
+        "02": "Februar",
+        "03": "März",
+        "04": "April",
+        "05": "Mai",
+        "06": "Juni",
+        "07": "Juli",
+        "08": "August",
+        "09": "September",
+        "10": "Oktober",
+        "11": "November",
+        "12": "Dezember",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/faker/providers/date_time/es_ES/__init__.py
+++ b/faker/providers/date_time/es_ES/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "domingo",
+        "1": "lunes",
+        "2": "martes",
+        "3": "miércoles",
+        "4": "jueves",
+        "5": "viernes",
+        "6": "sábado",
+    }
+
+    MONTH_NAMES = {
+        "01": "enero",
+        "02": "febrero",
+        "03": "marzo",
+        "04": "abril",
+        "05": "mayo",
+        "06": "junio",
+        "07": "julio",
+        "08": "agosto",
+        "09": "septiembre",
+        "10": "octubre",
+        "11": "noviembre",
+        "12": "diciembre",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/faker/providers/date_time/it_IT/__init__.py
+++ b/faker/providers/date_time/it_IT/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "domenica",
+        "1": "lunedì",
+        "2": "martedì",
+        "3": "mercoledì",
+        "4": "giovedì",
+        "5": "venerdì",
+        "6": "sabato",
+    }
+
+    MONTH_NAMES = {
+        "01": "gennaio",
+        "02": "febbraio",
+        "03": "marzo",
+        "04": "aprile",
+        "05": "maggio",
+        "06": "giugno",
+        "07": "luglio",
+        "08": "agosto",
+        "09": "settembre",
+        "10": "ottobre",
+        "11": "novembre",
+        "12": "dicembre",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/faker/providers/date_time/sk_SK/__init__.py
+++ b/faker/providers/date_time/sk_SK/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "nedeľa",
+        "1": "pondelok",
+        "2": "utorok",
+        "3": "streda",
+        "4": "štvrtok",
+        "5": "piatok",
+        "6": "sobota",
+    }
+
+    MONTH_NAMES = {
+        "01": "január",
+        "02": "február",
+        "03": "marec",
+        "04": "apríl",
+        "05": "máj",
+        "06": "jún",
+        "07": "júl",
+        "08": "august",
+        "09": "september",
+        "10": "október",
+        "11": "november",
+        "12": "december",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/faker/providers/date_time/tr_TR/__init__.py
+++ b/faker/providers/date_time/tr_TR/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "Pazar",
+        "1": "Pazartesi",
+        "2": "Salı",
+        "3": "Çarşamba",
+        "4": "Perşembe",
+        "5": "Cuma",
+        "6": "Cumartesi",
+    }
+
+    MONTH_NAMES = {
+        "01": "Ocak",
+        "02": "Şubat",
+        "03": "Mart",
+        "04": "Nisan",
+        "05": "Mayıs",
+        "06": "Haziran",
+        "07": "Temmuz",
+        "08": "Ağustos",
+        "09": "Eylül",
+        "10": "Ekim",
+        "11": "Kasım",
+        "12": "Aralık",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -18,11 +18,17 @@ from faker.providers.date_time import Provider as DatetimeProvider
 from faker.providers.date_time import change_year
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
+from faker.providers.date_time.cs_CZ import Provider as CsCzProvider
+from faker.providers.date_time.de_AT import Provider as DeAtProvider
 from faker.providers.date_time.de_DE import Provider as DeDeProvider
+from faker.providers.date_time.es_ES import Provider as EsEsProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
+from faker.providers.date_time.it_IT import Provider as ItItProvider
 from faker.providers.date_time.pl_PL import Provider as PlProvider
 from faker.providers.date_time.ru_RU import Provider as RuProvider
+from faker.providers.date_time.sk_SK import Provider as SkSkProvider
 from faker.providers.date_time.ta_IN import Provider as TaInProvider
+from faker.providers.date_time.tr_TR import Provider as TrTrProvider
 
 
 def is64bit():
@@ -785,3 +791,93 @@ class TestRuRu(unittest.TestCase):
             timezone = self.fake.timezone()
             assert isinstance(timezone, str)
             assert re.match(r'[А-Яа-я]', timezone)
+
+
+class TestCsCz(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('cs_CZ')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in CsCzProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in CsCzProvider.MONTH_NAMES.values()
+
+
+class TestDeAt(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('de_AT')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in DeAtProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in DeAtProvider.MONTH_NAMES.values()
+
+
+class TestEsEs(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('es_ES')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in EsEsProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in EsEsProvider.MONTH_NAMES.values()
+
+
+class TestItIt(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('it_IT')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in ItItProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in ItItProvider.MONTH_NAMES.values()
+
+
+class TestSkSk(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('sk_SK')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in SkSkProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in SkSkProvider.MONTH_NAMES.values()
+
+
+class TestTrTr(unittest.TestCase):
+
+    def setUp(self):
+        self.fake = Faker('tr_TR')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in TrTrProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in TrTrProvider.MONTH_NAMES.values()


### PR DESCRIPTION
Similar to previous PR for `de_DE` https://github.com/joke2k/faker/pull/1171 along with tests, which are now inviting to switch to pytest structures with fixtures and parametrizing, just like proposed in https://github.com/joke2k/faker/issues/1162 and started in https://github.com/joke2k/faker/pull/1167