### PR TITLE
Adding .uk email providers and TLDs.

### DIFF
--- a/faker/providers/internet/en_GB/__init__.py
+++ b/faker/providers/internet/en_GB/__init__.py
@@ -1,0 +1,15 @@
+from .. import Provider as InternetProvider
+
+
+class Provider(InternetProvider):
+
+    free_email_domains = (
+        'gmail.com',
+        'yahoo.com',
+        'hotmail.com',
+        'gmail.co.uk',
+        'yahoo.co.uk',
+        'hotmail.co.uk',
+    )
+
+    tlds = ('com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'co.uk')

--- a/faker/providers/internet/en_GB/__init__.py
+++ b/faker/providers/internet/en_GB/__init__.py
@@ -2,6 +2,8 @@ from .. import Provider as InternetProvider
 
 
 class Provider(InternetProvider):
+    # Data taken from
+    # https://github.com/fzaninotto/Faker/blob/master/src/Faker/Provider/en_GB/Internet.php
 
     free_email_domains = (
         'gmail.com',

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -7,6 +7,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 
 from faker.providers.internet import Provider as InternetProvider
+from faker.providers.internet.en_GB import Provider as EnGbInternetProvider
 from faker.providers.internet.pl_PL import Provider as PlPlInternetProvider
 from faker.providers.internet.zh_CN import Provider as ZhCnInternetProvider
 from faker.providers.person.ja_JP import Provider as JaPersonProvider
@@ -616,3 +617,15 @@ class TestFilPh(TestEnPh):
 class TestTlPh(TestFilPh):
     """Test tl_PH internet provider methods"""
     pass
+
+
+class TestEnGb:
+    """Tests for the en_GB locale."""
+
+    def test_free_email_domain(self, faker):
+        domain = faker.free_email_domain()
+        assert domain in EnGbInternetProvider.free_email_domains
+
+    def test_tld(self, faker):
+        tld = faker.tld()
+        assert tld in EnGbInternetProvider.tlds


### PR DESCRIPTION
Adds some British free email providers and TLDs.

Data taken from https://github.com/fzaninotto/Faker/blob/master/src/Faker/Provider/en_GB/Internet.php