### PR TITLE
Split first names into male and female first names on pt_PT provider

### DIFF
--- a/faker/providers/person/pt_PT/__init__.py
+++ b/faker/providers/person/pt_PT/__init__.py
@@ -2,51 +2,70 @@ from .. import Provider as PersonProvider
 
 
 class Provider(PersonProvider):
-    formats = (
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{last_name}}',
-        '{{first_name}} {{prefix}} {{last_name}}',
-        '{{first_name}} {{last_name}}-{{last_name}}',
-        '{{first_name}}-{{first_name}} {{last_name}}',
+    formats_male = (
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}',
+        '{{first_name_male}} {{prefix}} {{last_name}}',
+        '{{first_name_male}} {{last_name}}-{{last_name}}',
     )
 
-    first_names = (
-        'Adriana', 'Afonso', 'Alex', 'Alexandra', 'Alexandre', 'Alice',
-        'Alícia', 'Amélia', 'Ana', 'Andreia', 'André', 'Anita', 'António',
-        'Ariana', 'Artur', 'Beatriz', 'Benedita', 'Benjamim', 'Bernardo',
-        'Bianca', 'Brian', 'Bruna', 'Bruno', 'Bryan', 'Bárbara', 'Caetana',
-        'Camila', 'Carlos', 'Carlota', 'Carminho', 'Carolina', 'Catarina',
-        'Clara', 'Cláudio', 'Constança', 'Cristiano', 'César', 'Daniel',
-        'Daniela', 'David', 'Denis', 'Diana', 'Diego', 'Dinis', 'Diogo',
-        'Duarte', 'Débora', 'Edgar', 'Eduarda', 'Eduardo', 'Ema', 'Emanuel',
-        'Emma', 'Emília', 'Enzo', 'Erica', 'Erika', 'Eva', 'Fabiana',
-        'Fernando', 'Filipa', 'Filipe', 'Flor', 'Francisca', 'Francisco',
-        'Frederico', 'Fábio', 'Gabriel', 'Gabriela', 'Gaspar', 'Gil', 'Gonçalo',
-        'Guilherme', 'Gustavo', 'Helena', 'Henrique', 'Hugo', 'Iara', 'Igor',
-        'Inês', 'Irina', 'Isaac', 'Isabel', 'Isabela', 'Ivan', 'Ivo', 'Jaime',
-        'Joana', 'Joaquim', 'Joel', 'Jorge', 'José', 'João', 'Juliana',
-        'Jéssica', 'Júlia', 'Kelly', 'Kevin', 'Kyara', 'Kévim', 'Lara',
-        'Larissa', 'Laura', 'Leandro', 'Leonardo', 'Leonor', 'Letícia', 'Lia',
-        'Lisandro', 'Lorena', 'Lourenço', 'Luana', 'Luca', 'Lucas', 'Luciana',
-        'Luna', 'Luís', 'Luísa', 'Lúcia', 'Madalena', 'Mafalda', 'Manuel',
-        'Mara', 'Marco', 'Marcos', 'Margarida', 'Maria', 'Mariana', 'Marta',
-        'Martim', 'Mateus', 'Matias', 'Matilde', 'Mauro', 'Melissa', 'Mia',
-        'Micael', 'Miguel', 'Miriam', 'Márcio', 'Mário', 'Mélanie', 'Naiara',
-        'Nair', 'Nelson', 'Nicole', 'Noa', 'Noah', 'Nuno', 'Nádia', 'Núria',
-        'Patrícia', 'Paulo', 'Pedro', 'Petra', 'Pilar', 'Rafael', 'Rafaela',
-        'Raquel', 'Renata', 'Renato', 'Ricardo', 'Rita', 'Rodrigo', 'Rui',
-        'Rúben', 'Salomé', 'Salvador', 'Samuel', 'Sandro', 'Santiago', 'Sara',
-        'Sebastião', 'Simão', 'Sofia', 'Soraia', 'Sérgio', 'Tatiana', 'Teresa',
-        'Tiago', 'Tomás', 'Tomé', 'Valentim', 'Valentina', 'Vasco', 'Vera',
-        'Vicente', 'Victória', 'Violeta', 'Vitória', 'Vítor', 'William',
-        'Wilson', 'Xavier', 'Yara', 'Yasmin', 'Álvaro', 'Ângela', 'Ângelo',
-        'Érica', 'Íris',
+    formats_female = (
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}',
+        '{{first_name_female}} {{prefix}} {{last_name}}',
+        '{{first_name_female}} {{last_name}}-{{last_name}}',
+        '{{first_name_female}}-{{first_name_female}} {{last_name}}',
     )
