### PR TITLE
Add more samples to automotive es_ES test to prevent random coverage decrease

### DIFF
--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -157,9 +157,15 @@ class TestEsEs:
             assert plate[:2] == "CA"
 
     def test_plate_format(self, faker):
+        faker.seed_instance(5600)
+
         plate = faker.license_plate()
         assert isinstance(plate, str)
-        assert self.new_format_pattern.match(plate) or self.old_format_pattern.match(plate)
+        assert self.new_format_pattern.match(plate)
+
+        plate = faker.license_plate()
+        assert isinstance(plate, str)
+        assert self.old_format_pattern.match(plate)
 
 
 class TestTrTr(_SimpleAutomotiveTestMixin):

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -156,16 +156,11 @@ class TestEsEs:
             assert self.old_format_pattern.match(plate)
             assert plate[:2] == "CA"
 
-    def test_plate_format(self, faker):
-        faker.seed_instance(5600)
-
-        plate = faker.license_plate()
-        assert isinstance(plate, str)
-        assert self.new_format_pattern.match(plate)
-
-        plate = faker.license_plate()
-        assert isinstance(plate, str)
-        assert self.old_format_pattern.match(plate)
+    def test_plate_format(self, faker, num_samples):
+        for _ in range(num_samples):
+            plate = faker.license_plate()
+            assert isinstance(plate, str)
+            assert self.new_format_pattern.match(plate) or self.old_format_pattern.match(plate)
 
 
 class TestTrTr(_SimpleAutomotiveTestMixin):


### PR DESCRIPTION
### What does this changes

Seeds an automotive `es_ES` provider test to prevent a random coverage decrease.

### What was wrong

The method `license_plate` of `es_ES` automotive provider selects randomly between old and new Spanish license plates formats, and this is causing a random coverage decrease because one of the strategies are not been processed, like in [this job](https://coveralls.io/jobs/68951268/source_files/2836171701#L123).

### How this fixes it

Seeds the faker instance in test and checks each format separately. 
