### PR TITLE
💂 Fix max_value/positive pyfloat interaction

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -77,7 +77,9 @@ class Provider(BaseProvider):
                 max_value += 1  # as the random_int will be generated up to max_value - 1
             if min_value is not None and min_value < 0:
                 min_value += 1  # as we then append digits after the left_number
-            left_number = self._safe_random_int(min_value, max_value)
+            left_number = self._safe_random_int(
+                min_value, max_value, positive,
+            )
         else:
             sign = '+' if positive else self.random_element(('+', '-'))
             left_number = self.random_number(left_digits)
@@ -88,7 +90,7 @@ class Provider(BaseProvider):
             self.random_number(right_digits),
         ))
 
-    def _safe_random_int(self, min_value, max_value):
+    def _safe_random_int(self, min_value, max_value, positive):
         orig_min_value = min_value
         orig_max_value = max_value
 
@@ -96,8 +98,11 @@ class Provider(BaseProvider):
             min_value = max_value - self.random_int()
         if max_value is None:
             max_value = min_value + self.random_int()
+        if positive:
+            min_value = max(min_value, 0)
+
         if min_value == max_value:
-            return self._safe_random_int(orig_min_value, orig_max_value)
+            return self._safe_random_int(orig_min_value, orig_max_value, positive)
         else:
             return self.random_int(min_value, max_value - 1)
 

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -66,6 +66,9 @@ class Provider(BaseProvider):
             raise ValueError('Min value cannot be greater than max value')
         if None not in (min_value, max_value) and min_value == max_value:
             raise ValueError('Min and max value cannot be the same')
+        if positive and min_value is not None and min_value < 0:
+            raise ValueError(
+                'Cannot combine positive=True and negative min_value')
 
         left_digits = left_digits if left_digits is not None else (
             self.random_int(1, sys.float_info.dig))

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -101,6 +101,21 @@ class TestPyfloat(unittest.TestCase):
         self.assertLessEqual(result, 100)
         self.assertGreaterEqual(result, 0)
 
+    def test_positive_and_min_value_incompatible(self):
+        """
+        An exception should be raised if positive=True is set, but
+        a negative min_value is provided.
+        """
+
+        expected_message = (
+            "Cannot combine positive=True and negative min_value"
+        )
+        with self.assertRaises(ValueError) as raises:
+            self.fake.pyfloat(min_value=-100, positive=True)
+
+        message = str(raises.exception)
+        self.assertEqual(message, expected_message)
+
 
 class TestPystrFormat(unittest.TestCase):
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -91,6 +91,16 @@ class TestPyfloat(unittest.TestCase):
         message = str(raises.exception)
         self.assertEqual(message, expected_message)
 
+    def test_max_value_and_positive(self):
+        """
+        Combining the max_value and positive keyword arguments produces
+        numbers that obey both of those constraints.
+        """
+
+        result = self.fake.pyfloat(positive=True, max_value=100)
+        self.assertLessEqual(result, 100)
+        self.assertGreaterEqual(result, 0)
+
 
 class TestPystrFormat(unittest.TestCase):
 


### PR DESCRIPTION
When pyfloat(max_value=100, positive=True) is called, it sometimes
returns negative numbers, which is unexpected.

To fix it, we just need to "cap" our internal minimum value to zero.

This does leave `pyfloat(max_value=100, min_value=-100, positive=True)`
as a call that secretly moves the min_value up to 0 though.

Fixes #1212.