### PR TITLE
Remove warnings when building documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.intersphinx',
     'faker.sphinx.autodoc',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -98,7 +99,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/fakerclass.rst
+++ b/docs/fakerclass.rst
@@ -21,7 +21,7 @@ new ``Faker.seed()`` points to ``Generator.seed()``, in new ``Faker``, invocatio
 from a ``Faker`` object instance has been disabled, and attempting to do so will raise a
 ``TypeError`` as shown below.
 
-.. code:: python
+.. code:: text
 
     TypeError: Calling `.seed()` on instances is deprecated. Use the class method `Faker.seed()` instead.
 

--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -22,52 +22,52 @@ class Provider(BaseProvider):
 
     def city_suffix(self):
         """
-        :example 'town'
+        :example: 'town'
         """
         return self.random_element(self.city_suffixes)
 
     def street_suffix(self):
         """
-        :example 'Avenue'
+        :example: 'Avenue'
         """
         return self.random_element(self.street_suffixes)
 
     def building_number(self):
         """
-        :example '791'
+        :example: '791'
         """
         return self.numerify(self.random_element(self.building_number_formats))
 
     def city(self):
         """
-        :example 'Sashabury'
+        :example: 'Sashabury'
         """
         pattern = self.random_element(self.city_formats)
         return self.generator.parse(pattern)
 
     def street_name(self):
         """
-        :example 'Crist Parks'
+        :example: 'Crist Parks'
         """
         pattern = self.random_element(self.street_name_formats)
         return self.generator.parse(pattern)
 
     def street_address(self):
         """
-        :example '791 Crist Parks'
+        :example: '791 Crist Parks'
         """
         pattern = self.random_element(self.street_address_formats)
         return self.generator.parse(pattern)
 
     def postcode(self):
         """
-        :example 86039-9874
+        :example: 86039-9874
         """
         return self.bothify(self.random_element(self.postcode_formats)).upper()
 
     def address(self):
         """
-        :example '791 Crist Parks, Sashabury, IL 86039-9874'
+        :example: '791 Crist Parks, Sashabury, IL 86039-9874'
         """
         pattern = self.random_element(self.address_formats)
         return self.generator.parse(pattern)

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -396,25 +396,25 @@ class Provider(AddressProvider):
 
     def military_ship(self):
         """
-        :example 'USS'
+        :example: 'USS'
         """
         return self.random_element(self.military_ship_prefix)
 
     def military_state(self):
         """
-        :example 'APO'
+        :example: 'APO'
         """
         return self.random_element(self.military_state_abbr)
 
     def military_apo(self):
         """
-        :example 'PSC 5394 Box 3492
+        :example: 'PSC 5394 Box 3492
         """
         return self.numerify(self.military_apo_format)
 
     def military_dpo(self):
         """
-        :example 'Unit 3333 Box 9342'
+        :example: 'Unit 3333 Box 9342'
         """
         return self.numerify(self.military_dpo_format)
 

