### PR TITLE
Improve proxy initialization as list type error.

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -30,9 +30,10 @@ class Faker:
         # This guarantees a FIFO ordering of elements in `locales` based on the final
         # locale string while discarding duplicates after processing
         elif isinstance(locale, (list, tuple, set)):
-            assert all(isinstance(local_code, str) for local_code in locale)
             locales = []
             for code in locale:
+                if not isinstance(code, str):
+                    raise TypeError('The locale "%s" must be a string.' % str(code))
                 final_locale = code.replace('-', '_')
                 if final_locale not in locales:
                     locales.append(final_locale)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -36,6 +36,12 @@ class TestFakerProxyClass:
         fake = Faker(locale)
         assert fake.locales == expected
         assert len(fake.factories) == len(expected)
+    
+    def test_locale_as_list_invalid_value_type(self):
+        locale = [1, 2]
+        with pytest.raises(TypeError) as exc:
+            fake = Faker(locale)
+        assert str(exc.value) == 'The locale "1" must be a string.'
 
     def test_locale_as_ordereddict(self):
         locale = OrderedDict([

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -36,7 +36,7 @@ class TestFakerProxyClass:
         fake = Faker(locale)
         assert fake.locales == expected
         assert len(fake.factories) == len(expected)
-    
+
     def test_locale_as_list_invalid_value_type(self):
         locale = [1, 2]
         with pytest.raises(TypeError) as exc:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -40,7 +40,7 @@ class TestFakerProxyClass:
     def test_locale_as_list_invalid_value_type(self):
         locale = [1, 2]
         with pytest.raises(TypeError) as exc:
-            fake = Faker(locale)
+            Faker(locale)
         assert str(exc.value) == 'The locale "1" must be a string.'
 
     def test_locale_as_ordereddict(self):


### PR DESCRIPTION
### What does this changes

When `Faker` class is initialized as list with values that are not strings, a better exception is raised. 

### Actual behaviour

```python
>>> from faker import Faker
>>> Faker([1, 2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../faker/faker/proxy.py", line 33, in __init__
    assert all(isinstance(local_code, str) for local_code in locale)
AssertionError
```

### Behaviour after this pull

```python
>>> from faker import Faker
>>> Faker([1, 2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../faker/faker/proxy.py", line 36, in __init__
    raise TypeError('The locale "%s" must be a string.' % str(code))
TypeError: The locale "1" must be a string.
```
