### PR TITLE
Use non-zero number for first digit of Swedish postal codes.

### DIFF
--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -21,7 +21,10 @@ class Provider(AddressProvider):
 
     address_formats = ("{{street_address}}\n{{postcode}} {{city}}", )
 
-    postcode_formats = ('#####', )
+    # Postcode should be formatted as described in
+    # https://sv.wikipedia.org/wiki/Postnummer_i_Sverige and
+    # in 2nd chapter of https://www.postnord.se/siteassets/pdf/faktablad/postnummersystemet-i-sverige-171213.pdf.
+    postcode_formats = ('%####', )
 
     city_formats = ('{{city_name}}', )
 


### PR DESCRIPTION
### What does this changes

This change corrects the postal code format in the Swedish locale of the address faker.

### What was wrong

The Swedish locale of the address faker generated postal codes that did not comply to the real format of Swedish postal codes.

See https://sv.wikipedia.org/wiki/Postnummer_i_Sverige and 2nd chapter of https://www.postnord.se/siteassets/pdf/faktablad/postnummersystemet-i-sverige-171213.pdf.
### How this fixes it

By changing the postal code format of the Swedish locale of the address faker to generate a leading non-zero digit the faker generates correct Swedish postal codes.