### PR TITLE
th_TH strftime: normalize output for unsupported directive

### DIFF
--- a/faker/providers/date_time/th_TH/__init__.py
+++ b/faker/providers/date_time/th_TH/__init__.py
@@ -64,11 +64,10 @@ def _std_strftime(dt_obj: datetime, fmt_char: str) -> str:
     str_ = ""
     try:
         str_ = dt_obj.strftime("%{}".format(fmt_char))
-        if str_ == "%{}".format(fmt_char):
+        if not str_ or str_ == "%{}".format(fmt_char):
             # normalize outputs for unsupported directives
             # in different platforms
-            # unsupported "%Q" in platform A may return "Q"
-            # unsupported "%Q" in platform A may return "%Q"
+            # "%Q" may result "%Q", "Q", or "", make it "Q"
             str_ = fmt_char
     except ValueError as err:  # pragma: no cover
         # Unsupported directives may raise ValueError on Windows,


### PR DESCRIPTION
### What does this changes

Normalizes output from th_TH's localized version of `strftime()` to make the output of unsupported directives the same in every platforms.

### What was wrong

`strftime()` with unsupported directive returns empty string in `musl` (used in Linux distros like Alpine).
This is different from the output from `glibc`, where it will return a character part (non-%) of the directive.

For example, "%Q" directive will result "Q" on glibc, while it will be "" on musl.

### How this fixes it

Make th_TH strftime() returns the character part (non-%) of the directive, independently from the platform.

Fixes #1333 

Requires #1337 to test against.
