### PR TITLE
Fix generation of names ending with spaces (and more)

### DIFF
--- a/faker/providers/address/hy_AM/__init__.py
+++ b/faker/providers/address/hy_AM/__init__.py
@@ -3,6 +3,7 @@ from .. import Provider as AddressProvider
 
 class Provider(AddressProvider):
 
+    city_formats = ('{{first_name}}',)
     city_prefixes = ('ք.',)
     city_suffixes = ('',)
     street_prefixes = ('փողոց', 'պողոտա')

--- a/faker/providers/company/pt_PT/__init__.py
+++ b/faker/providers/company/pt_PT/__init__.py
@@ -9,9 +9,6 @@ class Provider(CompanyProvider):
         '{{last_name}}',
     )
 
-    catch_phrase_formats = (
-        '{{catch_phrase_noun}} {{catch_phrase_verb}} {{catch_phrase_attribute}}', )
-
     nouns = (
         'a segurança', 'o prazer', 'o conforto', 'a simplicidade', 'a certeza',
         'a arte', 'o poder', 'o direito', 'a possibilidade', 'a vantagem',

--- a/faker/providers/person/de_AT/__init__.py
+++ b/faker/providers/person/de_AT/__init__.py
@@ -10,8 +10,6 @@ class Provider(PersonProvider):
         '{{first_name_male}} {{last_name}}',
         '{{first_name_male}} {{last_name}}-{{last_name}}',
         '{{prefix_male}} {{first_name_male}} {{last_name}}',
-        '{{first_name_male}} {{last_name}} {{suffix_male}}',
-        '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix_male}}',
     )
 
     formats_female = (
@@ -21,8 +19,6 @@ class Provider(PersonProvider):
         '{{first_name_female}} {{last_name}}',
         '{{first_name_female}} {{last_name}}-{{last_name}}',
         '{{prefix_female}} {{first_name_female}} {{last_name}}',
-        '{{first_name_female}} {{last_name}} {{suffix_female}}',
-        '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix_female}}',
     )
 
     formats = formats_male + formats_female

--- a/faker/providers/person/fa_IR/__init__.py
+++ b/faker/providers/person/fa_IR/__init__.py
@@ -9,8 +9,6 @@ class Provider(PersonProvider):
         '{{first_name_female}} {{last_name}}',
         '{{first_name_female}} {{last_name}}',
         '{{prefix_female}} {{first_name_female}} {{last_name}}',
-        '{{first_name_female}} {{last_name}} {{suffix}}',
-        '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix}}',
     )
 
     formats_male = (
@@ -20,8 +18,6 @@ class Provider(PersonProvider):
         '{{first_name_male}} {{last_name}}',
         '{{first_name_male}} {{last_name}}',
         '{{prefix_male}} {{first_name_male}} {{last_name}}',
-        '{{first_name_male}} {{last_name}} {{suffix}}',
-        '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix}}',
     )
 
     formats = formats_female + formats_male

--- a/faker/providers/person/it_IT/__init__.py
+++ b/faker/providers/person/it_IT/__init__.py
@@ -10,8 +10,6 @@ class Provider(PersonProvider):
         '{{first_name_male}} {{last_name}}',
         '{{first_name_male}} {{last_name}}-{{last_name}}',
         '{{prefix_male}} {{first_name_male}} {{last_name}}',
-        '{{first_name_male}} {{last_name}} {{suffix_male}}',
-        '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix_male}}',
     )
 
     formats_female = (
@@ -21,8 +19,6 @@ class Provider(PersonProvider):
         '{{first_name_female}} {{last_name}}',
         '{{first_name_female}} {{last_name}}-{{last_name}}',
         '{{prefix_female}} {{first_name_female}} {{last_name}}',
-        '{{first_name_female}} {{last_name}} {{suffix_female}}',
-        '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix_female}}',
     )
 
     formats = formats_male + formats_female

--- a/tests/test_providers_formats.py
+++ b/tests/test_providers_formats.py
@@ -1,0 +1,65 @@
+import re
+
+import pytest
+
+from faker import Factory
+from faker.config import AVAILABLE_LOCALES, PROVIDERS
+
+locales = AVAILABLE_LOCALES
+
+# searches {{group}} and capture the _group_
+find_group = re.compile(r"\{\{(\w+)\}\}")
+
+
+@pytest.mark.parametrize("locale", locales)
+def test_no_invalid_formats(locale):
+    """
+    For each locale, for each provider, search all the definitions of "formats"
+    and make sure that all the providers in there (e.g. {{group}}) are valid
+    and do not emit empty strings. Empty strings are allows only if the group
+    is not surrounded by spaces. This is a quick way to make sure that no
+    string is generated with "double spaces", starting spaces or ending spaces.
+    """
+    faker = Factory.create(locale)
+    errors = []
+
+    for provider in PROVIDERS:
+        if provider == "faker.providers":
+            continue
+        prov_cls, lang = Factory._get_provider_class(provider, locale)
+        assert lang == locale
+
+        attributes = set(dir(prov_cls))
+
+        for attribute in attributes:
+            # consider only the format attributes
+            if not attribute.endswith("formats"):
+                continue
+            formats = getattr(prov_cls, attribute)
+            # may be a function or some other bizarre types
+            if not isinstance(formats, (list, tuple)):
+                continue
+            for format in formats:
+                # search all the {{groups}} in the format
+                for match in find_group.finditer(format):
+                    group = match.group(1)
+                    try:
+                        attr = faker.format(group)
+                    except AttributeError as e:
+                        errors.append(str(e))
+                        continue
+                    # touching = True if the group is touching sometime on at
+                    # least one side, i.e. it's not surrounded by spaces
+                    touching = False
+                    if match.start() != 0 and format[match.start() - 1] != " ":
+                        touching = True
+                    if match.end() != len(format) and format[match.end()] != " ":
+                        touching = True
+
+                    if not attr and not touching:
+                        errors.append(
+                            "Attribute {{%s}} provided an invalid value in format '%s' from %s.%s.%s"
+                            % (group, format, provider, locale, attribute),
+                        )
+    # group errors reporting all the ones from the same locale
+    assert not errors, "Errors:\n - " + "\n - ".join(errors)