+
+    formats = formats_male + formats_female
+
+    first_names_male = (
+        'Afonso', 'Alexandre', 'Álvaro', 'André', 'Ângelo', 'António', 'Artur',
+        'Benjamim', 'Bernardo', 'Brian', 'Bruno', 'Bryan', 'Carlos',
+        'Cláudio', 'Cristiano', 'César', 'Daniel', 'David', 'Denis',
+        'Diego', 'Dinis', 'Diogo', 'Duarte', 'Edgar', 'Eduardo', 'Emanuel',
+        'Enzo', 'Fernando', 'Filipe', 'Francisco', 'Frederico', 'Fábio',
+        'Gabriel', 'Gaspar', 'Gil', 'Gonçalo', 'Guilherme', 'Gustavo',
+        'Henrique', 'Hugo', 'Igor', 'Isaac', 'Ismael', 'Ivan', 'Ivo', 'Jaime',
+        'Joaquim', 'Joel', 'Jorge', 'José', 'João', 'Kevin', 'Kévim',
+        'Leandro', 'Leonardo', 'Lisandro', 'Lourenço', 'Luca', 'Lucas',
+        'Luís', 'Manuel', 'Marco', 'Marcos', 'Martim', 'Mateus',
+        'Matias', 'Mauro', 'Micael', 'Miguel', 'Márcio', 'Mário',
+        'Nelson', 'Noa', 'Noah', 'Nuno', 'Paulo', 'Pedro', 'Rafael',
+        'Renato', 'Ricardo', 'Rodrigo', 'Rui', 'Rúben', 'Salvador',
+        'Samuel', 'Sandro', 'Santiago', 'Sebastião', 'Simão', 'Sérgio', 'Tiago',
+        'Tomás', 'Tomé', 'Valentim', 'Vasco', 'Vicente', 'Vítor', 'William',
+        'Wilson', 'Xavier',
+    )
+
+    first_names_female = (
+        'Adriana', 'Alexandra', 'Alice', 'Alícia', 'Amélia', 'Ana', 'Andreia',
+        'Ângela', 'Anita', 'Ariana', 'Beatriz', 'Benedita', 'Bianca', 'Bruna',
+        'Bárbara', 'Caetana', 'Camila', 'Carlota', 'Carminho', 'Carolina',
+        'Catarina', 'Clara', 'Constança', 'Daniela', 'Diana', 'Débora', 'Eduarda',
+        'Ema', 'Emma', 'Emília', 'Erica', 'Érica', 'Erika', 'Eva', 'Fabiana',
+        'Filipa', 'Flor', 'Francisca', 'Gabriela', 'Helena', 'Iara', 'Inês',
+        'Irina', 'Íris', 'Isabel', 'Isabela', 'Joana', 'Juliana', 'Jéssica',
+        'Júlia', 'Kelly', 'Kyara', 'Lara', 'Larissa', 'Laura', 'Leonor', 'Letícia',
+        'Lia', 'Lorena', 'Luana', 'Luciana', 'Luna', 'Luísa', 'Lúcia', 'Madalena',
+        'Mafalda', 'Mara', 'Margarida', 'Maria', 'Mariana', 'Marta', 'Matilde',
+        'Melissa', 'Mia', 'Miriam', 'Mélanie', 'Naiara', 'Nair', 'Nicole', 'Nádia',
+        'Núria', 'Patrícia', 'Petra', 'Pilar', 'Rafaela', 'Raquel', 'Renata',
+        'Rita', 'Salomé', 'Sara', 'Sofia', 'Soraia', 'Tatiana', 'Teresa',
+        'Valentina', 'Vera', 'Victória', 'Violeta', 'Vitória', 'Yara', 'Yasmin',
+    )
+
+    first_names = first_names_male + first_names_female
 
     last_names = (
         'Abreu', 'Almeida', 'Alves', 'Amaral', 'Amorim', 'Andrade', 'Anjos',

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -15,6 +15,7 @@ from faker.providers.person.hy_AM import Provider as HyAmProvider
 from faker.providers.person.ne_NP import Provider as NeProvider
 from faker.providers.person.or_IN import Provider as OrINProvider
 from faker.providers.person.pl_PL import Provider as PlPLProvider
+from faker.providers.person.pt_PT import Provider as PtPtProvider
 from faker.providers.person.pl_PL import checksum_identity_card_number as pl_checksum_identity_card_number
 from faker.providers.person.ru_RU import Provider as RuProvider
 from faker.providers.person.ru_RU import translit
@@ -614,6 +615,26 @@ class TestEsES(unittest.TestCase):
     def test_language_name(self):
         language_name = self.fake.language_name()
         assert language_name in EsESProvider.language_names
+
+
+class TestPtPt(unittest.TestCase):
+    """Tests person in the pt_PT locale."""
+
+    def setUp(self):
+        self.fake = Faker('pt_PT')
+        Faker.seed(0)
+    
+    def test_male_first_name(self):
+        first_name_male = self.fake.first_name_male()
+        assert first_name_male in PtPtProvider.first_names_male
+    
+    def test_female_first_name(self):
+        first_name_female = self.fake.first_name_female()
+        assert first_name_female in PtPtProvider.first_names_female
+
+    def test_last_name(self):
+        last_name = self.fake.last_name()
+        assert last_name in PtPtProvider.last_names
 
 
 class TestUs(unittest.TestCase):

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -15,8 +15,8 @@ from faker.providers.person.hy_AM import Provider as HyAmProvider
 from faker.providers.person.ne_NP import Provider as NeProvider
 from faker.providers.person.or_IN import Provider as OrINProvider
 from faker.providers.person.pl_PL import Provider as PlPLProvider
-from faker.providers.person.pt_PT import Provider as PtPtProvider
 from faker.providers.person.pl_PL import checksum_identity_card_number as pl_checksum_identity_card_number
+from faker.providers.person.pt_PT import Provider as PtPtProvider
 from faker.providers.person.ru_RU import Provider as RuProvider
 from faker.providers.person.ru_RU import translit
 from faker.providers.person.sv_SE import Provider as SvSEProvider
@@ -623,11 +623,11 @@ class TestPtPt(unittest.TestCase):
     def setUp(self):
         self.fake = Faker('pt_PT')
         Faker.seed(0)
-    
+
     def test_male_first_name(self):
         first_name_male = self.fake.first_name_male()
         assert first_name_male in PtPtProvider.first_names_male
-    
+
     def test_female_first_name(self):
         first_name_female = self.fake.first_name_female()
         assert first_name_female in PtPtProvider.first_names_female


### PR DESCRIPTION
### What does this changes

Corrects the first names when requested with gender specifications (e.g.: `fake.first_name_male()` and `fake.name_female()`).
 
### What was wrong

When, in example, `fake.name_male()` was requested, a female name is provided.

### How this fixes it

By spliting the female and male first names into seperate designated groups, it's possible to generate gender-specific names correctly. The last names are family names and are not gender-specific.
