### PR TITLE
Handle isort 5.X upgrade

### DIFF
--- a/faker/providers/job/bs_BA/__init__.py
+++ b/faker/providers/job/bs_BA/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as BaseProvider
 
-
 """
 Data is provided by the official list of professions from
 National institue for statistics

--- a/faker/providers/ssn/nl_BE/__init__.py
+++ b/faker/providers/ssn/nl_BE/__init__.py
@@ -1,6 +1,5 @@
 from .. import Provider as SsnProvider
 
-
 """
 For more info on rijksregisternummer, see https://nl.wikipedia.org/wiki/Rijksregisternummer
 Dutch/French only for now ...

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1,6 +1,8 @@
 import re
 import unittest
 
+from ukpostcodeparser.parser import parse_uk_postcode
+
 from faker import Faker
 from faker.providers.address.de_AT import Provider as DeAtProvider
 from faker.providers.address.de_DE import Provider as DeProvider
@@ -17,7 +19,6 @@ from faker.providers.address.hy_AM import Provider as HyAmProvider
 from faker.providers.address.ja_JP import Provider as JaProvider
 from faker.providers.address.ne_NP import Provider as NeProvider
 from faker.providers.address.pt_PT import Provider as PtPtProvider
-from ukpostcodeparser.parser import parse_uk_postcode
 
 
 class TestBaseProvider(unittest.TestCase):

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -159,6 +159,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_datetime_safe(self):
         from faker.utils import datetime_safe
+
         # test using example provided in module
         result = datetime_safe.date(1850, 8, 2).strftime('%Y/%m/%d was a %A')
         assert result == '1850/08/02 was a Friday'

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -6,14 +6,15 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 
+from validators import domain as validate_domain
+from validators import email as validate_email
+
 from faker.providers.internet import Provider as InternetProvider
 from faker.providers.internet.en_GB import Provider as EnGbInternetProvider
 from faker.providers.internet.pl_PL import Provider as PlPlInternetProvider
 from faker.providers.internet.zh_CN import Provider as ZhCnInternetProvider
 from faker.providers.person.ja_JP import Provider as JaPersonProvider
 from faker.utils import text
-from validators import domain as validate_domain
-from validators import email as validate_email
 
 
 class TestInternetProvider:

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -8,6 +8,10 @@ import freezegun
 import pytest
 import random2
 
+from validators.i18n.es import es_cif as is_cif
+from validators.i18n.es import es_nie as is_nie
+from validators.i18n.es import es_nif as is_nif
+
 from faker import Faker
 from faker.providers.ssn.en_CA import checksum as ca_checksum
 from faker.providers.ssn.es_MX import curp_checksum as mx_curp_checksum
@@ -21,9 +25,6 @@ from faker.providers.ssn.pl_PL import calculate_month as pl_calculate_mouth
 from faker.providers.ssn.pl_PL import checksum as pl_checksum
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
 from faker.utils.checksums import luhn_checksum
-from validators.i18n.es import es_cif as is_cif
-from validators.i18n.es import es_nie as is_nie
-from validators.i18n.es import es_nif as is_nif
 
 
 class TestSvSE(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 deps =
     isort
 commands =
-    {envpython} -m isort --check-only --diff
+    {envpython} -m isort --check-only --diff .
 
 [testenv:32bit]
 basepython = python


### PR DESCRIPTION
### What does this changes

This will fix the recent isort failures in travis CI as well as fix outstanding isort issues in other files. 

### What was wrong

The isort package recently had a [major update](https://timothycrosley.github.io/isort/CHANGELOG/#500-penny-july-4-2020). Our CI isort tasks started failing around the 5.0 release, and basically, the isort 5.X now [requires](https://github.com/timothycrosley/isort/blob/64ab238666298d5ff203082a6213087fa4a39858/isort/main.py#L619) files/paths to be specified. This did not use to be the case in the 4.3.21 where the current working directory will [implicitly be used](https://github.com/timothycrosley/isort/blob/7c29dd9d55161704cfc45998c6f5c2c43d39264b/isort/main.py#L334).


