### PR TITLE
Update bban format for French locale and add tests for it

### DIFF
--- a/faker/providers/bank/fr_FR/__init__.py
+++ b/faker/providers/bank/fr_FR/__init__.py
@@ -2,5 +2,5 @@ from .. import Provider as BankProvider
 
 
 class Provider(BankProvider):
-    bban_format = '########################'
+    bban_format = '#######################'
     country_code = 'FR'

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -131,6 +131,22 @@ class TestEsES(unittest.TestCase):
         assert re.match(r"ES\d{22}", iban)
 
 
+class TestFrFR(unittest.TestCase):
+    """Tests the bank provider for fr_FR locale"""
+
+    def setUp(self):
+        self.fake = Faker('fr_FR')
+        Faker.seed(0)
+
+    def test_bban(self):
+        bban = self.fake.bban()
+        assert re.match(r"\d{23}", bban)
+
+    def test_iban(self):
+        iban = self.fake.iban()
+        assert re.match(r"FR\d{25}", iban)
+
+
 class TestEnPh:
 
     def test_swift(self, faker, num_samples):


### PR DESCRIPTION
Fixes #1234 

### What does this changes

bban_format for FR is shortened to 23 characters. Related test also added.

### What was wrong

Generated French IBAN was 28 characters of length when it should've been 27 characters of length. 
French IBAN consists of :
FRkk bbbb bsss sscc cccc cccc cxx
where 
* b = National bank code
* s = Branch code (code guichet [fr])
* c = Account number
* x = National check digits (clé RIB [fr]) 

So BBAN is `kk bbbb bsss sscc cccc cccc c` = 23 charcaters

### How this fixes it

BBan pattern fixed means iban generation correct.
Tests are added to avoid regressions on that 
