### PR TITLE
Use pathlib for dir/file operations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,8 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# documentation root, use Path.resolve to make it absolute, like shown here.
+#sys.path.insert(0, str(Path().resolve()))
 
 # -- General configuration ------------------------------------------------
 

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -4,6 +4,8 @@ import os
 import random
 import sys
 
+from pathlib import Path
+
 from faker import VERSION, Faker, documentor
 from faker.config import AVAILABLE_LOCALES, DEFAULT_LOCALE, META_PROVIDERS_MODULES
 
@@ -112,7 +114,7 @@ class Command:
 
     def __init__(self, argv=None):
         self.argv = argv or sys.argv[:]
-        self.prog_name = os.path.basename(self.argv[0])
+        self.prog_name = Path(self.argv[0]).name
 
     def execute(self):
         """

--- a/faker/sphinx/documentor.py
+++ b/faker/sphinx/documentor.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 import importlib
 import inspect
-import os
+
+from pathlib import Path
 
 from faker.config import AVAILABLE_LOCALES
 from faker.config import PROVIDERS as STANDARD_PROVIDER_NAMES
 from faker.providers import BaseProvider
 
-DOCS_ROOT = os.path.abspath(os.path.join('..', 'docs'))
+DOCS_ROOT = Path(__file__).resolve().parents[1] / 'docs'
 
 SECTION_ADORNMENTS = '#*=-~'
 
@@ -79,8 +80,7 @@ def _write_includes(fh):
 
 
 def _write_standard_provider_index():
-    fname = os.path.join(DOCS_ROOT, 'providers.rst')
-    with open(fname, 'wb') as fh:
+    with (DOCS_ROOT / 'providers.rst').open('wb') as fh:
         _hide_edit_on_github(fh)
         _write_title(fh, 'Standard Providers')
         _write(fh, '.. toctree::\n')
@@ -91,8 +91,7 @@ def _write_standard_provider_index():
 
 
 def _write_base_provider_docs():
-    fname = os.path.join(DOCS_ROOT, 'providers', 'baseprovider.rst')
-    with open(fname, 'wb') as fh:
+    with (DOCS_ROOT / 'providers' / 'baseprovider.rst').open('wb') as fh:
         _hide_edit_on_github(fh)
         _write_title(fh, '``faker.providers``')
         _write_includes(fh)
@@ -104,8 +103,7 @@ def _write_base_provider_docs():
 
 def _write_standard_provider_docs():
     for provider_name in STANDARD_PROVIDER_NAMES:
-        fname = os.path.join(DOCS_ROOT, 'providers', '%s.rst' % provider_name)
-        with open(fname, 'wb') as fh:
+        with (DOCS_ROOT / 'providers' / '{}.rst'.format(provider_name)) as fh:
             provider_class = '{}.Provider'.format(provider_name)
             provider_methods = _get_provider_methods(provider_class)
             _hide_edit_on_github(fh)
@@ -118,8 +116,7 @@ def _write_standard_provider_docs():
 
 
 def _write_localized_provider_index():
-    fname = os.path.join(DOCS_ROOT, 'locales.rst')
-    with open(fname, 'wb') as fh:
+    with(DOCS_ROOT / 'locales.rst').open('wb') as fh:
         _hide_edit_on_github(fh)
         _write_title(fh, 'Localized Providers')
         _write(fh, '.. toctree::\n')
@@ -131,8 +128,7 @@ def _write_localized_provider_index():
 def _write_localized_provider_docs():
     for locale in AVAILABLE_LOCALES:
         info = _get_localized_provider_info(locale)
-        fname = os.path.join(DOCS_ROOT, 'locales', '{}.rst'.format(locale))
-        with open(fname, 'wb') as fh:
+        with (DOCS_ROOT / 'locales' / '{}.rst'.format(locale)).open('wb') as fh:
             _hide_edit_on_github(fh)
             _write_title(fh, 'Locale {}'.format(locale))
             _write_includes(fh)

--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -1,8 +1,8 @@
-import os
 import pkgutil
 import sys
 
 from importlib import import_module
+from pathlib import Path
 from types import ModuleType
 from typing import List, Set
 
@@ -13,17 +13,15 @@ def get_path(module: ModuleType) -> str:
 
         if getattr(sys, '_MEIPASS', False):
             # PyInstaller
-            lib_dir = getattr(sys, '_MEIPASS')
+            lib_dir = Path(getattr(sys, '_MEIPASS'))
         else:
             # others
-            base_dir = os.path.dirname(sys.executable)
-            lib_dir = os.path.join(base_dir, "lib")
+            lib_dir = Path(sys.executable).parent / 'lib'
 
-        module_to_rel_path = os.path.join(*module.__package__.split(".")) if module.__package__ else ''
-        path = os.path.join(lib_dir, module_to_rel_path)
+        path = lib_dir.joinpath(*module.__package__.split("."))
     else:
         # unfrozen
-        path = os.path.dirname(os.path.realpath(module.__file__))
+        path = Path(module.__file__).parent
     return path
 
 
@@ -32,9 +30,7 @@ def list_module(module: ModuleType) -> List[str]:
 
     if getattr(sys, '_MEIPASS', False):
         # PyInstaller
-        return [name for name in os.listdir(path)
-                if os.path.isdir(os.path.join(path, name)) and
-                "__init__.py" in os.listdir(os.path.join(path, name))]
+        return [file.parent.name for file in Path(path).glob('*/__init__.py')]
     else:
         return [name for _, name, is_pkg in pkgutil.iter_modules([path]) if is_pkg]
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,13 @@
 
 import os
 
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
-here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as fp:
-    README = fp.read()
-
-with open(os.path.join(here, 'VERSION')) as version_file:
-    VERSION = version_file.read().strip()
+here = Path(__file__).resolve().parent
+README = (here / 'README.rst').read_text(encoding='utf-8')
+VERSION = (here / 'VERSION').read_text(encoding='utf-8').strip()
 
 excluded_packages = ["docs", "tests", "tests.*"]
 if not os.environ.get('READTHEDOCS', False):

--- a/tests/pytest/session_overrides/conftest.py
+++ b/tests/pytest/session_overrides/conftest.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -20,7 +20,7 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption(EXCLUSIVE_SESSION_FLAG):
         return
     skip_lacks_exclusive_session = pytest.mark.skip(reason=SKIP_REASON)
-    session_overrides_dir = os.path.abspath(os.path.join(__file__, '..'))
+    session_overrides_dir = Path(__file__).resolve().parent
     for item in items:
-        if str(item.fspath).startswith(session_overrides_dir):
+        if str(item.fspath).startswith(str(session_overrides_dir)):
             item.add_marker(skip_lacks_exclusive_session)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,8 +1,8 @@
 import json
-import os
 import unittest
 
 from importlib import import_module
+from pathlib import Path
 
 from faker.config import META_PROVIDERS_MODULES, PROVIDERS
 from faker.generator import random
@@ -11,7 +11,7 @@ from faker.utils.datasets import add_dicts
 from faker.utils.distribution import choices_distribution, choices_distribution_unique
 from faker.utils.loading import find_available_locales, find_available_providers
 
-TEST_DIR = os.path.dirname(__file__)
+TEST_DIR = Path(__file__).resolve().parent
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -22,8 +22,7 @@ class UtilsTestCase(unittest.TestCase):
         sample = choices_distribution(a, p)[0]
         assert sample in a
 
-        with open(os.path.join(TEST_DIR, 'random_state.json'), 'r') as fh:
-            random_state = json.load(fh)
+        random_state = json.loads((TEST_DIR / 'random_state.json').read_text())
         random_state[1] = tuple(random_state[1])
 
         random.setstate(random_state)


### PR DESCRIPTION
Since the project is Python3 only, we can use `pathlib.Path` instead of all `os.path/glob/fnmatch/open` calls.