### PR TITLE
Avoid sv_SE postal codes starting with zero

### DIFF
--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -21,7 +21,8 @@ class Provider(AddressProvider):
 
     address_formats = ("{{street_address}}\n{{postcode}} {{city}}", )
 
-    postcode_formats = ('#####', )
+    postcode_formats = ('1####', '2####', '3####', '4####', '5####', '6####',
+                        '7####', '8####', '9####')
 
     city_formats = ('{{city_name}}', )
 


### PR DESCRIPTION
### What was wrong

Swedish postal codes are five digits and start with a non-zero digit (https://sv.wikipedia.org/wiki/Postnummer_i_Sverige). Currently invalid postal codes are sometimes generated since they start with a zero.

### How this fixes it

Changes postal code starting digit from any digit to 1..9.