--- a/tests/test_providers_formats.py
+++ b/tests/test_providers_formats.py
@@ -16,7 +16,7 @@ def test_no_invalid_formats(locale):
     """
     For each locale, for each provider, search all the definitions of "formats"
     and make sure that all the providers in there (e.g. {{group}}) are valid
-    and do not emit empty strings. Empty strings are allows only if the group
+    and do not emit empty strings. Empty strings are allowed only if the group
     is not surrounded by spaces. This is a quick way to make sure that no
     string is generated with "double spaces", starting spaces or ending spaces.
     """


### PR DESCRIPTION
### What does this changes

Add a test that checks in all the formats defined in the providers if there are invalid fields. A field is invalid if it gets formatted into an empty string (i.e. the field is not applicable) and the field is surrounded by spaces.

In this configuration the generated string may be malformed (double spaces, starting with a space or ending with a space).

Then, this PR fixes the found issues.


### What was wrong

For example in this provider, in one of the formats it is used `{{suffix_male}}`, but the provider didn't define it (it gets defaulted to an empty string). Therefore, when that format is selected the generated name will end with a space.

https://github.com/joke2k/faker/blob/299f6b6bbc18fc576642069ccfbf279160b7be54/faker/providers/person/it_IT/__init__.py#L13-L14

Moreover, I've removed `catch_phrase_formats` that seems to be unused.

https://github.com/joke2k/faker/blob/299f6b6bbc18fc576642069ccfbf279160b7be54/faker/providers/company/pt_PT/__init__.py#L12-L13

<details>
    <summary>Test output</summary>

```
test_no_invalid_formats[de_AT]
E       AssertionError: Errors:
E          - Attribute {{suffix_male}} provided an invalid value in format '{{first_name_male}} {{last_name}} {{suffix_male}}' from faker.providers.person.de_AT.formats
E          - Attribute {{suffix_male}} provided an invalid value in format '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix_male}}' from faker.providers.person.de_AT.formats
E          - Attribute {{suffix_female}} provided an invalid value in format '{{first_name_female}} {{last_name}} {{suffix_female}}' from faker.providers.person.de_AT.formats
E          - Attribute {{suffix_female}} provided an invalid value in format '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix_female}}' from faker.providers.person.de_AT.formats

test_no_invalid_formats[fa_IR]
E       AssertionError: Errors:
E          - Attribute {{suffix}} provided an invalid value in format '{{first_name_female}} {{last_name}} {{suffix}}' from faker.providers.person.fa_IR.formats
E          - Attribute {{suffix}} provided an invalid value in format '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix}}' from faker.providers.person.fa_IR.formats
E          - Attribute {{suffix}} provided an invalid value in format '{{first_name_male}} {{last_name}} {{suffix}}' from faker.providers.person.fa_IR.formats
E          - Attribute {{suffix}} provided an invalid value in format '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix}}' from faker.providers.person.fa_IR.formats

test_no_invalid_formats[hy_AM]
E       AssertionError: Errors:
E          - Attribute {{city_suffix}} provided an invalid value in format '{{first_name}} {{city_suffix}}' from faker.providers.address.hy_AM.city_formats

test_no_invalid_formats[it_IT]
E       AssertionError: Errors:
E          - Attribute {{suffix_male}} provided an invalid value in format '{{first_name_male}} {{last_name}} {{suffix_male}}' from faker.providers.person.it_IT.formats
E          - Attribute {{suffix_male}} provided an invalid value in format '{{prefix_male}} {{first_name_male}} {{last_name}} {{suffix_male}}' from faker.providers.person.it_IT.formats
E          - Attribute {{suffix_female}} provided an invalid value in format '{{first_name_female}} {{last_name}} {{suffix_female}}' from faker.providers.person.it_IT.formats
E          - Attribute {{suffix_female}} provided an invalid value in format '{{prefix_female}} {{first_name_female}} {{last_name}} {{suffix_female}}' from faker.providers.person.it_IT.formats

test_no_invalid_formats[pt_PT]
E       AssertionError: Errors:
E          - Unknown formatter "catch_phrase_noun" with locale "pt_PT"
E          - Unknown formatter "catch_phrase_verb" with locale "pt_PT"
E          - Unknown formatter "catch_phrase_attribute" with locale "pt_PT"
```

</details>

### How this fixes it

The first commit adds a test to make sure that this won't happen in the future. The second commit fixes the currently present problems.

Fixes #1311