### PR TITLE
Add es_ES autonomous communities (Spanish regions).

### DIFF
--- a/faker/providers/address/es_ES/__init__.py
+++ b/faker/providers/address/es_ES/__init__.py
@@ -63,6 +63,30 @@ class Provider(AddressProvider):
         'Zamora',
         'Zaragoza')
 
+    # Source:
+    # https://administracionelectronica.gob.es/ctt/resources/Soluciones
+    # /238/Descargas/Catalogo-de-Comunidades-Autonomas.xlsx
+    regions = (
+        'Andalucía',
+        'Aragón',
+        'Principado de Asturias',
+        'Illes Balears',
+        'Canarias',
+        'Cantabria',
+        'Castilla y León',
+        'Castilla-La Mancha',
+        'Cataluña',
+        'Comunitat Valenciana',
+        'Extremadura',
+        'Galicia',
+        'Comunidad de Madrid',
+        'Región de Murcia',
+        'Comunidad Foral de Navarra',
+        'País Vasco',
+        'La Rioja',
+        'Ciudad Autónoma de Ceuta',
+        'Ciudad Autónoma de Melilla')
+
     city_formats = (
         '{{state_name}}',
     )
@@ -94,3 +118,8 @@ class Provider(AddressProvider):
 
     def state(self):
         return self.random_element(self.states)
+
+    def region(self):
+        return self.random_element(self.regions)
+
+    autonomous_community = region

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -463,6 +463,16 @@ class TestEsES(unittest.TestCase):
         secondary_address = self.fake.secondary_address()
         assert isinstance(secondary_address, str)
 
+    def test_regions(self):
+        region = self.fake.region()
+        assert isinstance(region, str)
+        assert region in EsEsProvider.regions
+
+        # Spanish regions, also known as "autonomous communities"
+        autonomous_community = self.fake.autonomous_community()
+        assert isinstance(autonomous_community, str)
+        assert autonomous_community in EsEsProvider.regions
+
 
 class TestEsMX(unittest.TestCase):
     """ Tests the addresses in the es_MX locale """


### PR DESCRIPTION
### What does this changes

Add Spanish regions (locally known as "autonomous communities") to `es_ES` address provider using government spreadsheet as source.
