### PR TITLE
Use "Belarus" instead of "Vitryssland"

### DIFF
--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -40,8 +40,8 @@ class Provider(AddressProvider):
         'Afghanistan', 'Albanien', 'Algeriet', 'Amerikanska Samoa', 'Andorra',
         'Angola', 'Anguilla', 'Antarktis', 'Antigua och Barbuda', 'Argentina',
         'Armenien', 'Aruba', 'Ascension', 'Australien', 'Azerbajdzjan',
-        'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados', 'Belgien', 'Belize',
-        'Benin', 'Bermuda', 'Bhutan', 'Bolivia', 'Bosnien och Hercegovina',
+        'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados', 'Belarus', 'Belgien',
+        'Belize', 'Benin', 'Bermuda', 'Bhutan', 'Bolivia', 'Bosnien och Hercegovina',
         'Botswana', 'Brasilien', 'Brittiska Jungfruöarna', 'Brunei',
         'Bulgarien', 'Burkina Faso', 'Burma', 'Burundi', 'Caymanöarna',
         'Centralafrikanska republiken', 'Chile', 'Colombia', 'Cooköarna',
@@ -83,7 +83,7 @@ class Provider(AddressProvider):
         'Tunisien', 'Turkiet', 'Turkmenistan', 'Turks-och Caicosöarna',
         'Tuvalu', 'Tyskland', 'Uganda', 'Ukraina', 'Ungern', 'Uruguay', 'USA',
         'Uzbekistan', 'Vanuatu', 'Vatikanstaten', 'Venezuela', 'Vietnam',
-        'Vitryssland', 'Wake', 'Wallis-och Futunaöarna', 'Zambia', 'Zimbabwe',
+        'Wake', 'Wallis-och Futunaöarna', 'Zambia', 'Zimbabwe',
         'Österrike', 'Östtimor',
     )
 


### PR DESCRIPTION
### What does this changes

The name of the country Belarus in the Swedish address locale is changed from the older Swedish variant. The Swedish government (among other governments) has since some time been using "Belarus" to name the country.

- https://www.svt.se/nyheter/utrikes/regeringen-vitryssland-blir-belarus
- https://spraktidningen.se/artiklar/2020/04/vitryssland-eller-belarus

### What was wrong

Belarus was named as "Vitryssland" which is outdated.

### How this fixes it

Instead of "Vitryssland", "Belarus" is used as the Swedish name of the country Belarus.
