### PR TITLE
Fix hu_HU color provider inheritance

### DIFF
--- a/faker/providers/color/hu_HU/__init__.py
+++ b/faker/providers/color/hu_HU/__init__.py
@@ -1,7 +1,7 @@
-from faker.providers import BaseProvider
+from .. import Provider as ColorProvider
 
 
-class Provider(BaseProvider):
+class Provider(ColorProvider):
     """Implement color provider for ``hu_HU`` locale."""
 
     safe_colors = (


### PR DESCRIPTION
### What does this changes

Fix hu_HU color provider inheritance

### What was wrong

It was broken since it was first introduced
in d5ad2d04dd512852bd2903f12d991db6de2d21dc

### How this fixes it

The common ColorProvider must be inherited, no the abstract BaseProvider

Addresses #490 
Unblocks #1254 
