### PR TITLE
[Japanese/PersonProvider] add name pairs to get matched representation

### DIFF
--- a/faker/providers/person/ja_JP/__init__.py
+++ b/faker/providers/person/ja_JP/__init__.py
@@ -1,225 +1,243 @@
 from collections import OrderedDict
+from operator import itemgetter
 
 from .. import Provider as PersonProvider
 
 
 class Provider(PersonProvider):
-    formats_female = (
-        '{{last_name}} {{first_name_female}}',
+    # link: http://dic.nicovideo.jp/a/日本人の名前一覧
+    # link: http://www.meijiyasuda.co.jp/enjoy/ranking/
+    first_name_female_pairs = (
+        ('明美', 'アケミ', 'Akemi'),
+        ('あすか', 'アスカ', 'Asuka'),
+        ('香織', 'カオリ', 'Kaori'),
+        ('加奈', 'カナ', 'Kana'),
+        ('くみ子', 'クミコ', 'Kumiko'),
+        ('さゆり', 'サユリ', 'Sayuri'),
+        ('知実', 'サトミ', 'Satomi'),
+        ('千代', 'チヨ', 'Chiyo'),
+        ('直子', 'ナオコ', 'Naoko'),
+        ('七夏', 'ナナカ', 'Nanaka'),
+        ('花子', 'ハナコ', 'Hanako'),
+        ('春香', 'ハルカ', 'Haruka'),
+        ('真綾', 'マアヤ', 'Maaya'),
+        ('舞', 'マイ', 'Mai'),
+        ('美加子', 'ミカコ', 'Mikako'),
+        ('幹', 'ミキ', 'Miki'),
+        ('桃子', 'モモコ', 'Momoko'),
+        ('結衣', 'ユイ', 'Yui'),
+        ('裕美子', 'ユミコ', 'Yumiko'),
+        ('陽子', 'ヨウコ', 'Yoko'),
+        ('里佳', 'リカ', 'Rika'),
     )
+
+    # for backwards compatibility
+    first_names_female = tuple(map(itemgetter(0), first_name_female_pairs))
+    first_kana_names_female = tuple(map(itemgetter(1), first_name_female_pairs))
+    first_romanized_names_female = tuple(map(itemgetter(2), first_name_female_pairs))
+
+    first_name_male_pairs = (
+        ('晃', 'アキラ', 'Akira'),
+        ('篤司', 'アツシ', 'Atsushi'),
+        ('治', 'オサム', 'Osamu'),
+        ('和也', 'カズヤ', 'Kazuya'),
+        ('京助', 'キョウスケ', 'Kyosuke'),
+        ('健一', 'ケンイチ', 'Kenichi'),
+        ('修平', 'シュウヘイ', 'Shohei'),
+        ('翔太', 'ショウタ', 'Shota'),
+        ('淳', 'ジュン', 'Jun'),
+        ('聡太郎', 'ソウタロウ', 'Sotaro'),
+        ('太一', 'タイチ', 'Taichi'),
+        ('太郎', 'タロウ', 'Taro'),
+        ('拓真', 'タクマ', 'Takuma'),
+        ('翼', 'ツバサ', 'Tsubasa'),
+        ('智也', 'トモヤ', 'Tomoya'),
+        ('直樹', 'ナオキ', 'Naoki'),
+        ('直人', 'ナオト', 'Naoto'),
+        ('英樹', 'ヒデキ', 'Hideki'),
+        ('浩', 'ヒロシ', 'Hiroshi'),
+        ('学', 'マナブ', 'Manabu'),
+        ('充', 'ミツル', 'Mituru'),
+        ('稔', 'ミノル', 'Minoru'),
+        ('裕樹', 'ユウキ', 'Yuki'),
+        ('裕太', 'ユウタ', 'Yuta'),
+        ('康弘', 'ヤスヒロ', 'Yasuhiro'),
+        ('陽一', 'ヨウイチ', 'Yoichi'),
+        ('洋介', 'ヨウスケ', 'Yosuke'),
+        ('亮介', 'リョウスケ', 'Ryosuke'),
+        ('涼平', 'リョウヘイ', 'Ryohei'),
+        ('零', 'レイ', 'Rei'),
+    )
+
+    # for backwards compatibility
+    first_names_male = tuple(map(itemgetter(0), first_name_male_pairs))
+    first_kana_names_male = tuple(map(itemgetter(1), first_name_male_pairs))
+    first_romanized_names_male = tuple(map(itemgetter(2), first_name_male_pairs))
+
+    # for backwards compatibility
+    first_names = first_names_male + first_names_female
+    first_kana_names = first_kana_names_male + first_kana_names_female
+    first_romanized_names = first_romanized_names_male \
+        + first_romanized_names_female
+
+    first_name_pairs = first_name_male_pairs + first_name_female_pairs
+
+    last_name_pairs = OrderedDict((
+        (("佐藤", "サトウ", "Sato"), 366803),
+        (("鈴木", "スズキ", "Suzuki"), 321135),
+        (("高橋", "タカハシ", "Takahashi"), 266782),
+        (("田中", "タナカ", "Tanaka"), 245821),
+        (("伊藤", "イトウ", "Ito"), 203357),
+        (("渡辺", "ワタナベ", "Watanabe"), 200504),
+        (("山本", "ヤマモト", "Yamamoto"), 200134),
+        (("中村", "ナカムラ", "Nakamura"), 195219),
+        (("小林", "コバヤシ", "Kobayashi"), 191819),
+        (("加藤", "カトウ", "Kato"), 160283),
+        (("吉田", "ヨシダ", "Yoshida"), 154461),
+        (("山田", "ヤマダ", "Yamada"), 151675),
+        (("佐々木", "ササキ", "Sasaki"), 135927),
+        (("山口", "ヤマグチ", "Yamaguchi"), 119501),
+        (("松本", "マツモト", "Matsumoto"), 116490),
+        (("井上", "イノウエ", "Inoue"), 111287),
+        (("木村", "キムラ", "Kimura"), 107446),
+        (("林", "ハヤシ", "Hayashi"), 101826),
+        (("斎藤", "サイトウ", "Saito"), 101774),
+        (("清水", "シミズ", "Shimizu"), 97826),
+        (("山崎", "ヤマザキ", "Yamazaki"), 90781),
+        (("阿部", "アベ", "Abe"), 86833),
+        (("森", "モリ", "Mori"), 86507),
+        (("池田", "イケダ", "Ikeda"), 84860),
+        (("橋本", "ハシモト", "Hashimoto"), 82836),
+        (("山下", "ヤマシタ", "Yamashita"), 80588),
+        (("石川", "イシカワ", "Ishikawa"), 77471),
+        (("中島", "ナカジマ", "Nakajima"), 74106),
+        (("前田", "マエダ", "Maeda"), 72930),
+        (("藤田", "フジタ", "Fujita"), 72375),
+        (("後藤", "ゴトウ", "Goto"), 71629),
+        (("小川", "オガワ", "Ogawa"), 71179),
+        (("岡田", "オカダ", "Okada"), 70347),
+        (("長谷川", "ハセガワ", "Hasegawa"), 69201),
+        (("村上", "ムラカミ", "Murakami"), 68606),
+        (("近藤", "コンドウ", "Kondo"), 68297),
+        (("石井", "イシイ", "Ishii"), 67079),
+        (("遠藤", "エンドウ", "Endo"), 62620),
+        (("斉藤", "サイトウ", "Saito"), 62540),
+        (("坂本", "サカモト", "Sakamoto"), 62308),
+        (("青木", "アオキ", "Aoki"), 59516),
+        (("藤井", "フジイ", "Fujii"), 59204),
+        (("西村", "ニシムラ", "Nishimura"), 58821),
+        (("福田", "フクダ", "Fukuda"), 58714),
+        (("太田", "オオタ", "Ota"), 58439),
+        (("三浦", "ミウラ", "Miura"), 58006),
+        (("藤原", "フジワラ", "Fujiwara"), 57742),
+        (("松田", "マツダ", "Matsuda"), 55883),
+        (("岡本", "オカモト", "Okamoto"), 55539),
+        (("中川", "ナカガワ", "Nakagawa"), 55221),
+    ))
+
+    # for backwards compatibility only. use the pairs instead
+    last_names = tuple(map(itemgetter(0), last_name_pairs))
+    last_kana_names = tuple(map(itemgetter(1), last_name_pairs))
+    last_romanized_names = tuple(map(itemgetter(2), last_name_pairs))
 
     formats_male = (
         '{{last_name}} {{first_name_male}}',
     )
 
+    formats_female = (
+        '{{last_name}} {{first_name_female}}',
+    )
+
     formats = formats_male + formats_female
 
-    # link: http://dic.nicovideo.jp/a/日本人の名前一覧
-    # link: http://www.meijiyasuda.co.jp/enjoy/ranking/
-    first_names_female = (
-        '明美', 'あすか', '香織', '加奈', 'くみ子', 'さゆり', '知実', '千代',
-        '直子', '七夏', '花子', '春香', '真綾', '舞', '美加子', '幹',
-        '桃子', '結衣', '裕美子', '陽子', '里佳',
-    )
-
-    # link: http://dic.nicovideo.jp/a/日本人の名前一覧
-    # link: http://www.meijiyasuda.co.jp/enjoy/ranking/
-    first_names_male = (
-        '晃', '篤司', '治', '和也', '京助', '健一', '修平', '翔太',
-        '淳', '聡太郎', '太一', '太郎', '拓真', '翼', '智也', '直樹',
-        '直人', '英樹', '浩', '学', '充', '稔', '裕樹', '裕太',
-        '康弘', '陽一', '洋介', '亮介', '涼平', '零',
-    )
-
-    first_names = first_names_male + first_names_female
-
-    # based on: https://www2.nipponsoft.co.jp/bldoko/index.asp
-    last_names = OrderedDict((
-        ("佐藤", 366803),
-        ("鈴木", 321135),
-        ("高橋", 266782),
-        ("田中", 245821),
-        ("伊藤", 203357),
-        ("渡辺", 200504),
-        ("山本", 200134),
-        ("中村", 195219),
-        ("小林", 191819),
-        ("加藤", 160283),
-        ("吉田", 154461),
-        ("山田", 151675),
-        ("佐々木", 135927),
-        ("山口", 119501),
-        ("松本", 116490),
-        ("井上", 111287),
-        ("木村", 107446),
-        ("林", 101826),
-        ("斎藤", 101774),
-        ("清水", 97826),
-        ("山崎", 90781),
-        ("阿部", 86833),
-        ("森", 86507),
-        ("池田", 84860),
-        ("橋本", 82836),
-        ("山下", 80588),
-        ("石川", 77471),
-        ("中島", 74106),
-        ("前田", 72930),
-        ("藤田", 72375),
-        ("後藤", 71629),
-        ("小川", 71179),
-        ("岡田", 70347),
-        ("長谷川", 69201),
-        ("村上", 68606),
-        ("近藤", 68297),
-        ("石井", 67079),
-        ("遠藤", 62620),
-        ("斉藤", 62540),
-        ("坂本", 62308),
-        ("青木", 59516),
-        ("藤井", 59204),
-        ("西村", 58821),
-        ("福田", 58714),
-        ("太田", 58439),
-        ("三浦", 58006),
-        ("藤原", 57742),
-        ("松田", 55883),
-        ("岡本", 55539),
-        ("中川", 55221),
-    ))
-
-    kana_formats = (
-        '{{last_kana_name}} {{first_kana_name_female}}',
+    kana_formats_male = (
         '{{last_kana_name}} {{first_kana_name_male}}',
     )
 
-    first_kana_names_female = (
-        'アケミ', 'アスカ', 'カオリ', 'カナ',
-        'クミコ', 'サユリ', 'サトミ', 'チヨ',
-        'ナオコ', 'ナナミ', 'ハナコ', 'ハルカ',
-        'マアヤ', 'マイ', 'ミカコ', 'ミキ',
-        'モモコ', 'ユイ', 'ユミコ', 'ヨウコ',
-        'リカ',
+    kana_formats_female = (
+        '{{last_kana_name}} {{first_kana_name_female}}',
     )
 
-    first_kana_names_male = (
-        'アキラ', 'アツシ', 'オサム', 'カズヤ',
-        'キョウスケ', 'ケンイチ', 'シュウヘイ', 'ショウタ',
-        'ジュン', 'ソウタロウ', 'タイチ', 'タロウ',
-        'タクマ', 'ツバサ', 'トモヤ', 'ナオキ',
-        'ナオト', 'ヒデキ', 'ヒロシ', 'マナブ',
-        'ミツル', 'ミノル', 'ユウキ', 'ユウタ',
-        'ヤスヒロ', 'ヨウイチ', 'ヨウスケ', 'リョウスケ',
-        'リョウヘイ', 'レイ',
-    )
+    kana_formats = kana_formats_male + kana_formats_female
 
-    first_kana_names = first_kana_names_male + first_kana_names_female
-
-    last_kana_names = (
-        'アオタ', 'アオヤマ', 'イシダ', 'イダカ',
-        'イトウ', 'イノウエ', 'ウノ', 'エコダ',
-        'オオガキ', 'カトウ', 'カノウ', 'キジマ',
-        'キムラ', 'キリヤマ', 'クドウ', 'コイズミ',
-        'コバヤシ', 'コンドウ', 'サイトウ', 'サカモト',
-        'ササキ', 'サトウ', 'ササダ', 'スズキ',
-        'スギヤマ', 'タカハシ', 'タナカ', 'タナベ',
-        'ツダ', 'ナカジマ', 'ナカムラ', 'ナギサ',
-        'ナカツガワ', 'ニシノソノ', 'ノムラ', 'ハラダ',
-        'ハマダ', 'ヒロカワ', 'フジモト', 'マツモト',
-        'ミヤケ', 'ミヤザワ', 'ムラヤマ', 'ヤマギシ',
-        'ヤマグチ', 'ヤマダ', 'ヤマモト', 'ヨシダ',
-        'ヨシモト', 'ワカマツ', 'ワタナベ',
-    )
-
-    romanized_formats = (
-        '{{first_romanized_name_female}} {{last_romanized_name}}',
+    romanized_formats_male = (
         '{{first_romanized_name_male}} {{last_romanized_name}}',
     )
 
-    first_romanized_names_female = (
-        'Akemi', 'Asuka', 'Kaori', 'Kana',
-        'Kumiko', 'Sayuri', 'Satomi', 'Chiyo',
-        'Naoko', 'Nanami', 'Hanako', 'Haruka',
-        'Maaya', 'Mai', 'Mikako', 'Miki',
-        'Momoko', 'Yui', 'Yumiko', 'Yoko',
-        'Rika',
+    romanized_formats_female = (
+        '{{first_romanized_name_female}} {{last_romanized_name}}',
     )
 
-    first_romanized_names_male = (
-        'Akira', 'Atsushi', 'Osamu', 'Kazuya',
-        'Kyosuke', 'Kenichi', 'Shohei', 'Shota',
-        'Jun', 'Sotaro', 'Taichi', 'Taro',
-        'Takuma', 'Tsubasa', 'Tomoya', 'Naoki',
-        'Naoto', 'Hideki', 'Hiroshi', 'Manabu',
-        'Mituru', 'Minoru', 'Yuki', 'Yuta',
-        'Yasuhiro', 'Yoichi', 'Yosuke', 'Ryosuke',
-        'Ryohei', 'Rei',
-    )
+    romanized_formats = romanized_formats_male + romanized_formats_female
 
-    first_romanized_names = first_romanized_names_male \
-        + first_romanized_names_female
+    def first_name_pair(self):
+        return self.random_element(self.first_name_pairs)
 
-    last_romanized_names = (
-        'Aota', 'Aoyama', 'Ishida', 'Idaka',
-        'Ito', 'Inoue', 'Uno', 'Ekoda',
-        'Ogaki', 'Kato', 'Kano', 'Kijima',
-        'Kimura', 'Kiriyama', 'Kudo', 'Koizumi',
-        'Kobayashi', 'Kondo', 'Saito', 'Sakamoto',
-        'Sasaki', 'Sato', 'Sasada', 'Suzuki',
-        'Sugiyama', 'Takahashi', 'Tanaka', 'Tanabe',
-        'Tsuda', 'Nakajima', 'Nakamura', 'Nagisa',
-        'Nakatsugawa', 'Nishinosono', 'Nomura', 'Harada',
-        'Hamada', 'Hirokawa', 'Fujimoto', 'Matsumoto',
-        'Miyake', 'Miyagawa', 'Murayama', 'Yamagishi',
-        'Yamaguchi', 'Yamada', 'Yamamoto', 'Yoshida',
-        'Yoshimoto', 'Wakamatsu', 'Watanabe',
-    )
+    def first_name_male_pair(self):
+        return self.random_element(self.first_name_male_pairs)
+
+    def first_name_female_pair(self):
+        return self.random_element(self.first_name_female_pairs)
+
+    def last_name_pair(self):
+        return self.random_element(self.last_name_pairs)
+
+    def first_name(self):
+        return self.first_name_pair()[0]
+
+    def first_name_male(self):
+        return self.first_name_male_pair()[0]
+
+    def first_name_female(self):
+        return self.first_name_female_pair()[0]
+
+    def last_name(self):
+        return self.last_name_pair()[0]
+
+    def first_kana_name(self):
+        return self.first_name_pair()[1]
+
+    def first_kana_name_male(self):
+        return self.first_name_male_pair()[1]
+
+    def first_kana_name_female(self):
+        return self.first_name_female_pair()[1]
+
+    def last_kana_name(self):
+        return self.last_name_pair()[1]
+
+    def first_romanized_name(self):
+        return self.first_name_pair()[2]
+
+    def first_romanized_name_male(self):
+        return self.first_name_male_pair()[2]
+
+    def first_romanized_name_female(self):
+        return self.first_name_female_pair()[2]
+
+    def last_romanized_name(self):
+        return self.last_name_pair()[2]
 
     def kana_name(self):
-        '''
-        @example 'アオタ アキラ'
-        '''
         pattern = self.random_element(self.kana_formats)
         return self.generator.parse(pattern)
 
-    def first_kana_name(self):
-        '''
-        @example 'アキラ'
-        '''
-        return self.random_element(self.first_kana_names)
+    def kana_name_male(self):
+        pattern = self.random_element(self.kana_formats_male)
+        return self.generator.parse(pattern)
 
-    def first_kana_name_female(self):
-        return self.random_element(self.first_kana_names_female)
-
-    def first_kana_name_male(self):
-        return self.random_element(self.first_kana_names_male)
-
-    def last_kana_name(self):
-        '''
-        @example 'アオタ'
-        '''
-        return self.random_element(self.last_kana_names)
+    def kana_name_female(self):
+        pattern = self.random_element(self.kana_formats_female)
+        return self.generator.parse(pattern)
 
     def romanized_name(self):
-        '''
-        @example 'Akira Aota'
-        '''
         pattern = self.random_element(self.romanized_formats)
         return self.generator.parse(pattern)
 
-    def first_romanized_name(self):
-        '''
-        @example 'Akira'
-        '''
-        return self.random_element(self.first_romanized_names)
+    def romanized_name_male(self):
+        pattern = self.random_element(self.romanized_formats_male)
+        return self.generator.parse(pattern)
 
-    def first_romanized_name_female(self):
-        return self.random_element(self.first_romanized_names_female)
-
-    def first_romanized_name_male(self):
-        return self.random_element(self.first_romanized_names_male)
-
-    def last_romanized_name(self):
-        '''
-        @example 'Aota'
-        '''
-        return self.random_element(self.last_romanized_names)
+    def romanized_name_female(self):
+        pattern = self.random_element(self.romanized_formats_female)
+        return self.generator.parse(pattern)

--- a/faker/providers/person/ja_JP/__init__.py
+++ b/faker/providers/person/ja_JP/__init__.py
@@ -17,7 +17,7 @@ class Provider(PersonProvider):
         ('知実', 'サトミ', 'Satomi'),
         ('千代', 'チヨ', 'Chiyo'),
         ('直子', 'ナオコ', 'Naoko'),
-        ('七夏', 'ナナカ', 'Nanaka'),
+        ('七夏', 'ナナミ', 'Nanami'),
         ('花子', 'ハナコ', 'Hanako'),
         ('春香', 'ハルカ', 'Haruka'),
         ('真綾', 'マアヤ', 'Maaya'),

--- a/faker/providers/person/ja_JP/__init__.py
+++ b/faker/providers/person/ja_JP/__init__.py
@@ -171,73 +171,139 @@ class Provider(PersonProvider):
     romanized_formats = romanized_formats_male + romanized_formats_female
 
     def first_name_pair(self):
+        """
+        @example ('明美', 'アケミ', 'Akemi')
+        """
         return self.random_element(self.first_name_pairs)
 
     def first_name_male_pair(self):
+        """
+        @example ('晃', 'アキラ', 'Akira')
+        """
         return self.random_element(self.first_name_male_pairs)
 
     def first_name_female_pair(self):
+        """
+        @example ('明美', 'アケミ', 'Akemi')
+        """
         return self.random_element(self.first_name_female_pairs)
 
     def last_name_pair(self):
+        """
+        @example ('佐藤', 'サトウ', 'Sato')
+        """
         return self.random_element(self.last_name_pairs)
 
     def first_name(self):
+        """
+        @example '明美'
+        """
         return self.first_name_pair()[0]
 
     def first_name_male(self):
+        """
+        @example '晃'
+        """
         return self.first_name_male_pair()[0]
 
     def first_name_female(self):
+        """
+        @example '明美'
+        """
         return self.first_name_female_pair()[0]
 
     def last_name(self):
+        """
+        @example '佐藤'
+        """
         return self.last_name_pair()[0]
 
     def first_kana_name(self):
+        """
+        @example 'アケミ'
+        """
         return self.first_name_pair()[1]
 
     def first_kana_name_male(self):
+        """
+        @example 'アキラ'
+        """
         return self.first_name_male_pair()[1]
 
     def first_kana_name_female(self):
+        """
+        @example 'アケミ'
+        """
         return self.first_name_female_pair()[1]
 
     def last_kana_name(self):
+        """
+        @example 'サトウ'
+        """
         return self.last_name_pair()[1]
 
     def first_romanized_name(self):
+        """
+        @example 'Akemi'
+        """
         return self.first_name_pair()[2]
 
     def first_romanized_name_male(self):
+        """
+        @example 'Akira'
+        """
         return self.first_name_male_pair()[2]
 
     def first_romanized_name_female(self):
+        """
+        @example 'Akemi'
+        """
         return self.first_name_female_pair()[2]
 
     def last_romanized_name(self):
+        """
+        @example 'Sato'
+        """
         return self.last_name_pair()[2]
 
     def kana_name(self):
+        """
+        @example 'サトウ アケミ'
+        """
         pattern = self.random_element(self.kana_formats)
         return self.generator.parse(pattern)
 
     def kana_name_male(self):
+        """
+        @example 'サトウ アキラ'
+        """
         pattern = self.random_element(self.kana_formats_male)
         return self.generator.parse(pattern)
 
     def kana_name_female(self):
+        """
+        @example 'サトウ アケミ'
+        """
         pattern = self.random_element(self.kana_formats_female)
         return self.generator.parse(pattern)
 
     def romanized_name(self):
+        """
+        @example 'Akemi Sato'
+        """
         pattern = self.random_element(self.romanized_formats)
         return self.generator.parse(pattern)
 
     def romanized_name_male(self):
+        """
+        @example 'Akira Sato'
+        """
         pattern = self.random_element(self.romanized_formats_male)
         return self.generator.parse(pattern)
 
     def romanized_name_female(self):
+        """
+        @example 'Akemi Sato'
+        """
         pattern = self.random_element(self.romanized_formats_female)
         return self.generator.parse(pattern)

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -141,6 +141,26 @@ class TestJaJP(unittest.TestCase):
         assert last_romanized_name
         assert isinstance(last_romanized_name, str)
 
+        first_name_pair = self.fake.first_name_pair()
+        assert first_name_pair
+        assert len(first_name_pair) == 3
+        assert all(map(lambda s: isinstance(s, str), first_name_pair))
+
+        first_name_male_pair = self.fake.first_name_male_pair()
+        assert first_name_male_pair
+        assert len(first_name_male_pair) == 3
+        assert all(map(lambda s: isinstance(s, str), first_name_male_pair))
+
+        first_name_female_pair = self.fake.first_name_female_pair()
+        assert first_name_female_pair
+        assert len(first_name_female_pair) == 3
+        assert all(map(lambda s: isinstance(s, str), first_name_female_pair))
+
+        last_name_pair = self.fake.last_name_pair()
+        assert last_name_pair
+        assert len(last_name_pair) == 3
+        assert all(map(lambda s: isinstance(s, str), last_name_pair))
+
 
 class TestNeNP(unittest.TestCase):
 


### PR DESCRIPTION
### What does this changes

add pairs of matching representation to Japanese person provider

### What was wrong

#1310 added frequency to Japanese last names, but it didn't keep the consistency with other representation of it (katakana version and the romanized version)
You could say #1310 broke the consistency, but the original consistency was implicit and hard to tell (you needed to zip the list in order to get a consistent representation) so I came up with a new way.

### How this fixes it

This patch introduces the idea of "pairs" to names and its representation, and you can get a consistent pair if you wanted, or you could get a part of it if you prefer the normal way.

example: (assuming the same seed was provided)
```
>>> fake = Faker(locale='ja_JP')
>>> fake.first_name_pair()
('太郎', 'タロウ', 'Taro')
>>> fake.first_name()
太郎
>>> fake.first_kana_name()
タロウ
>>> fake.first_romanized_name()
Taro
```
