### PR TITLE
Remove abandoned Community Provider CloudProvider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -12,10 +12,6 @@ Here's a list of Providers written by the community:
 |               | mime-type and web server |                                  +
 |               | versions.                |                                  +
 +---------------+--------------------------+----------------------------------+
-| CloudProvider | Cloud-related data       | `faker_cloud`_                   +
-|               | generic or specialized   |                                  +
-|               | by cloud.                |                                  +
-+---------------+--------------------------+----------------------------------+
 | Wi-Fi ESSID   | Fake Wi-Fi ESSIDs.       | `faker_wifi_essid`_              +
 +---------------+--------------------------+----------------------------------+
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |
@@ -41,7 +37,6 @@ In order to be inlcuded, your provider must satisfy these requirement:
 .. _repo: https://github.com/joke2k/faker/
 .. _OSI-Approved: https://opensource.org/licenses/alphabetical
 .. _faker_web: https://pypi.org/project/faker_web/
-.. _faker_cloud: https://pypi.org/project/faker-cloud/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/


### PR DESCRIPTION
CloudProvider, a Community Provider added in 2018, consisted of only a single release and the Home Page link from pypi no longer worked. Poking around the owner's github account shows that the repo has been archived. 