### PR TITLE
Upgrade pytest to version 6

### DIFF
--- a/tests/providers/test_barcode.py
+++ b/tests/providers/test_barcode.py
@@ -66,7 +66,7 @@ class TestBarcodeProvider:
             assert (sum(ean13_digits) + 2 * sum(ean13_digits[1::2])) % 10 == 0
 
 
-@pytest.fixture('class')
+@pytest.fixture(scope='class')
 def provider_class(request):
     if hasattr(request.cls, 'get_provider_class') and callable(request.cls.get_provider_class):
         _provider_class = request.cls.get_provider_class()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 deps =
     coverage
     freezegun<0.4
-    pytest>=5.4.0,<5.5
+    pytest>=6.0.1
     random2
     ukpostcodeparser>=1.1.1
     validators>=0.13.0


### PR DESCRIPTION
### What does this changes

The unique change affected for 6 version is the mandatory use of keyword arguments in fixtures decorators, proposed in [this issue](https://github.com/pytest-dev/pytest/issues/1682).

### What was wrong

Running the test suite with pytest 6 raises next warning error:

```
Passing arguments to pytest.fixture() as positional arguments is deprecated - pass them as a keyword argument instead
```

### How this fixes it

Use `scope='class'` in `tests/providers/test_barcode.py` fixture.
