### PR TITLE
Type error on calling Faker from within an internal pytest fixture

### DIFF
--- a/faker/contrib/pytest/plugin.py
+++ b/faker/contrib/pytest/plugin.py
@@ -16,7 +16,7 @@ def _session_faker(request):
     if 'faker_session_locale' in request.fixturenames:
         locale = request.getfixturevalue('faker_session_locale')
     else:
-        locale = [DEFAULT_LOCALE]
+        locale = DEFAULT_LOCALE
     return Faker(locale=locale)
 
 

--- a/faker/providers/person/__init__.py
+++ b/faker/providers/person/__init__.py
@@ -67,6 +67,14 @@ class Provider(BaseProvider):
         pattern = self.random_element(formats)
         return self.generator.parse(pattern)
 
+    def name_nonbinary(self):
+        if hasattr(self, 'formats_nonbinary'):
+            formats = self.formats_nonbinary
+        else:
+            formats = self.formats
+        pattern = self.random_element(formats)
+        return self.generator.parse(pattern)
+
     def name_female(self):
         if hasattr(self, 'formats_female'):
             formats = self.formats_female
@@ -80,6 +88,11 @@ class Provider(BaseProvider):
             return self.random_element(self.first_names_male)
         return self.first_name()
 
+    def first_name_nonbinary(self):
+        if hasattr(self, 'first_names_nonbinary'):
+            return self.random_element(self.first_names_nonbinary)
+        return self.first_name()
+
     def first_name_female(self):
         if hasattr(self, 'first_names_female'):
             return self.random_element(self.first_names_female)
@@ -90,6 +103,11 @@ class Provider(BaseProvider):
             return self.random_element(self.last_names_male)
         return self.last_name()
 
+    def last_name_nonbinary(self):
+        if hasattr(self, 'last_names_nonbinary'):
+            return self.random_element(self.last_names_nonbinary)
+        return self.last_name()
+
     def last_name_female(self):
         if hasattr(self, 'last_names_female'):
             return self.random_element(self.last_names_female)
@@ -98,6 +116,10 @@ class Provider(BaseProvider):
     def prefix(self):
         if hasattr(self, 'prefixes'):
             return self.random_element(self.prefixes)
+        if hasattr(self, 'prefixes_male') and hasattr(self, 'prefixes_female') and hasattr(self, 'prefixes_nonbinary'):
+            prefixes = self.random_element(
+                (self.prefixes_male, self.prefixes_female, self.prefixes_nonbinary))
+            return self.random_element(prefixes)
         if hasattr(self, 'prefixes_male') and hasattr(self, 'prefixes_female'):
             prefixes = self.random_element(
                 (self.prefixes_male, self.prefixes_female))
@@ -109,6 +131,11 @@ class Provider(BaseProvider):
             return self.random_element(self.prefixes_male)
         return self.prefix()
 
+    def prefix_nonbinary(self):
+        if hasattr(self, 'prefixes_nonbinary'):
+            return self.random_element(self.prefixes_nonbinary)
+        return self.prefix()
+
     def prefix_female(self):
         if hasattr(self, 'prefixes_female'):
             return self.random_element(self.prefixes_female)
@@ -117,6 +144,10 @@ class Provider(BaseProvider):
     def suffix(self):
         if hasattr(self, 'suffixes'):
             return self.random_element(self.suffixes)
+        if hasattr(self, 'suffixes_male') and hasattr(self, 'suffixes_female') and hasattr(self, 'suffixes_nonbinary'):
+            suffixes = self.random_element(
+                (self.suffixes_male, self.suffixes_female, self.suffixes_nonbinary))
+            return self.random_element(suffixes)
         if hasattr(self, 'suffixes_male') and hasattr(self, 'suffixes_female'):
             suffixes = self.random_element(
                 (self.suffixes_male, self.suffixes_female))
@@ -126,6 +157,11 @@ class Provider(BaseProvider):
     def suffix_male(self):
         if hasattr(self, 'suffixes_male'):
             return self.random_element(self.suffixes_male)
+        return self.suffix()
+
+    def suffix_nonbinary(self):
+        if hasattr(self, 'suffixes_nonbinary'):
+            return self.random_element(self.suffixes_nonbinary)
         return self.suffix()
 
     def suffix_female(self):

--- a/faker/providers/person/en_US/__init__.py
+++ b/faker/providers/person/en_US/__init__.py
@@ -11,6 +11,13 @@ class Provider(PersonProvider):
         ('{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix_female}}', 0.005),
     ))
 
