### PR TITLE
[BREAKING] Fix CLI only giving 10 possible outputs

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -236,7 +236,7 @@ examples:
             logging.basicConfig(level=logging.CRITICAL)
 
         random.seed(arguments.seed)
-        seeds = random.sample(range(arguments.repeat*10), arguments.repeat)
+        seeds = [random.random() for _ in range(arguments.repeat)]
 
         for i in range(arguments.repeat):
 
@@ -264,3 +264,6 @@ def execute_from_command_line(argv=None):
 
     command = Command(argv)
     command.execute()
+
+if __name__ == '__main__':
+    execute_from_command_line()

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -265,5 +265,6 @@ def execute_from_command_line(argv=None):
     command = Command(argv)
     command.execute()
 
+
 if __name__ == '__main__':
     execute_from_command_line()


### PR DESCRIPTION
When running the cli command `faker name`, I’ve been surprised to see very
little variation in the outputs. For me, the output is always one of these
10 names:

    Brian Foster
    Chris Curtis
    James Taylor
    Joshua Wood
    Natalie Pope
    Norma Fisher
    Ryan Gallagher
    Samantha Washington
    Theresa Brown
    Victor Martinez

The line of code that causes this seems to be this:

    seeds = random.sample(range(arguments.repeat*10), arguments.repeat)

This is sampling `repeat` values from the list of integers
[0, 10 × repeat), which is [0, 9) when `repeat` is at its default value
of 1. When there are only 10 possible seeds, there are only 10 possible
outputs.

By seeding individual instances with `random.random()` output like
`0.49892926139211313`, running `faker <anything>` hundreds or thousands of
times will result in hundreds or thousands of different outputs, instead of
only 10.

This will break the reproducibility of `faker --seed` between different
releases of faker; if that’s a big problem, the default `seeds` could at
least be set to a list of `None` if no `--seed` argument is passed on the
command line.