### PR TITLE
Don't return too long company ids. Fix for #1233

### DIFF
--- a/faker/providers/company/fi_FI/__init__.py
+++ b/faker/providers/company/fi_FI/__init__.py
@@ -27,15 +27,21 @@ class Provider(CompanyProvider):
             sum_ = 0
             for x, y in zip(number, factors):
                 sum_ = sum_ + int(x) * y
+            if sum_ % 11 == 1:
+                raise ValueError('Checksum 1 is invalid')
             if sum_ % 11 == 0:
                 return '0'
             else:
                 return str(11 - sum_ % 11)
 
-        first_digit = str(self.random_digit_not_null())
-        body = first_digit + self.bothify('######')
-        cs = calculate_checksum(body)
-        return body + '-' + str(cs)
+        while True:
+            first_digit = str(self.random_digit_not_null())
+            body = first_digit + self.bothify('######')
+            try:
+                cs = calculate_checksum(body)
+            except ValueError:
+                continue
+            return body + '-' + str(cs)
 
     def company_vat(self):
         """

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -23,9 +23,10 @@ class TestFiFI(unittest.TestCase):
         self.fake.random.seed(6)
         company_id = self.fake.company_business_id()
         assert company_id.endswith('0')
-        for seed in range(0, 11):
-            self.fake.random.seed(seed)
-            self.fake.company_business_id()
+
+        for seed in range(0, 1000):
+            Faker.seed(seed)
+            assert (len(self.fake.company_business_id()) == 9)
 
 
 class TestHyAm(unittest.TestCase):


### PR DESCRIPTION
### What does this changes

This is a bugfix for #1233 . 

### What was wrong

Finnish company id calculation did not handle invalid remainder 1 in checksum calculation, resulting two digit checksums.

### How this fixes it

Company id is generated until a valid one is found