+    formats_nonbinary = OrderedDict((
+        ('{{first_name_nonbinary}} {{last_name}}', 0.97),
+        ('{{prefix_nonbinary}} {{first_name_nonbinary}} {{last_name}}', 0.015),
+        ('{{first_name_nonbinary}} {{last_name}} {{suffix_nonbinary}}', 0.02),
+        ('{{prefix_nonbinary}} {{first_name_nonbinary}} {{last_name}} {{suffix_nonbinary}}', 0.005),
+    ))
+
     formats_male = OrderedDict((
         ('{{first_name_male}} {{last_name}}', 0.97),
         ('{{prefix_male}} {{first_name_male}} {{last_name}}', 0.015),
@@ -740,6 +747,9 @@ class Provider(PersonProvider):
 
     first_names = first_names_male.copy()
     first_names.update(first_names_female)
+
+    first_names_nonbinary = first_names_male.copy()
+    first_names_nonbinary.update(first_names_female)
 
     # Top 1000 US surnames from US Census data
     # Weighted by number of occurrences
@@ -1758,6 +1768,14 @@ class Provider(PersonProvider):
         ('Dr.', 0.3),
     ))
 
+    # https://en.wikipedia.org/wiki/Gender-neutral_title
+    prefixes_nonbinary = OrderedDict((
+        ('Mx.', 0.5),
+        ('Ind.', 0.1),
+        ('Misc.', 0.1),
+        ('Dr.', 0.3),
+    ))
+
     suffixes_female = OrderedDict((
         ('MD', 0.5),
         ('DDS', 0.3),
@@ -1777,3 +1795,5 @@ class Provider(PersonProvider):
         ('PhD', 0.1),
         ('DVM', 0.1),
     ))
+
+    suffixes_nonbinary = suffixes_male.copy()

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -7,6 +7,8 @@ from unittest import mock
 from faker import Faker
 from faker.providers.person.ar_AA import Provider as ArProvider
 from faker.providers.person.cs_CZ import Provider as CsCZProvider
+from faker.providers.person.en import Provider as EnProvider
+from faker.providers.person.en_US import Provider as EnUSProvider
 from faker.providers.person.es_ES import Provider as EsESProvider
 from faker.providers.person.fi_FI import Provider as FiProvider
 from faker.providers.person.hy_AM import Provider as HyAmProvider
@@ -611,3 +613,86 @@ class TestEsES(unittest.TestCase):
     def test_language_name(self):
         language_name = self.fake.language_name()
         assert language_name in EsESProvider.language_names
+
+
+class TestUs(unittest.TestCase):
+    """ Tests person in the en_US locale """
+
+    def setUp(self):
+        self.fake = Faker('en_US')
+        Faker.seed(0)
+
+    def test_first_names(self):
+        # General first name
+        name = self.fake.first_name()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.first_names
+
+        # Female first name
+        name = self.fake.first_name_female()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.first_names
+        assert name in EnUSProvider.first_names_female
+
+        # Male first name
+        name = self.fake.first_name_male()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.first_names
+        assert name in EnUSProvider.first_names_male
+
+        # Nonbinary first name
+        name = self.fake.first_name_nonbinary()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.first_names
+        assert name in EnUSProvider.first_names_nonbinary
+
+    def test_last_names(self):
+
+        # General last name
+        name = self.fake.last_name()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.last_names
+
+        # Female last name
+        name = self.fake.last_name_female()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.last_names
+
+        # Male last name
+        name = self.fake.last_name_male()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.last_names
+
+        # Nonbinary last name
+        name = self.fake.last_name_nonbinary()
+        self.assertIsInstance(name, str)
+        assert name in EnUSProvider.last_names
+
+    def test_prefix(self):
+
+        # Nonbinary prefix
+        prefix = self.fake.prefix_nonbinary()
+        self.assertIsInstance(prefix, str)
+        assert prefix in EnUSProvider.prefixes_nonbinary
+
+    def test_suffix(self):
+
+        # Nonbinary suffix
+        suffix = self.fake.suffix_nonbinary()
+        self.assertIsInstance(suffix, str)
+        assert suffix in EnUSProvider.suffixes_nonbinary
+
+
+class TestEn(unittest.TestCase):
+    """ Tests person in the en locale """
+
+    def setUp(self):
+        self.fake = Faker('en')
+        Faker.seed(0)
+
+    def test_suffix(self):
+
+        # Traditional suffix -- provider does not offer a nonbinary suffix at this time
+        suffix = self.fake.suffix()
+        self.assertIsInstance(suffix, str)
+        assert suffix in EnProvider.suffixes_male or suffix in EnProvider.suffixes_female


### PR DESCRIPTION
For reasons I don't understand yet, pytest is calling this private fixture
during the setup phase of the tests. Regardless the reason, the code contains a
bug since it expects a `string` but the `_session_faker` constructs a `List`
before calling the constructor

* Faker version: 0.7.4
* OS: `Ubuntu 14.04.6 LTS. travis`
* Python: 3.6.5

