### PR TITLE
Fixed company format for Armenian localization

### DIFF
--- a/faker/providers/company/hy_AM/__init__.py
+++ b/faker/providers/company/hy_AM/__init__.py
@@ -5,7 +5,7 @@ class Provider(CompanyProvider):
 
     formats = (
         '{{first_name}} և {{first_name}} {{company_suffix}}',
-        '{{last_name} {{company_suffix}}',
+        '{{last_name}} {{company_suffix}}',
         '{{last_name}} և {{last_name}} {{company_suffix}}'
         '{{last_name}}, {{last_name}} և {{last_name}} {{company_suffix}}',
     )


### PR DESCRIPTION
### What does this changes

Added a missing close curly bracket in company format for Armenian localization

### What was wrong

Company format for Armenian localization was missing a close curly bracket
Due to this typo last_name became a valid name  for Armenian companies

### How this fixes it
The format is now correct

Fixes #1188
