### PR TITLE
Generate Valid Org Id in sv_SE provider

### DIFF
--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -42,7 +42,7 @@ class Provider(SsnProvider):
 
         return pnr
 
-    ORG_ID_DIGIT_1 = (1, 2, 3, 5, 6, 7, 8, 9)
+    ORG_ID_DIGIT_1 = (2, 5, 7, 8, 9)
 
     def org_id(self, long=False, dash=True):
         """

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -127,7 +127,7 @@ class TestSvSE(unittest.TestCase):
         for _ in range(100):
             vat_id = self.fake.vat_id()
             assert re.search(r'SE\d{12}', vat_id)
-            assert int(vat_id[2]) in (1, 2, 3, 5, 6, 7, 8, 9)
+            assert int(vat_id[2]) in (2, 5, 7, 8, 9)
             assert int(vat_id[6:8]) >= 20
 
     def test_org_and_vat_id(self):


### PR DESCRIPTION
Should pass test "valid_organisation" in local-flavor https://github.com/django/django-localflavor/blob/5808835c49bb4330a75f3cf730f70a1d8e105bb8/localflavor/se/utils.py#L90

### What does this changes
Generate a valid organization number.

### What was wrong
Org ID introduced in https://github.com/joke2k/faker/pull/1022 is invalid.

Fixes https://github.com/joke2k/faker/issues/1262.