```
request = <SubRequest '_session_faker' for <TestCaseFunction test_get_access_method_for_event>>
    @pytest.fixture(scope='session', autouse=True)
    def _session_faker(request):
        """Fixture that stores the session level ``Faker`` instance.

        This fixture is internal and is only meant for use within the project.
        Third parties should instead use the ``faker`` fixture for their tests.
        """
        if 'faker_session_locale' in request.fixturenames:
            locale = request.getfixturevalue('faker_session_locale')
        else:
            locale = [DEFAULT_LOCALE]
>       return Faker(locale=locale)
../../../virtualenv/python3.6.5/lib/python3.6/site-packages/faker/contrib/pytest/plugin.py:20:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cls = <class 'faker.factory.Factory'>, locale = ['en_US'], providers = None
generator = None, includes = [], config = {}
    @classmethod
    def create(cls, locale=None, providers=None, generator=None, includes=None, **config):
        if includes is None:
            includes = []

        # fix locale to package name
>       locale = locale.replace('-', '_') if locale else DEFAULT_LOCALE
E       AttributeError: 'list' object has no attribute 'replace'
../../../virtualenv/python3.6.5/lib/python3.6/site-packages/faker/factory.py:22: AttributeError
```

The stacktrace that leads to this execution is the following

```
-> "__main__", mod_spec)
  /opt/python/3.6.5/lib/python3.6/runpy.py(85)_run_code()
-> exec(code, run_globals)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pytest.py(102)<module>()
-> raise SystemExit(pytest.main())
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/config/__init__.py(82)main()
-> return config.hook.pytest_cmdline_main(config=config)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/hooks.py(286)__call__()
-> return self._hookexec(self, self.get_hookimpls(), kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(93)_hookexec()
-> return self._inner_hookexec(hook, methods, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(87)<lambda>()
-> firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/callers.py(187)_multicall()
-> res = hook_impl.function(*args)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/main.py(243)pytest_cmdline_main()
-> return wrap_session(config, _main)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/main.py(206)wrap_session()
-> session.exitstatus = doit(config, session) or 0
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/main.py(250)_main()
-> config.hook.pytest_runtestloop(session=session)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/hooks.py(286)__call__()
-> return self._hookexec(self, self.get_hookimpls(), kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(93)_hookexec()
-> return self._inner_hookexec(hook, methods, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(87)<lambda>()
-> firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/callers.py(187)_multicall()
-> res = hook_impl.function(*args)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/main.py(271)pytest_runtestloop()
-> item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/hooks.py(286)__call__()
-> return self._hookexec(self, self.get_hookimpls(), kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(93)_hookexec()
-> return self._inner_hookexec(hook, methods, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(87)<lambda>()
-> firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/callers.py(187)_multicall()
-> res = hook_impl.function(*args)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(78)pytest_runtest_protocol()
-> runtestprotocol(item, nextitem=nextitem)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(87)runtestprotocol()
-> rep = call_and_report(item, "setup", log)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(173)call_and_report()
-> call = call_runtest_hook(item, when, **kwds)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(198)call_runtest_hook()
-> lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(226)from_call()
-> result = func()
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(198)<lambda>()
-> lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/hooks.py(286)__call__()
-> return self._hookexec(self, self.get_hookimpls(), kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(93)_hookexec()
-> return self._inner_hookexec(hook, methods, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(87)<lambda>()
-> firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/callers.py(187)_multicall()
-> res = hook_impl.function(*args)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(116)pytest_runtest_setup()
-> item.session._setupstate.prepare(item)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/runner.py(362)prepare()
-> col.setup()
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/unittest.py(119)setup()
-> self._request._fillfixtures()
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(469)_fillfixtures()
-> item.funcargs[argname] = self.getfixturevalue(argname)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(479)getfixturevalue()
-> return self._get_active_fixturedef(argname).cached_result[0]
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(502)_get_active_fixturedef()
-> self._compute_fixture_value(fixturedef)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(587)_compute_fixture_value()
-> fixturedef.execute(request=subrequest)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(894)execute()
-> return hook.pytest_fixture_setup(fixturedef=self, request=request)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/hooks.py(286)__call__()
-> return self._hookexec(self, self.get_hookimpls(), kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(93)_hookexec()
-> return self._inner_hookexec(hook, methods, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/manager.py(87)<lambda>()
-> firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/pluggy/callers.py(187)_multicall()
-> res = hook_impl.function(*args)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(936)pytest_fixture_setup()
-> result = call_fixture_func(fixturefunc, request, kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/_pytest/fixtures.py(795)call_fixture_func()
-> res = fixturefunc(**kwargs)
  /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/faker/contrib/pytest/plugin.py(20)_session_faker()
-> return Faker(locale=locale)
> /home/travis/virtualenv/python3.6.5/lib/python3.6/site-packages/faker/factory.py(28)create()
```

### What does this changes

Brief summary of the changes

### What was wrong

Description of what was the root cause of the issue.

### How this fixes it

Description of how the changes fix the issue.

Fixes #...
