### PR TITLE
Add safe domain names

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -58,7 +58,7 @@ class _IPv4Constants:
 
 
 class Provider(BaseProvider):
-    safe_email_tlds = ('org', 'com', 'net')
+    safe_domain_names = ('example.org', 'example.com', 'example.net')
     free_email_domains = ('gmail.com', 'yahoo.com', 'hotmail.com')
     tlds = (
         'com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org',
@@ -129,7 +129,7 @@ class Provider(BaseProvider):
 
     @lowercase
     def safe_domain_name(self):
-        return 'example.' + self.random_element(self.safe_email_tlds)
+        return self.random_element(self.safe_domain_names)
 
     @lowercase
     def safe_email(self):

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -128,10 +128,12 @@ class Provider(BaseProvider):
         return email
 
     @lowercase
+    def safe_domain_name(self):
+        return 'example.' + self.random_element(self.safe_email_tlds)
+
+    @lowercase
     def safe_email(self):
-        return '{}@example.{}'.format(
-            self.user_name(), self.random_element(self.safe_email_tlds),
-        )
+        return self.user_name() + '@' + self.safe_domain_name()
 
     @lowercase
     def free_email(self):
@@ -154,11 +156,7 @@ class Provider(BaseProvider):
 
     @lowercase
     def ascii_safe_email(self):
-        return self._to_ascii(
-            self.user_name() +
-            '@example.' +
-            self.random_element(self.safe_email_tlds),
-        )
+        return self._to_ascii(self.user_name() + '@' + self.safe_domain_name())
 
     @lowercase
     def ascii_free_email(self):

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -39,6 +39,12 @@ class TestInternetProvider:
         email = faker.email(domain=domain)
         assert email.split('@')[1] == domain
 
+    def test_safe_email(self, faker, num_samples):
+        expected_domains = ['example.com', 'example.org', 'example.net']
+        for _ in range(num_samples):
+            email = faker.safe_email()
+            assert email.split('@')[1] in expected_domains
+
     def test_safe_domain_names(self, faker, num_samples):
         expected_domains = ['example.com', 'example.org', 'example.net']
         for _ in range(num_samples):

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -39,6 +39,12 @@ class TestInternetProvider:
         email = faker.email(domain=domain)
         assert email.split('@')[1] == domain
 
+    def test_safe_domain_names(self, faker, num_samples):
+        expected_domains = ['example.com', 'example.org', 'example.net']
+        for _ in range(num_samples):
+            safe_domain_name = faker.safe_domain_name()
+            assert safe_domain_name in expected_domains
+
     @patch(
         'faker.providers.internet.Provider.image_placeholder_services',
         {'https://dummyimage.com/{width}x{height}'},


### PR DESCRIPTION
### What does this change

Refactors safe email domain generation and provides a new mechanism to generate random safe domains (one of 'example.com', 'example.org', 'example.net'). Refer to [RFC 2606](https://tools.ietf.org/html/rfc2606) and [RFC 6761](https://tools.ietf.org/html/rfc6761) for more information on these domains, intended for use in documentation.

Closes #1182 
