### PR TITLE
Added new style pt_PT automotive plates

### DIFF
--- a/faker/providers/automotive/pt_PT/__init__.py
+++ b/faker/providers/automotive/pt_PT/__init__.py
@@ -6,11 +6,13 @@ class Provider(AutomotiveProvider):
 
     Sources:
 
-    - https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal
+    - https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Portugal
     """
 
     license_formats = (
         '##-##-??',
         '##-??-##',
         '??-##-##',
+        # New format since March 2020
+        '??-##-??',
     )

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -29,7 +29,8 @@ class TestPtPt(_SimpleAutomotiveTestMixin):
     license_plate_pattern = re.compile(
         r'\d{2}-\d{2}-[A-Z]{2}|'
         r'\d{2}-[A-Z]{2}-\d{2}|'
-        r'[A-Z]{2}-\d{2}-\d{2}',
+        r'[A-Z]{2}-\d{2}-\d{2}|'
+        r'[A-Z]{2}-\d{2}-[A-Z]{2}',
     )
 
 


### PR DESCRIPTION
### What does this changes

Adds the newest style of Portugal's automotive plates, which is being used since March 2020.

### What was wrong

Missing newest style of Portugal's automotive plates.

### How this fixes it

The new style can now be generated.
