### PR TITLE
Update zh_CN ssn provider support gender

### DIFF
--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -511,7 +511,12 @@ class Provider(SsnProvider):
         "659003", "659004", "710000", "810000", "820000",
     ]
 
-    def ssn(self, min_age=18, max_age=90):
+    def ssn(self, min_age=18, max_age=90, gender=None):
+        """
+        Return 18 character chinese personal identity code
+
+        :param gender: F for female  M for male  None for default
+        """
         def checksum(s):
             return str((1 - 2 * int(s, 13)) % 11).replace('10', 'X')
 
@@ -521,5 +526,17 @@ class Provider(SsnProvider):
         birthday_str = birthday.strftime('%Y%m%d')
 
         ssn_without_checksum = self.numerify(
-            self.random_element(self.area_codes) + birthday_str + "###")
+            self.random_element(self.area_codes) + birthday_str + "##")
+
+        _number = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
+        if gender:
+            if gender in ('F', 'f'):
+                gender_num = self.generator.random.choice(_number[::2])
+            elif gender in ('M', 'm'):
+                gender_num = self.generator.random.choice(_number[1::2])
+            else:
+                raise ValueError('Gender must be one of F or M.')
+        else:
+            gender_num = self.generator.random.choice(_number)
+        ssn_without_checksum += gender_num
         return ssn_without_checksum + checksum(ssn_without_checksum)

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -25,6 +25,7 @@ from faker.providers.ssn.no_NO import checksum as no_checksum
 from faker.providers.ssn.pl_PL import calculate_month as pl_calculate_mouth
 from faker.providers.ssn.pl_PL import checksum as pl_checksum
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
+from faker.providers.ssn.zh_CN import Provider as cn_Provider
 from faker.utils.checksums import luhn_checksum
 
 
@@ -965,3 +966,30 @@ class TestEnIn(unittest.TestCase):
     def test_valid_luhn(self):
         for aadhaar_id in self.aadhaar_ids:
             assert luhn_checksum(aadhaar_id) == 0
+
+
+class TestZhCN(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker('zh_CN')
+        Faker.seed(0)
+
+    def test_zh_CN_ssn(self):
+        for _ in range(100):
+            ssn = self.fake.ssn()
+            assert len(ssn) == 18
+
+    def test_zh_CN_ssn_invalid_gender_passed(self):
+        with pytest.raises(ValueError):
+            self.fake.ssn(gender='X')
+        with pytest.raises(ValueError):
+            self.fake.ssn(gender='*')
+        with pytest.raises(ValueError):
+            self.fake.ssn(gender='22')
+
+    def test_zh_CN_ssn_gender_passed(self):
+        # Females have even number at index 17
+        ssn = self.fake.ssn(gender='F')
+        assert int(ssn[16]) % 2 == 0
+        # Males have odd number at index 17
+        ssn = self.fake.ssn(gender='M')
+        assert int(ssn[16]) % 2 == 1

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -25,7 +25,6 @@ from faker.providers.ssn.no_NO import checksum as no_checksum
 from faker.providers.ssn.pl_PL import calculate_month as pl_calculate_mouth
 from faker.providers.ssn.pl_PL import checksum as pl_checksum
 from faker.providers.ssn.pt_BR import checksum as pt_checksum
-from faker.providers.ssn.zh_CN import Provider as cn_Provider
 from faker.utils.checksums import luhn_checksum
 
 


### PR DESCRIPTION
### What does this changes

Update zh_CN ssn provider, it will support gender option.

### What was wrong

The zh_CN ssn not support gender option when generate ssn code.

### How this fixes it

ssn function add gender parameter with a default value.
