### PR TITLE
Add Turkish translation to automotive provider

### DIFF
--- a/faker/providers/automotive/tr_TR/__init__.py
+++ b/faker/providers/automotive/tr_TR/__init__.py
@@ -1,0 +1,31 @@
+import re
+
+from .. import Provider as AutomotiveProvider
+
+
+class Provider(AutomotiveProvider):
+    """Implement automotive provider for ``tr_TR`` locale.
+
+    Sources:
+
+    - https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Turkey
+    """
+
+    license_formats = (
+        '## ? ####',
+        '## ? #####',
+        '## ?? ###',
+        '## ?? ####',
+        '## ??? ##',
+        '## ??? ###',
+    )
+    ascii_uppercase_turkish = 'ABCDEFGHIJKLMNOPRSTUVYZ'
+
+    def license_plate(self) -> str:
+        """Generate a license plate."""
+        temp = re.sub(r'\?',
+                      lambda x: self.random_element(self.ascii_uppercase_turkish),
+                      self.random_element(self.license_formats))
+        temp = temp.replace('##', '{:02d}', 1)
+        temp = temp.format(self.random_element(range(1, 82)))
+        return self.numerify(temp)

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -3,6 +3,7 @@ import re
 from faker.providers.automotive.de_DE import Provider as DeDeAutomotiveProvider
 from faker.providers.automotive.es_ES import Provider as EsEsAutomotiveProvider
 from faker.providers.automotive.ru_RU import Provider as RuRuAutomotiveProvider
+from faker.providers.automotive.tr_TR import Provider as TrTrAutomotiveProvider
 
 
 class _SimpleAutomotiveTestMixin:
@@ -158,3 +159,20 @@ class TestEsEs:
         plate = faker.license_plate()
         assert isinstance(plate, str)
         assert self.new_format_pattern.match(plate) or self.old_format_pattern.match(plate)
+
+
+class TestTrTr(_SimpleAutomotiveTestMixin):
+    """Test tr_TR automotive provider methods"""
+    license_plate_pattern = re.compile(
+        r'\d{2} [A-Z] \d{4}|'
+        r'\d{2} [A-Z] \d{5}|'
+        r'\d{2} [A-Z]{2} \d{3}|'
+        r'\d{2} [A-Z]{2} \d{4}|'
+        r'\d{2} [A-Z]{3} \d{2}|'
+        r'\d{2} [A-Z]{3} \d{3}',
+    )
+
+    def perform_extra_checks(self, license_plate, match):
+        [city_code, letters, _] = license_plate.split(' ')
+        assert int(city_code) in range(1, 82)
+        assert all([letter in TrTrAutomotiveProvider.ascii_uppercase_turkish for letter in letters])

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -175,4 +175,4 @@ class TestTrTr(_SimpleAutomotiveTestMixin):
     def perform_extra_checks(self, license_plate, match):
         [city_code, letters, _] = license_plate.split(' ')
         assert int(city_code) in range(1, 82)
-        assert all([letter in TrTrAutomotiveProvider.ascii_uppercase_turkish for letter in letters])
+        assert all(letter in TrTrAutomotiveProvider.ascii_uppercase_turkish for letter in letters)


### PR DESCRIPTION
### What does this changes

Add custom automotive provider for tr_TR locale

### What was wrong

The automotive provider of tr_TR was the default automotive provider.

### How this fixes it

The added automotive provider will return a license plate in Turkish.

Fixes #1286 
