### PR TITLE
Add language names for person es_ES provider.

### DIFF
--- a/faker/providers/person/es_ES/__init__.py
+++ b/faker/providers/person/es_ES/__init__.py
@@ -369,3 +369,39 @@ class Provider(PersonProvider):
     )
 
     prefixes = ('de', 'del')
+    
+    # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+    language_names = [
+        'Afar', 'Abjasio', 'Avéstico', 'Africaans', 'Akánico', 'Amhárico',
+        'Aragonés', 'Arábico', 'Asamés', 'Avar', 'Aimara', 'Azerí',
+        'Baskir', 'Bielorruso', 'Búlgaro', 'lenguas Bihari', 'Bislama',
+        'Bambara', 'Bengalí', 'Tibetano', 'Bretón', 'Bosnio', 'Catalán',
+        'Checheno', 'Chamorro', 'Corso', 'Cree', 'Checo', 'Eslavo eclesiástico',
+        'Chuvasio', 'Galés', 'Danés', 'Alemán', 'Maldivo', 'Dzongkha', 'Ewé',
+        'Griego', 'Inglés', 'Esperanto', 'Español', 'Estonio', 'Vasco',
+        'Persa', 'Fula', 'Finés', 'Fiyiano', 'Feroés', 'Francés',
+        'lenguas Frisonas', 'Irlandés', 'Gaélico', 'Gallego', 'Guaraní',
+        'Gujarati', 'Manés', 'Hausa', 'Hebreo', 'Hindú', 'Hiri Motu',
+        'Croata', 'Haitiano', 'Húngaro', 'Armenio', 'Herero',
+        'Interlingua', 'Indonés', 'Igbo', 'Nuosu', 'lenguas esquimales',
+        'Ido', 'Islandés', 'Italiano', 'Inuit', 'Japonés', 'Javanés',
+        'Georgiano', 'Congolés', 'Kikuyu', 'Kuanyama', 'Kazajo',
+        'Groenlandés', 'Camboyano', 'Canarés', 'Coreano', 'Kanurí',
+        'Kashmiri Masala', 'Kurdo', 'Komi', 'Córnico', 'Kirguís', 'Latín',
+        'Luxemburgués', 'Luganda', 'Limburgués', 'Lingala', 'Lao',
+        'Lituano', 'Kiluba', 'Letón', 'Malgache', 'Marshalés', 'Maorí',
+        'Macedonio', 'Malabar', 'Mongol', 'Marathí', 'Malayo', 'Maltés',
+        'Birmano', 'Nauru', 'Ndebele norte', 'Nepalí', 'Ndonga',
+        'Neerlandés', 'Nuevo Noruego', 'Noruego', 'Ndebele sur',
+        'Navajo', 'Chichewa', 'Occitano', 'Ojibwa', 'Oromo', 'Oriya',
+        'Osetio', 'Panyabí', 'Pali', 'Polaco', 'Pastún', 'Portugués',
+        'Quechua', 'Romanche', 'Rundi', 'Rumano', 'Ruso', 'Kiñaruanda',
+        'Sánscrito', 'Sardo', 'Sindi', 'Sami septentrional', 'Sango',
+        'Cingalés', 'Eslovaco', 'Samoano', 'Shona', 'Somalí', 'Albanés',
+        'Serbio', 'Suazi', 'Sesoto', 'Sondanés', 'Sueco', 'Swahili',
+        'Tamil', 'Télugu', 'Takiyo', 'Tailandés', 'Tigriña', 'Turcomano',
+        'Tagalo', 'Setsuana', 'Tongoano', 'Turco', 'Tsonga', 'Tártaro',
+        'Tahitiano', 'Uigur', 'Ucraniano', 'Urdu', 'Uzbeko', 'Venda',
+        'Vietnamita', 'Valón', 'Wólof', 'Xhosa', 'Yidis', 'Yoruba',
+        'Zhuang', 'Chino', 'Zulú',
+    ]

--- a/faker/providers/person/es_ES/__init__.py
+++ b/faker/providers/person/es_ES/__init__.py
@@ -369,7 +369,7 @@ class Provider(PersonProvider):
     )
 
     prefixes = ('de', 'del')
-    
+
     # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
     language_names = [
         'Afar', 'Abjasio', 'Avéstico', 'Africaans', 'Akánico', 'Amhárico',

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -7,6 +7,7 @@ from unittest import mock
 from faker import Faker
 from faker.providers.person.ar_AA import Provider as ArProvider
 from faker.providers.person.cs_CZ import Provider as CsCZProvider
+from faker.providers.person.es_ES import Provider as EsESProvider
 from faker.providers.person.fi_FI import Provider as FiProvider
 from faker.providers.person.hy_AM import Provider as HyAmProvider
 from faker.providers.person.ne_NP import Provider as NeProvider
@@ -598,3 +599,15 @@ class TestRuRU(unittest.TestCase):
     def test_language_name(self):
         language_name = self.fake.language_name()
         assert language_name in RuProvider.language_names
+
+
+class TestEsES(unittest.TestCase):
+    """Tests person in the es_ES locale."""
+
+    def setUp(self):
+        self.fake = Faker('es_ES')
+        Faker.seed(0)
+
+    def test_language_name(self):
+        language_name = self.fake.language_name()
+        assert language_name in EsESProvider.language_names


### PR DESCRIPTION
### What does this changes
Add Spanish language names to person `es_ES` provider.