### PR TITLE
Remove "sexy" from the list of bs words

### DIFF
--- a/faker/providers/company/__init__.py
+++ b/faker/providers/company/__init__.py
@@ -413,7 +413,6 @@ class Provider(BaseProvider):
          'web-enabled',
          'interactive',
          'dot-com',
-         'sexy',
          'back-end',
          'real-time',
          'efficient',


### PR DESCRIPTION
### What does this changes

Removes "sexy" from the list of bs words.

### What was wrong

The bs faker could generate borderline not safe for work associations like "enhance sexy experiences" or "enhance sexy relationships".

### How this fixes it

Removing "sexy" as a word prevents this from happening.
