### PR TITLE
Fixed typo in German job provider

### DIFF
--- a/faker/providers/job/de_DE/__init__.py
+++ b/faker/providers/job/de_DE/__init__.py
@@ -24,7 +24,7 @@ class Provider(BaseProvider):
         'Fachinformatiker',
         'Fleischer',
         'Florist',
-        'Forstwirst',
+        'Forstwirt',
         'Friseur',
         'Informatiker',
         'Programmierer',


### PR DESCRIPTION
### What does this change

Fixed typo in line 27 of German job provider `providers/job/de_DE/__init__.py`

### What was wrong

Minor typo in job "Forstwirst" -> should be "Forstwirt"

### How this fixes it

Changed typo to correct spelling
