### PR TITLE
Add mdgen to community-providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ nosetests.xml
 *.iml
 *.ipr
 venv/
+.vscode

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -22,6 +22,9 @@ Here's a list of Providers written by the community:
 | Vehicle       | Fake vehicle information | `faker_vehicle`_                 |
 |               | includes Year Make Model |                                  |
 +---------------+--------------------------+----------------------------------+
+| Posts         | Fake posts in markdown   | `mdgen`_                         |
+|               | format                   |                                  |
++---------------+--------------------------+----------------------------------+
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -41,3 +44,4 @@ In order to be inlcuded, your provider must satisfy these requirement:
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/
+.. _mdgen: https://pypi.org/project/mdgen/


### PR DESCRIPTION
### What does this changes

I would like to add my community provider- `fake.post` to the docs.

### What was wrong

Initially this project was conceived since I needed to populate my django models with fake data. Faker doesn't provide any way to create markdown formatted fake data, and I decided to extend it.

This is in regards to #1299.

I am a bit unsure where to make my PR to. Do I make it to the `master` branch?