--- a/faker/providers/address/es_MX/__init__.py
+++ b/faker/providers/address/es_MX/__init__.py
@@ -102,13 +102,13 @@ class Provider(AddressProvider):
 
     def street_prefix(self):
         """
-        :example 'Avenida'
+        :example: 'Avenida'
         """
         return self.random_element(self.street_prefixes)
 
     def secondary_address(self):
         """
-        :example '020 Interior 999'
+        :example: '020 Interior 999'
         """
         return self.numerify(
             self.random_element(

--- a/faker/providers/address/fr_CH/__init__.py
+++ b/faker/providers/address/fr_CH/__init__.py
@@ -99,33 +99,33 @@ class Provider(AddressProvider):
 
     def street_prefix(self):
         """
-        :example 'rue'
+        :example: 'rue'
         """
         return self.random_element(self.street_prefixes)
 
     def city_prefix(self):
         """
-        :example 'rue'
+        :example: 'rue'
         """
         return self.random_element(self.city_prefixes)
 
     def canton(self):
         """
         Randomly returns a swiss canton ('Abbreviated' , 'Name').
-        :example ('VD' . 'Vaud')
+        :example: ('VD' . 'Vaud')
         """
         return self.random_element(self.cantons)
 
     def canton_name(self):
         """
         Randomly returns a Swiss canton name.
-        :example 'Vaud'
+        :example: 'Vaud'
         """
         return self.canton()[1]
 
     def canton_code(self):
         """
         Randomly returns a Swiss canton code.
-        :example 'VD'
+        :example: 'VD'
         """
         return self.canton()[0]

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -137,33 +137,33 @@ class Provider(AddressProvider):
 
     def street_prefix(self):
         """
-        :example 'rue'
+        :example: 'rue'
         """
         return self.random_element(self.street_prefixes)
 
     def city_prefix(self):
         """
-        :example 'rue'
+        :example: 'rue'
         """
         return self.random_element(self.city_prefixes)
 
     def region(self):
         """
-        :example 'Guadeloupe'
+        :example: 'Guadeloupe'
         """
         return self.random_element(self.regions)
 
     def department(self):
         """
         Randomly returns a french department ('departmentNumber' , 'departmentName').
-        :example ('2B' . 'Haute-Corse')
+        :example: ('2B' . 'Haute-Corse')
         """
         return self.random_element(self.departments)
 
     def department_name(self):
         """
         Randomly returns a french department name.
-        :example 'Ardèche'
+        :example: 'Ardèche'
         """
         return self.department()[1]
 
@@ -171,6 +171,6 @@ class Provider(AddressProvider):
         """
         Randomly returns a french department number.
 
-        :example '59'
+        :example: '59'
         """
         return self.department()[0]

--- a/faker/providers/address/hy_AM/__init__.py
+++ b/faker/providers/address/hy_AM/__init__.py
@@ -600,25 +600,25 @@ class Provider(AddressProvider):
 
     def city(self):
         """
-        :example 'Բյուրեղավան'
+        :example: 'Բյուրեղավան'
         """
         return self.random_element(self.cities)
 
     def city_prefix(self):
         """
-        :example 'ք.'
+        :example: 'ք.'
         """
         return self.random_element(self.city_prefixes)
 
     def postcode(self):
         """
-        :example '3159'
+        :example: '3159'
         """
         return "%04d" % self.generator.random.randint(200, 4299)
 
     def postcode_in_state(self, state_abbr=None):
         """
-        :example '4703'
+        :example: '4703'
         """
         if state_abbr is None:
             state_abbr = self.random_element(self.states_abbr)
@@ -638,42 +638,42 @@ class Provider(AddressProvider):
 
     def secondary_address(self):
         """
-        :example 'բն. 49'
+        :example: 'բն. 49'
         """
         return self.numerify(self.random_element(self.secondary_address_formats))
 
     def state(self):
         """
-        :example 'Կոտայք'
+        :example: 'Կոտայք'
         """
         return self.random_element(self.states)
 
     def state_abbr(self):
         """
-        :example 'ՎՁ'
+        :example: 'ՎՁ'
         """
         return self.random_element(self.states_abbr)
 
     def street(self):
         """
-        :example 'Ոսկերիչների'
+        :example: 'Ոսկերիչների'
         """
         return self.random_element(self.streets)
 
     def street_prefix(self):
         """
-        :example 'փողոց'
+        :example: 'փողոց'
         """
         return self.random_element(self.street_prefixes)
 
     def village(self):
         """
-        :example 'Ոսկեվազ'
+        :example: 'Ոսկեվազ'
         """
         return self.random_element(self.villages)
 
     def village_prefix(self):
         """
-        :example 'գ.'
+        :example: 'գ.'
         """
         return self.random_element(self.village_prefixes)

--- a/faker/providers/address/ja_JP/__init__.py
+++ b/faker/providers/address/ja_JP/__init__.py
@@ -304,49 +304,49 @@ class Provider(AddressProvider):
 
     def prefecture(self):
         """
-        :example '東京都'
+        :example: '東京都'
         """
         return self.random_element(self.prefectures)
 
     def city(self):
         """
-        :example '台東区'
+        :example: '台東区'
         """
         return self.random_element(self.cities)
 
     def town(self):
         """
-        :example '浅草'
+        :example: '浅草'
         """
         return self.random_element(self.towns)
 
     def chome(self):
         """
-        :example '1丁目'
+        :example: '1丁目'
         """
         return "%d丁目" % self.generator.random.randint(1, 42)
 
     def ban(self):
         """
-        :example '3番'
+        :example: '3番'
         """
         return "%d番" % self.generator.random.randint(1, 27)
 
     def gou(self):
         """
-        :example '10号'
+        :example: '10号'
         """
         return "%d号" % self.generator.random.randint(1, 20)
 
     def building_name(self):
         """
-        :example 'コーポ芝浦'
+        :example: 'コーポ芝浦'
         """
         return self.random_element(self.building_names)
 
     def postcode(self):
         """
-        :example '101-1212'
+        :example: '101-1212'
         """
         return "%03d-%04d" % (self.generator.random.randint(0, 999),
                               self.generator.random.randint(0, 9999))

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -7,13 +7,9 @@ ALPHABET = string.ascii_uppercase
 
 class Provider(AddressProvider):
     """
-    Korean Address Provider
-    =======================
-
     Korea has two address and postal code system.
 
-    Address
-    -------
+    **Address**
 
     - Address based on land parcel numbers
       (지번 주소, OLD, but someone use consistently)
@@ -23,8 +19,7 @@ class Provider(AddressProvider):
     :meth:`road_address` generate Address based on road names and building
     numbers.
 
-    Postal code
-    -----------
+    **Postal code**
 
     - Old postal code (6-digit, OLD and dead)
     - New postal code (5-digit, New)
@@ -32,8 +27,7 @@ class Provider(AddressProvider):
     :meth:`old_postal_code` and :meth:`postcode` generate old 6-digit code
     and :meth:`postal_code` generate newer 5-digit code.
 
-    Reference
-    ---------
+    **Reference**
 
     - `Official Confirmation Prividing that Old and New Addresses are Identical`__
       (warn: cert error)

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -317,33 +317,33 @@ class Provider(AddressProvider):
 
     def land_number(self):
         """
-        :example 507
+        :example: 507
         """
         return self.bothify(self.random_element(self.land_numbers))
 
     def land_address(self):
         """
-        :example 세종특별자치시 어진동 507
+        :example: 세종특별자치시 어진동 507
         """
         pattern = self.random_element(self.land_address_formats)
         return self.generator.parse(pattern)
 
     def road_number(self):
         """
-        :example 24
+        :example: 24
         """
         return self.bothify(self.random_element(self.road_numbers))
 
     def road_address(self):
         """
-        :example 세종특별자치시 도움5로 19 (어진동)
+        :example: 세종특별자치시 도움5로 19 (어진동)
         """
         pattern = self.random_element(self.road_address_formats)
         return self.generator.parse(pattern)
 
     def address_detail(self):
         """
-        :example 가나아파트 가동 102호
+        :example: 가나아파트 가동 102호
         """
         pattern = self.bothify(self.random_element(
             self.address_detail_formats))
@@ -351,94 +351,94 @@ class Provider(AddressProvider):
 
     def road(self):
         """
-        :example 도움5로
+        :example: 도움5로
         """
         pattern = self.random_element(self.road_formats)
         return self.generator.parse(pattern)
 
     def road_name(self):
         """
-        :example 압구정
+        :example: 압구정
         """
         return self.random_element(self.road_names)
 
     def road_suffix(self):
         """
-        :example 길
+        :example: 길
         """
         return self.random_element(self.road_suffixes)
 
     def metropolitan_city(self):
         """
-        :example 서울특별시
+        :example: 서울특별시
         """
         return self.random_element(self.metropolitan_cities)
 
     def province(self):
         """
-        :example 경기도
+        :example: 경기도
         """
         return self.random_element(self.provinces)
 
     def city(self):
         """
-        :example 고양시
+        :example: 고양시
         """
         pattern = self.random_element(self.cities)
         return self.generator.parse(pattern)
 
     def borough(self):
         """
-        :example 중구
+        :example: 중구
         """
         return self.random_element(self.boroughs)
 
     def town(self):
         """
-        :example 가나동
+        :example: 가나동
         """
         pattern = self.random_element(self.town_formats)
         return self.generator.parse(pattern)
 
     def town_suffix(self):
         """
-        :example 동
+        :example: 동
         """
         return self.random_element(self.town_suffixes)
 
     def building_name(self):
         """
-        :example 김구아파트
+        :example: 김구아파트
         """
         pattern = self.random_element(self.building_name_formats)
         return self.generator.parse(pattern)
 
     def building_suffix(self):
         """
-        :example 아파트
+        :example: 아파트
         """
         return self.random_element(self.building_suffixes)
 
     def building_dong(self):
         """
-        :example 가
+        :example: 가
         """
         return self.bothify(self.random_element(self.building_dongs))
 
     def old_postal_code(self):
         """
-        :example 123-456
+        :example: 123-456
         """
         return self.bothify(self.random_element(self.postcode_formats))
 
     def postcode(self):
         """
-        :example 12345
+        :example: 12345
         """
         return self.bothify(self.random_element(self.new_postal_code_formats))
 
     def postal_code(self):
         """
-        :example 12345
+        :example: 12345
         """
         return self.postcode()

--- a/faker/providers/address/ne_NP/__init__.py
+++ b/faker/providers/address/ne_NP/__init__.py
@@ -604,18 +604,18 @@ class Provider(AddressProvider):
 
     def district(self):
         """
-        :example अछाम
+        :example: अछाम
         """
         return self.random_element(self.districts)
 
     def city(self):
         """
-        :example कावासोती
+        :example: कावासोती
         """
         return self.random_element(self.cities)
 
     def building_prefix(self):
         """
-        :example वडा
+        :example: वडा
         """
         return self.random_element(self.building_prefixes)

--- a/faker/providers/address/pl_PL/__init__.py
+++ b/faker/providers/address/pl_PL/__init__.py
@@ -155,33 +155,33 @@ class Provider(AddressProvider):
     def street_prefix(self):
         """
         Randomly returns a street prefix
-        :example 'aleja'
+        :example: 'aleja'
         """
         return self.random_element(self.street_prefixes)
 
     def street_prefix_short(self):
         """
         Randomly returns an abbreviation of the street prefix.
-        :example 'al.'
+        :example: 'al.'
         """
         return self.random_element(self.street_prefixes)[:2] + '.'
 
     def street_name(self):
         """
         Randomly returns a street name
-        :example 'Wróblewskiego'
+        :example: 'Wróblewskiego'
         """
         return self.random_element(self.streets)
 
     def city(self):
         """
         Randomly returns a street name
-        :example 'Konin'
+        :example: 'Konin'
         """
         return self.random_element(self.cities)
 
     def region(self):
         """
-        :example 'Wielkopolskie'
+        :example: 'Wielkopolskie'
         """
         return self.random_element(self.regions)

--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -262,21 +262,21 @@ class Provider(AddressProvider):
 
     def street_prefix(self):
         """
-        :example 'rua'
+        :example: 'rua'
         """
         return self.random_element(self.street_prefixes)
 
     def estado(self):
         """
         Randomly returns a Brazilian State  ('sigla' , 'nome').
-        :example ('MG' . 'Minas Gerais')
+        :example: ('MG' . 'Minas Gerais')
         """
         return self.random_element(self.estados)
 
     def estado_nome(self):
         """
         Randomly returns a Brazilian State Name
-        :example 'Minas Gerais'
+        :example: 'Minas Gerais'
         """
         return self.estado()[1]
 
@@ -284,7 +284,7 @@ class Provider(AddressProvider):
         """
         Randomly returns the abbreviation of a Brazilian State
 
-        :example 'MG'
+        :example: 'MG'
         """
         return self.estado()[0]
 
@@ -293,7 +293,7 @@ class Provider(AddressProvider):
         Randomly returns a bairro (neighborhood) name.
         The names were taken from the city of Belo Horizonte - Minas Gerais
 
-        :example 'Serra'
+        :example: 'Serra'
         """
         return self.random_element(self.bairros)
 
@@ -301,8 +301,8 @@ class Provider(AddressProvider):
         """
         Randomly returns a postcode.
         :param formatted: True to allow formatted postcodes, else False (default True)
-        :example formatted: '41224-212' '83992-291' '12324322'
-        :example raw: '43920231' '34239530'
+        :example: formatted: '41224-212' '83992-291' '12324322'
+        :example: raw: '43920231' '34239530'
         """
         template = self.postcode_all_formats if formatted else self.postcode_raw_formats
         return self.bothify(self.random_element(template))

--- a/faker/providers/address/pt_PT/__init__.py
+++ b/faker/providers/address/pt_PT/__init__.py
@@ -389,36 +389,36 @@ class Provider(AddressProvider):
 
     def street_prefix(self):
         """
-        :example 'Rua'
+        :example: 'Rua'
         """
         return self.random_element(self.street_prefixes)
 
     def city_name(self):
         """
-        :example 'Amora'
+        :example: 'Amora'
         """
         return self.random_element(self.cities)
 
     def distrito(self):
         """
-        :example 'Bragança'
+        :example: 'Bragança'
         """
         return self.random_element(self.distritos)
 
     def concelho(self):
         """
-        :example 'Tondela'
+        :example: 'Tondela'
         """
         return self.random_element(self.concelhos)
 
     def freguesia(self):
         """
-        :example 'Miranda do Douro'
+        :example: 'Miranda do Douro'
         """
         return self.random_element(self.freguesias)
 
     def place_name(self):
         """
-        :example "do Pombal"
+        :example: "do Pombal"
         """
         return self.random_element(self.places)

--- a/faker/providers/company/__init__.py
+++ b/faker/providers/company/__init__.py
@@ -491,20 +491,20 @@ class Provider(BaseProvider):
 
     def company(self):
         """
-        :example 'Acme Ltd'
+        :example: 'Acme Ltd'
         """
         pattern = self.random_element(self.formats)
         return self.generator.parse(pattern)
 
     def company_suffix(self):
         """
-        :example 'Ltd'
+        :example: 'Ltd'
         """
         return self.random_element(self.company_suffixes)
 
     def catch_phrase(self):
         """
-        :example 'Robust full-range hub'
+        :example: 'Robust full-range hub'
         """
         result = []
         for word_list in self.catch_phrase_words:
@@ -514,7 +514,7 @@ class Provider(BaseProvider):
 
     def bs(self):
         """
-        :example 'integrate extensible convergence'
+        :example: 'integrate extensible convergence'
         """
         result = []
         for word_list in self.bsWords:

--- a/faker/providers/company/es_MX/__init__.py
+++ b/faker/providers/company/es_MX/__init__.py
@@ -149,7 +149,7 @@ class Provider(CompanyProvider):
 
     def catch_phrase(self):
         """
-        :example 'Robust full-range hub'
+        :example: 'Robust full-range hub'
         """
         result = []
         for word_list in self.catch_phrase_words:
@@ -159,7 +159,7 @@ class Provider(CompanyProvider):
 
     def bs(self):
         """
-        :example 'integrate extensible convergence'
+        :example: 'integrate extensible convergence'
         """
         result = []
         for word_list in self.bsWords:

--- a/faker/providers/company/fr_FR/__init__.py
+++ b/faker/providers/company/fr_FR/__init__.py
@@ -75,7 +75,7 @@ class Provider(CompanyProvider):
 
     def catch_phrase(self):
         """
-        :example 'integrate extensible convergence'
+        :example: 'integrate extensible convergence'
         """
         catch_phrase = ""
         while True:

--- a/faker/providers/company/it_IT/__init__.py
+++ b/faker/providers/company/it_IT/__init__.py
@@ -334,7 +334,7 @@ class Provider(CompanyProvider):
 
     def catch_phrase(self):
         """
-        :example 'Robust full-range hub'
+        :example: 'Robust full-range hub'
         """
         result = []
         for word_list in self.catch_phrase_words:
@@ -344,7 +344,7 @@ class Provider(CompanyProvider):
 
     def bs(self):
         """
-        :example 'integrate extensible convergence'
+        :example: 'integrate extensible convergence'
         """
         result = []
         for word_list in self.bsWords:

--- a/faker/providers/company/ko_KR/__init__.py
+++ b/faker/providers/company/ko_KR/__init__.py
@@ -359,7 +359,7 @@ class Provider(CompanyProvider):
 
     def catch_phrase(self):
         """
-        :example 'Robust full-range hub'
+        :example: 'Robust full-range hub'
         """
         result = []
         for word_list in self.catch_phrase_words:
@@ -369,7 +369,7 @@ class Provider(CompanyProvider):
 
     def bs(self):
         """
-        :example 'integrate extensible convergence'
+        :example: 'integrate extensible convergence'
         """
         result = []
         for word_list in self.bsWords:

--- a/faker/providers/company/nl_NL/__init__.py
+++ b/faker/providers/company/nl_NL/__init__.py
@@ -101,6 +101,6 @@ class Provider(CompanyProvider):
 
     def company_prefix(self):
         """
-        :example 'Stichting'
+        :example: 'Stichting'
         """
         return self.random_element(self.company_prefixes)

--- a/faker/providers/company/pl_PL/__init__.py
+++ b/faker/providers/company/pl_PL/__init__.py
@@ -68,7 +68,7 @@ class Provider(CompanyProvider):
 
     def company_prefix(self):
         """
-        :example 'Grupa'
+        :example: 'Grupa'
         """
         return self.random_element(self.company_prefixes)
 

--- a/faker/providers/company/pt_BR/__init__.py
+++ b/faker/providers/company/pt_BR/__init__.py
@@ -89,7 +89,7 @@ class Provider(CompanyProvider):
 
     def catch_phrase(self):
         """
-        :example 'a segurança de evoluir sem preocupação'
+        :example: 'a segurança de evoluir sem preocupação'
         """
         pattern = self.random_element(self.catch_phrase_formats)
         catch_phrase = self.generator.parse(pattern)

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1384,7 +1384,7 @@ class Provider(BaseProvider):
         """
         Get a timestamp between January 1, 1970 and now, unless passed
         explicit start_datetime or end_datetime values.
-        :example 1061306726
+        :example: 1061306726
         """
         start_datetime = self._parse_start_datetime(start_datetime)
         end_datetime = self._parse_end_datetime(end_datetime)
@@ -1405,7 +1405,7 @@ class Provider(BaseProvider):
         """
         Get a datetime object for a date between January 1, 1970 and now
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2005-08-16 20:39:21')
+        :example: DateTime('2005-08-16 20:39:21')
         :return: datetime
         """
         # NOTE: On windows, the lowest value you can get from windows is 86400
@@ -1418,7 +1418,7 @@ class Provider(BaseProvider):
         """
         Get a datetime object for a date between January 1, 001 and now
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1265-03-22 21:15:52')
+        :example: DateTime('1265-03-22 21:15:52')
         :return: datetime
         """
 
@@ -1444,7 +1444,7 @@ class Provider(BaseProvider):
     def iso8601(self, tzinfo=None, end_datetime=None):
         """
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example '2003-10-21T16:05:52+0000'
+        :example: '2003-10-21T16:05:52+0000'
         """
         return self.date_time(tzinfo, end_datetime=end_datetime).isoformat()
 
@@ -1452,14 +1452,14 @@ class Provider(BaseProvider):
         """
         Get a date string between January 1, 1970 and now
         :param pattern format
-        :example '2008-11-27'
+        :example: '2008-11-27'
         """
         return self.date_time(end_datetime=end_datetime).strftime(pattern)
 
     def date_object(self, end_datetime=None):
         """
         Get a date object between January 1, 1970 and now
-        :example datetime.date(2016, 9, 20)
+        :example: datetime.date(2016, 9, 20)
         """
         return self.date_time(end_datetime=end_datetime).date()
 
@@ -1467,7 +1467,7 @@ class Provider(BaseProvider):
         """
         Get a time string (24h format by default)
         :param pattern format
-        :example '15:02:34'
+        :example: '15:02:34'
         """
         return self.date_time(
             end_datetime=end_datetime).time().strftime(pattern)
@@ -1475,7 +1475,7 @@ class Provider(BaseProvider):
     def time_object(self, end_datetime=None):
         """
         Get a time object
-        :example datetime.time(15, 56, 56, 772876)
+        :example: datetime.time(15, 56, 56, 772876)
         """
         return self.date_time(end_datetime=end_datetime).time()
 
@@ -1570,7 +1570,7 @@ class Provider(BaseProvider):
         :param start_date Defaults to 30 years ago
         :param end_date Defaults to "now"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         start_date = self._parse_date_time(start_date, tzinfo=tzinfo)
@@ -1593,7 +1593,7 @@ class Provider(BaseProvider):
 
         :param start_date Defaults to 30 years ago
         :param end_date Defaults to "today"
-        :example Date('1999-02-02')
+        :example: Date('1999-02-02')
         :return: Date
         """
 
@@ -1609,7 +1609,7 @@ class Provider(BaseProvider):
 
         :param end_date Defaults to "+30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         return self.date_time_between(
@@ -1624,7 +1624,7 @@ class Provider(BaseProvider):
 
         :param end_date Defaults to "+30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         return self.date_between(start_date='+1d', end_date=end_date)
@@ -1637,7 +1637,7 @@ class Provider(BaseProvider):
 
         :param start_date Defaults to "-30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         return self.date_time_between(
@@ -1652,7 +1652,7 @@ class Provider(BaseProvider):
 
         :param start_date Defaults to "-30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         return self.date_between(start_date=start_date, end_date='-1d')
@@ -1670,7 +1670,7 @@ class Provider(BaseProvider):
         :param datetime_start: DateTime
         :param datetime_end: DateTime
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('1999-02-02 11:42:52')
+        :example: DateTime('1999-02-02 11:42:52')
         :return: DateTime
         """
         if datetime_start is None:
@@ -1718,7 +1718,7 @@ class Provider(BaseProvider):
         :param before_now: include days in current century before today
         :param after_now: include days in current century after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2012-04-04 11:02:02')
+        :example: DateTime('2012-04-04 11:02:02')
         :return: DateTime
         """
         now = datetime.now(tzinfo)
@@ -1748,7 +1748,7 @@ class Provider(BaseProvider):
         :param before_now: include days in current decade before today
         :param after_now: include days in current decade after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2012-04-04 11:02:02')
+        :example: DateTime('2012-04-04 11:02:02')
         :return: DateTime
         """
         now = datetime.now(tzinfo)
@@ -1778,7 +1778,7 @@ class Provider(BaseProvider):
         :param before_now: include days in current year before today
         :param after_now: include days in current year after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2012-04-04 11:02:02')
+        :example: DateTime('2012-04-04 11:02:02')
         :return: DateTime
         """
         now = datetime.now(tzinfo)
@@ -1807,7 +1807,7 @@ class Provider(BaseProvider):
         :param before_now: include days in current month before today
         :param after_now: include days in current month after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2012-04-04 11:02:02')
+        :example: DateTime('2012-04-04 11:02:02')
         :return: DateTime
         """
         now = datetime.now(tzinfo)
@@ -1832,7 +1832,7 @@ class Provider(BaseProvider):
 
         :param before_today: include days in current century before today
         :param after_today: include days in current century after today
-        :example Date('2012-04-04')
+        :example: Date('2012-04-04')
         :return: Date
         """
         today = date.today()
@@ -1855,7 +1855,7 @@ class Provider(BaseProvider):
 
         :param before_today: include days in current decade before today
         :param after_today: include days in current decade after today
-        :example Date('2012-04-04')
+        :example: Date('2012-04-04')
         :return: Date
         """
         today = date.today()
@@ -1877,7 +1877,7 @@ class Provider(BaseProvider):
 
         :param before_today: include days in current year before today
         :param after_today: include days in current year after today
-        :example Date('2012-04-04')
+        :example: Date('2012-04-04')
         :return: Date
         """
         today = date.today()
@@ -1900,7 +1900,7 @@ class Provider(BaseProvider):
         :param before_today: include days in current month before today
         :param after_today: include days in current month after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
-        :example DateTime('2012-04-04 11:02:02')
+        :example: DateTime('2012-04-04 11:02:02')
         :return: DateTime
         """
         today = date.today()
@@ -1975,7 +1975,7 @@ class Provider(BaseProvider):
 
     def century(self):
         """
-        :example 'XVII'
+        :example: 'XVII'
         """
         return self.random_element(self.centuries)
 
@@ -1989,7 +1989,7 @@ class Provider(BaseProvider):
         and return as a python object usable as a `tzinfo` to `datetime`
         or other fakers.
 
-        :example faker.pytimezone()
+        :example: faker.pytimezone()
         :return: dateutil.tz.tz.tzfile
         """
         return gettz(self.timezone(*args, **kwargs))
@@ -2004,7 +2004,7 @@ class Provider(BaseProvider):
         :param minimum_age Defaults to 0.
         :param maximum_age Defaults to 115.
 
-        :example Date('1979-02-02')
+        :example: Date('1979-02-02')
         :return: Date
         """
 

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1406,7 +1406,7 @@ class Provider(BaseProvider):
         Get a datetime object for a date between January 1, 1970 and now
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2005-08-16 20:39:21')
-        :return datetime
+        :return: datetime
         """
         # NOTE: On windows, the lowest value you can get from windows is 86400
         #       on the first day. Known python issue:
@@ -1419,7 +1419,7 @@ class Provider(BaseProvider):
         Get a datetime object for a date between January 1, 001 and now
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1265-03-22 21:15:52')
-        :return datetime
+        :return: datetime
         """
 
         # 1970-01-01 00:00:00 UTC minus 62135596800 seconds is
@@ -1571,7 +1571,7 @@ class Provider(BaseProvider):
         :param end_date Defaults to "now"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         start_date = self._parse_date_time(start_date, tzinfo=tzinfo)
         end_date = self._parse_date_time(end_date, tzinfo=tzinfo)
@@ -1594,7 +1594,7 @@ class Provider(BaseProvider):
         :param start_date Defaults to 30 years ago
         :param end_date Defaults to "today"
         :example Date('1999-02-02')
-        :return Date
+        :return: Date
         """
 
         start_date = self._parse_date(start_date)
@@ -1610,7 +1610,7 @@ class Provider(BaseProvider):
         :param end_date Defaults to "+30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         return self.date_time_between(
             start_date='+1s', end_date=end_date, tzinfo=tzinfo,
@@ -1625,7 +1625,7 @@ class Provider(BaseProvider):
         :param end_date Defaults to "+30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         return self.date_between(start_date='+1d', end_date=end_date)
 
@@ -1638,7 +1638,7 @@ class Provider(BaseProvider):
         :param start_date Defaults to "-30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         return self.date_time_between(
             start_date=start_date, end_date='-1s', tzinfo=tzinfo,
@@ -1653,7 +1653,7 @@ class Provider(BaseProvider):
         :param start_date Defaults to "-30d"
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         return self.date_between(start_date=start_date, end_date='-1d')
 
@@ -1671,7 +1671,7 @@ class Provider(BaseProvider):
         :param datetime_end: DateTime
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('1999-02-02 11:42:52')
-        :return DateTime
+        :return: DateTime
         """
         if datetime_start is None:
             datetime_start = datetime.now(tzinfo)
@@ -1703,7 +1703,7 @@ class Provider(BaseProvider):
 
         :param date_start: Date
         :param date_end: Date
-        :return Date
+        :return: Date
         """
         return self.date_time_between_dates(date_start, date_end).date()
 
@@ -1719,7 +1719,7 @@ class Provider(BaseProvider):
         :param after_now: include days in current century after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2012-04-04 11:02:02')
-        :return DateTime
+        :return: DateTime
         """
         now = datetime.now(tzinfo)
         this_century_start = datetime(
@@ -1749,7 +1749,7 @@ class Provider(BaseProvider):
         :param after_now: include days in current decade after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2012-04-04 11:02:02')
-        :return DateTime
+        :return: DateTime
         """
         now = datetime.now(tzinfo)
         this_decade_start = datetime(
@@ -1779,7 +1779,7 @@ class Provider(BaseProvider):
         :param after_now: include days in current year after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2012-04-04 11:02:02')
-        :return DateTime
+        :return: DateTime
         """
         now = datetime.now(tzinfo)
         this_year_start = now.replace(
@@ -1808,7 +1808,7 @@ class Provider(BaseProvider):
         :param after_now: include days in current month after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2012-04-04 11:02:02')
-        :return DateTime
+        :return: DateTime
         """
         now = datetime.now(tzinfo)
         this_month_start = now.replace(
@@ -1833,7 +1833,7 @@ class Provider(BaseProvider):
         :param before_today: include days in current century before today
         :param after_today: include days in current century after today
         :example Date('2012-04-04')
-        :return Date
+        :return: Date
         """
         today = date.today()
         this_century_start = date(today.year - (today.year % 100), 1, 1)
@@ -1856,7 +1856,7 @@ class Provider(BaseProvider):
         :param before_today: include days in current decade before today
         :param after_today: include days in current decade after today
         :example Date('2012-04-04')
-        :return Date
+        :return: Date
         """
         today = date.today()
         this_decade_start = date(today.year - (today.year % 10), 1, 1)
@@ -1878,7 +1878,7 @@ class Provider(BaseProvider):
         :param before_today: include days in current year before today
         :param after_today: include days in current year after today
         :example Date('2012-04-04')
-        :return Date
+        :return: Date
         """
         today = date.today()
         this_year_start = today.replace(month=1, day=1)
@@ -1901,7 +1901,7 @@ class Provider(BaseProvider):
         :param after_today: include days in current month after today
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example DateTime('2012-04-04 11:02:02')
-        :return DateTime
+        :return: DateTime
         """
         today = date.today()
         this_month_start = today.replace(day=1)
@@ -1990,7 +1990,7 @@ class Provider(BaseProvider):
         or other fakers.
 
         :example faker.pytimezone()
-        :return dateutil.tz.tz.tzfile
+        :return: dateutil.tz.tz.tzfile
         """
         return gettz(self.timezone(*args, **kwargs))
 
@@ -2005,7 +2005,7 @@ class Provider(BaseProvider):
         :param maximum_age Defaults to 115.
 
         :example Date('1979-02-02')
-        :return Date
+        :return: Date
         """
 
         if not isinstance(minimum_age, int):

--- a/faker/providers/geo/pt_PT/__init__.py
+++ b/faker/providers/geo/pt_PT/__init__.py
@@ -22,6 +22,6 @@ class Provider(GeoProvider):
 
     def nationality(self):
         """
-        :example 'Portuguesa'
+        :example: 'Portuguesa'
         """
         return self.random_element(self.nationalities)

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -262,8 +262,8 @@ class Provider(BaseProvider):
     def url(self, schemes=None):
         """
         :param schemes: a list of strings to use as schemes, one will chosen randomly.
-        If None, it will generate http and https urls.
-        Passing an empty list will result in schemeless url generation like "://domain.com".
+            If None, it will generate http and https urls.
+            Passing an empty list will result in schemeless url generation like "://domain.com".
 
         :returns: a random url string.
         """

--- a/faker/providers/lorem/pl_PL/__init__.py
+++ b/faker/providers/lorem/pl_PL/__init__.py
@@ -6,7 +6,9 @@ class Provider(LoremProvider):
 
     Sources:
 
-    - https://pl.wiktionary.org/wiki/Indeks:Polski_-_Najpopularniejsze_s%C5%82owa_1-2000
+    - `Indeks:Polski - Najpopularniejsze słowa 1-2000`__
+
+    __ https://pl.wiktionary.org/wiki/Indeks:Polski_-_Najpopularniejsze_s%C5%82owa_1-2000
     """
 
     word_list = (

--- a/faker/providers/person/__init__.py
+++ b/faker/providers/person/__init__.py
@@ -48,7 +48,7 @@ class Provider(BaseProvider):
 
     def name(self):
         """
-        :example 'John Doe'
+        :example: 'John Doe'
         """
         pattern = self.random_element(self.formats)
         return self.generator.parse(pattern)

--- a/faker/providers/phone_number/en_PH/__init__.py
+++ b/faker/providers/phone_number/en_PH/__init__.py
@@ -12,6 +12,7 @@ class Provider(BaseProvider):
     provider methods are there to enable the creation of more "realistic" fake data for such cases.
 
     Additional Notes:
+
     - The Philippine telecommunication industry is dominated by the Globe-PLDT duopoly. Globe offers landline services
       under the Globe brand and mobile services under the Globe and TM brands. PLDT offers landline services under the
       PLDT brand, and its subsidiaries offer mobile services under the Smart, TNT, and SUN brands. The rest of the
@@ -25,6 +26,7 @@ class Provider(BaseProvider):
       digit landline number.
 
     Sources:
+
     - https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Philippines
     - https://www.prefix.ph/prefixes/2019-updated-complete-list-of-philippine-mobile-network-prefixes/
     - https://powerpinoys.com/network-prefixes-philippines/

--- a/faker/providers/ssn/fr_CH/__init__.py
+++ b/faker/providers/ssn/fr_CH/__init__.py
@@ -7,7 +7,7 @@ class Provider(SsnProvider):
     def ssn(self):
         """
         Returns a 13 digits Swiss SSN named AHV (German) or
-                                            AVS (French and Italian)
+        AVS (French and Italian)
         See: http://www.bsv.admin.ch/themen/ahv/00011/02185/
         """
         def _checksum(digits):

--- a/faker/providers/ssn/tr_TR/__init__.py
+++ b/faker/providers/ssn/tr_TR/__init__.py
@@ -10,7 +10,7 @@ class Provider(BaseProvider):
 
     def ssn(self):
         """
-        :example '89340691651'
+        :example: '89340691651'
         """
         first_part = self.random_element((1, 2, 3, 4, 5, 6, 7, 8, 9))
         middle_part = self.bothify('#########')

--- a/setup.py
+++ b/setup.py
@@ -67,4 +67,10 @@ setup(
         "python-dateutil>=2.4",
         "text-unidecode==1.3",
     ],
+    extras_require={
+        "docs": [
+            "sphinx",
+            "sphinx-rtd-theme",
+        ],
+    },
 )


### PR DESCRIPTION
### What does this changes

This fixes any warnings emitted by Sphinx when the documentation site is built

### What was wrong

Lots of different things, mostly incorrect rST syntax. See the individual commits for details.
This resulted in 322 warnings as counted by Sphinx.

### How this fixes it

The invalid syntax has been corrected.

Note: This still leaves behind some messages about sample generation failing for a couple of methods plus a stream of "Numbers generated by this method are purely hypothetical." messages originating from https://github.com/joke2k/faker/blob/master/faker/providers/bank/en_PH/__init__.py