### PR TITLE
Update bban_format for country FI

### DIFF
--- a/faker/providers/bank/fi_FI/__init__.py
+++ b/faker/providers/bank/fi_FI/__init__.py
@@ -2,5 +2,5 @@ from .. import Provider as BankProvider
 
 
 class Provider(BankProvider):
-    bban_format = '################'
+    bban_format = '##############'
     country_code = 'FI'

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -25,7 +25,7 @@ class TestFiFi(unittest.TestCase):
 
     def test_bban(self):
         bban = self.fake.bban()
-        assert re.match(r"\d{16}", bban)
+        assert re.match(r"\d{14}", bban)
 
     def test_iban(self):
         iban = self.fake.iban()


### PR DESCRIPTION
Fixes #1219.

### What does this changes

`bban_format` for FI is shortened to 14 characters. Related test also updated.

### What was wrong

Generated Finnish IBAN was 20 characters of length when it should've been 18 characters of length. Finnish IBAN consists of 'FI' + 2 check numbers + BBAN (14 characters).

### How this fixes it

See first answer.

