### PR TITLE
Fixed zh_CN name provider to distinguish between male and female firs…

### DIFF
--- a/faker/providers/person/zh_CN/__init__.py
+++ b/faker/providers/person/zh_CN/__init__.py
@@ -4,7 +4,9 @@ from .. import Provider as PersonProvider
 
 
 class Provider(PersonProvider):
-    formats = ["{{last_name}}{{first_name}}"]
+    formats_male = ["{{last_name}}{{first_name_male}}"]
+    formats_female = ["{{last_name}}{{first_name_female}}"]
+    formats = formats_male + formats_female
 
     first_names_male = [
         "伟", "强", "磊", "洋", "勇", "军", "杰", "涛", "超", "明", "刚", "平", "辉", "鹏", "华", "飞",


### PR DESCRIPTION
### What does this change

Fixes a problem mentioned in https://github.com/joke2k/faker/issues/1210, where the zh_CN provider is not distinguishing between male and female first names.

### What was wrong
No `formats` for male and female first names

### How this fixes it
Using `formats_male` and `formats_female`:

`formats_male = ["{{last_name}}{{first_name_male}}"]`
`formats_female = ["{{last_name}}{{first_name_female}}"]`
`formats = formats_male + formats_female`
