### PR TITLE
use f-strings

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -24,8 +24,7 @@ def print_provider(doc,
         excludes = []
 
     print(file=output)
-    print("### {}".format(
-          doc.get_provider_name(provider)), file=output)
+    print(f"### {doc.get_provider_name(provider)}", file=output)
     print(file=output)
 
     for signature, example in formatters.items():
@@ -39,19 +38,13 @@ def print_provider(doc,
             # try to `print` the line.
             lines = ["<bytes>"]
         except UnicodeEncodeError:
-            raise Exception('error on "{}" with value "{}"'.format(
-                            signature, example))
+            raise Exception(f'error on {signature!r} with value {example!r}')
         margin = max(30, doc.max_name_len + 1)
         remains = 150 - margin
         separator = '#'
         for line in lines:
             for i in range(0, (len(line) // remains) + 1):
-                print("\t{fake:<{margin}}{separator} {example}".format(
-                    fake=signature,
-                    separator=separator,
-                    example=line[i * remains:(i + 1) * remains],
-                    margin=margin,
-                ), file=output)
+                print(f"\t{signature:<{margin}}{separator} {line[i * remains:(i + 1) * remains]}", file=output)
                 signature = separator = ' '
 
 
@@ -89,8 +82,7 @@ def print_doc(provider_or_field=None,
                     end='',
                     file=output)
             except AttributeError:
-                raise ValueError('No faker found for "{}({})"'.format(
-                    provider_or_field, args))
+                raise ValueError(f'No faker found for "{provider_or_field}({args})"')
 
     else:
         doc = documentor.Documentor(fake)
@@ -105,7 +97,7 @@ def print_doc(provider_or_field=None,
             if language == lang:
                 continue
             print(file=output)
-            print('## LANGUAGE {}'.format(language), file=output)
+            print(f'## LANGUAGE {language}', file=output)
             fake = Faker(locale=language)
             fake.seed_instance(seed)
             d = documentor.Documentor(fake)
@@ -133,18 +125,18 @@ class Command:
         if default_locale not in AVAILABLE_LOCALES:
             default_locale = DEFAULT_LOCALE
 
-        epilog = """supported locales:
+        epilog = f"""supported locales:
 
-  {0}
+  {', '.join(sorted(AVAILABLE_LOCALES))}
 
   Faker can take a locale as an optional argument, to return localized data. If
   no locale argument is specified, the factory falls back to the user's OS
   locale as long as it is supported by at least one of the providers.
-     - for this user, the default locale is {1}.
+     - for this user, the default locale is {default_locale}.
 
   If the optional argument locale and/or user's default locale is not available
   for the specified provider, the factory falls back to faker's default locale,
-  which is {2}.
+  which is {DEFAULT_LOCALE}.
 
 examples:
 
@@ -164,19 +156,17 @@ examples:
   Josiah Maggio;
   Gayla Schmitt;
 
-""".format(', '.join(sorted(AVAILABLE_LOCALES)),
-           default_locale,
-           DEFAULT_LOCALE)
+"""
 
         formatter_class = argparse.RawDescriptionHelpFormatter
         parser = argparse.ArgumentParser(
             prog=self.prog_name,
-            description='{} version {}'.format(self.prog_name, VERSION),
+            description=f'{self.prog_name} version {VERSION}',
             epilog=epilog,
             formatter_class=formatter_class)
 
         parser.add_argument("--version", action="version",
-                            version="%(prog)s {}".format(VERSION))
+                            version=f'%(prog)s {VERSION}')
 
         parser.add_argument('-v',
                             '--verbose',

--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -63,9 +63,9 @@ class Documentor:
                                 default = repr(default)
                             else:
                                 # TODO check default type
-                                default = "{}".format(default)
+                                default = f"{default}"
 
-                            arg = "{}={}".format(arg, default)
+                            arg = f'{arg}={default}'
 
                         except IndexError:
                             pass
@@ -81,7 +81,7 @@ class Documentor:
                         arguments.append('**' + argspec.varkw)
 
             # build fake method signature
-            signature = "{}{}({})".format(prefix, name, ", ".join(arguments))
+            signature = f"{prefix}{name}({', '.join(arguments)})"
 
             # make a fake example
             example = self.generator.format(name, *faker_args, **faker_kwargs)

--- a/faker/factory.py
+++ b/faker/factory.py
@@ -38,7 +38,7 @@ class Factory:
         locale = locale.replace('-', '_') if locale else DEFAULT_LOCALE
         locale = pylocale.normalize(locale).split('.')[0]
         if locale not in AVAILABLE_LOCALES:
-            msg = 'Invalid configuration for faker locale `{}`'.format(locale)
+            msg = f'Invalid configuration for faker locale `{locale}`'
             raise AttributeError(msg)
 
         config['locale'] = locale
@@ -81,8 +81,7 @@ class Factory:
         if provider_class:
             return provider_class, None
 
-        msg = 'Unable to find provider `{}` with locale `{}`'.format(
-            provider, locale)
+        msg = f'Unable to find provider `{provider}` with locale `{locale}`'
         raise ValueError(msg)
 
     @classmethod
@@ -92,36 +91,28 @@ class Factory:
 
         if getattr(provider_module, 'localized', False):
 
-            logger.debug('Looking for locale `{}` in provider `{}`.'.format(
-                locale, provider_module.__name__))
+            logger.debug('Looking for locale `%s` in provider `%s`.', locale, provider_module.__name__)
 
             available_locales = list_module(provider_module)
             if not locale or locale not in available_locales:
                 unavailable_locale = locale
                 locale = getattr(
                     provider_module, 'default_locale', DEFAULT_LOCALE)
-                logger.debug('Specified locale `{}` is not available for '
-                             'provider `{}`. Locale reset to `{}` for this '
-                             'provider.'.format(
-                                 unavailable_locale, provider_module.__name__, locale),
-                             )
+                logger.debug('Specified locale `%s` is not available for '
+                             'provider `%s`. Locale reset to `%s` for this '
+                             'provider.',
+                             unavailable_locale, provider_module.__name__, locale)
             else:
-                logger.debug('Provider `{}` has been localized to `{}`.'.format(
-                    provider_module.__name__, locale))
+                logger.debug('Provider `%s` has been localized to `%s`.', provider_module.__name__, locale)
 
-            path = "{provider_path}.{locale}".format(
-                provider_path=provider_path,
-                locale=locale,
-            )
+            path = f'{provider_path}.{locale}'
             provider_module = import_module(path)
 
         else:
 
-            logger.debug('Provider `{}` does not feature localization. '
-                         'Specified locale `{}` is not utilized for this '
-                         'provider.'.format(
-                             provider_module.__name__, locale),
-                         )
+            logger.debug('Provider `%s` does not feature localization. '
+                         'Specified locale `%s` is not utilized for this '
+                         'provider.', provider_module.__name__, locale)
 
             if locale is not None:
                 provider_module = import_module(provider_path)

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -80,13 +80,9 @@ class Generator:
             return getattr(self, formatter)
         except AttributeError:
             if 'locale' in self.__config:
-                msg = 'Unknown formatter "{}" with locale "{}"'.format(
-                    formatter, self.__config['locale'],
-                )
+                msg = f'Unknown formatter {formatter!r} with locale {self.__config["locale"]!r}'
             else:
-                raise AttributeError('Unknown formatter "{}"'.format(
-                    formatter,
-                ))
+                raise AttributeError(f'Unknown formatter {formatter!r}')
             raise AttributeError(msg)
 
     def set_formatter(self, name, method):
@@ -174,7 +170,7 @@ class Generator:
             try:
                 arguments = self.__config['arguments'][argument_group]
             except KeyError:
-                raise AttributeError('Unknown argument group "{}"'.format(argument_group))
+                raise AttributeError(f'Unknown argument group {argument_group!r}')
 
             formatted = str(self.format(formatter, **arguments))
         else:

--- a/faker/providers/address/en_PH/__init__.py
+++ b/faker/providers/address/en_PH/__init__.py
@@ -366,7 +366,7 @@ class Provider(AddressProvider):
         return str(num) + suffix
 
     def _create_postcode(self, postcodes):
-        return '{postcode:04d}'.format(postcode=self.random_element(postcodes))
+        return f'{self.random_element(postcodes):04d}'
 
     def _create_address(self, address_formats):
         return self.generator.parse(self.random_element(address_formats))
@@ -423,10 +423,7 @@ class Provider(AddressProvider):
         return self._ordinal_string(self.floor_number())
 
     def floor_unit_number(self):
-        return '{floor_number}{unit_number:02d}'.format(
-            floor_number=self.floor_number(),
-            unit_number=self.random_int(1, 40),
-        )
+        return f'{self.floor_number()}{self.random_int(1, 40):02d}'
 
     def building_unit_number(self):
         return self.generator.parse(self.random_element(self.building_unit_number_formats))
@@ -438,10 +435,10 @@ class Provider(AddressProvider):
         return self.numerify(self.random_element(self.building_name_suffixes))
 
     def subdivision_block_number(self):
-        return '{block_number:02d}'.format(block_number=self.random_int(1, 25))
+        return f'{self.random_int(1, 25):02d}'
 
     def subdivision_lot_number(self):
-        return '{lot_number:02d}'.format(lot_number=self.random_int(1, 99))
+        return f'{self.random_int(1, 99):02d}'
 
     def subdivision_unit_number(self):
         return self.generator.parse(self.random_element(self.subdivision_unit_number_formats))

--- a/faker/providers/address/hu_HU/__init__.py
+++ b/faker/providers/address/hu_HU/__init__.py
@@ -214,11 +214,7 @@ class Provider(AddressProvider):
         return self.random_element(self.counties)
 
     def street_address_with_county(self):
-        return "{street_address}\n{county} megye\n{postcode} {city}".format(
-            street_address=self.street_address(),
-            county=self.county(),
-            postcode=self.postcode(),
-            city=self.city().capitalize())
+        return f'{self.street_address()}\n{self.county()} megye\n{self.postcode()} {self.city().capitalize()}'
 
     def city_prefix(self):
         return self.random_element(self.city_prefs)
@@ -233,8 +229,8 @@ class Provider(AddressProvider):
         return self.random_element(self.frequent_street_names)
 
     def postcode(self):
-        return "H-{}{}{}{}".format(
-            super().random_digit_not_null(), super().random_digit(), super().random_digit(), super().random_digit())
+        return (f'H-{super().random_digit_not_null()}{super().random_digit()}'
+                f'{super().random_digit()}{super().random_digit()}')
 
     def street_name(self):
         return super().street_name().capitalize()

--- a/faker/providers/address/uk_UA/__init__.py
+++ b/faker/providers/address/uk_UA/__init__.py
@@ -161,10 +161,7 @@ class Provider(AddressProvider):
 
     def postcode(self):
         """The code consists of five digits (01000-99999)"""
-        return '{}{}'.format(
-            self.generator.random.randint(
-                0, 10), self.generator.random.randint(
-                1000, 10000))
+        return f'{self.generator.random.randint(0, 10)}{self.generator.random.randint(1000, 10000)}'
 
     def street_prefix(self):
         return self.random_element(self.street_prefixes)

--- a/faker/providers/color/__init__.py
+++ b/faker/providers/color/__init__.py
@@ -168,16 +168,11 @@ class Provider(BaseProvider):
 
     def hex_color(self):
         """Generate a color formatted as a hex triplet."""
-        return "#{}".format(
-            ("%x" %
-             self.random_int(
-                 1, 16777215)).ljust(
-                6, '0'))
+        return f'#{self.random_int(1, 16777215):06x}'
 
     def safe_hex_color(self):
         """Generate a web-safe color formatted as a hex triplet."""
-        color = ("%x" % self.random_int(0, 255)).ljust(3, '0')
-        return "#{0}{0}{1}{1}{2}{2}".format(*color)
+        return f'#{self.random_int(0, 15) * 17:02x}{self.random_int(0, 15) * 17:02x}{self.random_int(0, 15) * 17:02x}'
 
     def rgb_color(self):
         """Generate a color formatted as a comma-separated RGB value."""
@@ -185,8 +180,7 @@ class Provider(BaseProvider):
 
     def rgb_css_color(self):
         """Generate a color formatted as a CSS rgb() function."""
-        return 'rgb(%s)' % ','.join(
-            map(str, (self.random_int(0, 255) for _ in range(3))))
+        return f'rgb({self.random_int(0, 255)},{self.random_int(0, 255)},{self.random_int(0, 255)})'
 
     def color(self, hue=None, luminosity=None, color_format='hex'):
         """Generate a color in a human-friendly way.

--- a/faker/providers/color/color.py
+++ b/faker/providers/color/color.py
@@ -178,19 +178,19 @@ class RandomColor:
     def set_format(self, hsv, color_format):
         """Handle conversion of HSV values into desired format."""
         if color_format == 'hsv':
-            color = 'hsv({}, {}, {})'.format(*hsv)
+            color = f'hsv({hsv[0]}, {hsv[1]}, {hsv[2]})'
 
         elif color_format == 'hsl':
-            hsl = self.hsv_to_hsl(hsv)
-            color = 'hsl({}, {}, {})'.format(*hsl)
+            hsl = tuple(self.hsv_to_hsl(hsv))
+            color = f'hsl({hsl[0]}, {hsl[1]}, {hsl[2]})'
 
         elif color_format == 'rgb':
-            rgb = self.hsv_to_rgb(hsv)
-            color = 'rgb({}, {}, {})'.format(*rgb)
+            rgb = tuple(self.hsv_to_rgb(hsv))
+            color = f'rgb({rgb[0]}, {rgb[1]}, {rgb[2]})'
 
         else:
-            rgb = self.hsv_to_rgb(hsv)
-            color = '#{:02x}{:02x}{:02x}'.format(*rgb)
+            rgb = tuple(self.hsv_to_rgb(hsv))
+            color = f'#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}'
 
         return color
 

--- a/faker/providers/company/it_IT/__init__.py
+++ b/faker/providers/company/it_IT/__init__.py
@@ -378,4 +378,4 @@ class Provider(CompanyProvider):
         """
         code = self.bothify('#######') + str(self._random_vat_office()).zfill(3)
         luhn_checksum = str(calculate_luhn(code))
-        return 'IT{}{}'.format(code, luhn_checksum)
+        return f'IT{code}{luhn_checksum}'

--- a/faker/providers/company/pt_BR/__init__.py
+++ b/faker/providers/company/pt_BR/__init__.py
@@ -103,5 +103,4 @@ class Provider(CompanyProvider):
 
     def cnpj(self):
         digits = self.company_id()
-        return '{}.{}.{}/{}-{}'.format(digits[:2], digits[2:5], digits[5:8],
-                                       digits[8:12], digits[12:])
+        return f'{digits[:2]}.{digits[2:5]}.{digits[5:8]}/{digits[8:12]}-{digits[12:]}'

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1497,7 +1497,7 @@ class Provider(BaseProvider):
     def _parse_date_string(cls, value):
         parts = cls.regex.match(value)
         if not parts:
-            raise ParseError("Can't parse date string `{}`.".format(value))
+            raise ParseError(f"Can't parse date string `{value}`")
         parts = parts.groupdict()
         time_params = {}
         for (name_, param_) in parts.items():
@@ -1514,7 +1514,7 @@ class Provider(BaseProvider):
             time_params['days'] += 30.42 * time_params.pop('months')
 
         if not time_params:
-            raise ParseError("Can't parse date string `{}`.".format(value))
+            raise ParseError(f"Can't parse date string `{value}`")
         return time_params
 
     @classmethod
@@ -1526,7 +1526,7 @@ class Provider(BaseProvider):
             return timedelta(**time_params).total_seconds()
         if isinstance(value, (int, float)):
             return value
-        raise ParseError("Invalid format for timedelta '{}'".format(value))
+        raise ParseError(f"Invalid format for timedelta {value!r}")
 
     @classmethod
     def _parse_date_time(cls, value, tzinfo=None):
@@ -1542,7 +1542,7 @@ class Provider(BaseProvider):
             return datetime_to_timestamp(now + timedelta(**time_params))
         if isinstance(value, int):
             return datetime_to_timestamp(now + timedelta(value))
-        raise ParseError("Invalid format for date '{}'".format(value))
+        raise ParseError(f"Invalid format for date {value!r}")
 
     @classmethod
     def _parse_date(cls, value):
@@ -1560,7 +1560,7 @@ class Provider(BaseProvider):
             return today + timedelta(**time_params)
         if isinstance(value, int):
             return today + timedelta(value)
-        raise ParseError("Invalid format for date '{}'".format(value))
+        raise ParseError(f"Invalid format for date {value!r}")
 
     def date_time_between(self, start_date='-30y', end_date='now', tzinfo=None):
         """
@@ -1946,8 +1946,7 @@ class Provider(BaseProvider):
             def distrib(dt): return self.generator.random.uniform(0, precision)  # noqa
 
         if not callable(distrib):
-            raise ValueError(
-                "`distrib` must be a callable. Got {} instead.".format(distrib))
+            raise ValueError(f"`distrib` must be a callable. Got {distrib} instead.")
 
         datapoint = start_date
         while datapoint < end_date:

--- a/faker/providers/date_time/th_TH/__init__.py
+++ b/faker/providers/date_time/th_TH/__init__.py
@@ -63,8 +63,8 @@ def _std_strftime(dt_obj: datetime, fmt_char: str) -> str:
     """
     str_ = ""
     try:
-        str_ = dt_obj.strftime("%{}".format(fmt_char))
-        if not str_ or str_ == "%{}".format(fmt_char):
+        str_ = dt_obj.strftime(f'%{fmt_char}')
+        if not str_ or str_ == f'%{fmt_char}':
             # normalize outputs for unsupported directives
             # in different platforms
             # "%Q" may result "%Q", "Q", or "", make it "Q"
@@ -74,8 +74,8 @@ def _std_strftime(dt_obj: datetime, fmt_char: str) -> str:
         # in that case just use the fmt_char
         warnings.warn(
             (
-                "String format directive unknown/not support: %{}"
-                "The system raises this ValueError: {}".format(fmt_char, err)
+                f"String format directive unknown/not support: %{fmt_char}"
+                f"The system raises this ValueError: {err}"
             ),
             UserWarning,
         )
@@ -116,21 +116,14 @@ def _thai_strftime(
         # Locale’s appropriate date and time representation
         # Wed  6 Oct 01:40:00 1976
         # พ   6 ต.ค. 01:40:00 2519  <-- left-aligned weekday, right-aligned day
-        str_ = "{:<2} {:>2} {} {} {}".format(
-            _TH_ABBR_WEEKDAYS[dt_obj.weekday()],
-            dt_obj.day,
-            _TH_ABBR_MONTHS[dt_obj.month - 1],
-            dt_obj.strftime("%H:%M:%S"),
-            str(year).zfill(4),
-        )
+        str_ = (f'{_TH_ABBR_WEEKDAYS[dt_obj.weekday()]:<2} {dt_obj.day:>2} '
+                f'{_TH_ABBR_MONTHS[dt_obj.month - 1]} {dt_obj:%H:%M:%S} {year:04}')
     elif fmt_char == "D":
         # Equivalent to ``%m/%d/%y''
-        str_ = "{}/{}".format(
-            dt_obj.strftime("%m/%d"), (str(year)[-2:]).zfill(2),
-        )
+        str_ = f'{dt_obj:%m/%d}/{year % 100:02}'
     elif fmt_char == "F":
         # Equivalent to ``%Y-%m-%d''
-        str_ = "{}-{}".format(str(year).zfill(4), dt_obj.strftime("%m-%d"))
+        str_ = f'{year:04}-{dt_obj:%m-%d}'
     elif fmt_char == "G":
         # ISO 8601 year with century representing the year that contains
         # the greater part of the ISO week (%V). Monday as the first day
@@ -138,46 +131,35 @@ def _thai_strftime(
         year_G = int(dt_obj.strftime("%G"))
         if buddhist_era:
             year_G = year_G + _BE_AD_DIFFERENCE
-        str_ = str(year_G).zfill(4)
+        str_ = f'{year_G:04}'
     elif fmt_char == "g":
         # Same year as in ``%G'',
         # but as a decimal number without century (00-99).
         year_G = int(dt_obj.strftime("%G"))
         if buddhist_era:
             year_G = year_G + _BE_AD_DIFFERENCE
-        str_ = (str(year_G)[-2:]).zfill(2)
+        str_ = f'{year_G % 100:02}'
     elif fmt_char == "v":
         # BSD extension, ' 6-Oct-1976'
-        str_ = "{:>2}-{}-{}".format(
-            dt_obj.day, _TH_ABBR_MONTHS[dt_obj.month - 1], str(year).zfill(4),
-        )
+        str_ = f'{dt_obj.day:>2}-{_TH_ABBR_MONTHS[dt_obj.month - 1]}-{year:04}'
     elif fmt_char == "X":
         # Locale’s appropriate time representation.
-        str_ = dt_obj.strftime("%H:%M:%S")
+        str_ = f'{dt_obj:%H:%M:%S}'
     elif fmt_char == "x":
         # Locale’s appropriate date representation.
-        str_ = "{}/{}/{}".format(
-            str(dt_obj.day).zfill(2),
-            str(dt_obj.month).zfill(2),
-            str(year).zfill(4),
-        )
+        str_ = f'{dt_obj:%d/%m}/{year:04}'
     elif fmt_char == "Y":
         # Year with century
-        str_ = (str(year)).zfill(4)
+        str_ = f'{year:04}'
     elif fmt_char == "y":
         # Year without century
-        str_ = (str(year)[-2:]).zfill(2)
+        str_ = f'{year % 100:02}'
     elif fmt_char == "+":
         # National representation of the date and time
         # (the format is similar to that produced by date(1))
         # Wed  6 Oct 1976 01:40:00
-        str_ = "{:<2} {:>2} {} {} {}".format(
-            _TH_ABBR_WEEKDAYS[dt_obj.weekday()],
-            dt_obj.day,
-            _TH_ABBR_MONTHS[dt_obj.month - 1],
-            year,
-            dt_obj.strftime("%H:%M:%S"),
-        )
+        str_ = (f'{_TH_ABBR_WEEKDAYS[dt_obj.weekday()]:<2} {dt_obj.day:>2} '
+                f'{_TH_ABBR_MONTHS[dt_obj.month - 1]} {year} {dt_obj:%H:%M:%S}')
 
     return str_
 

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -233,7 +233,7 @@ class Provider(BaseProvider):
         """
         extension = extension if extension else self.file_extension(category)
         filename = self.generator.word()
-        return '{}.{}'.format(filename, extension)
+        return f'{filename}.{extension}'
 
     def file_extension(self, category=None):
         """Generate a file extension under the specified ``category``.
@@ -262,9 +262,9 @@ class Provider(BaseProvider):
         :sample: depth=5, category='video', extension='abcdef'
         """
         file = self.file_name(category, extension)
-        path = "/{}".format(file)
+        path = f'/{file}'
         for _ in range(0, depth):
-            path = "/{}{}".format(self.generator.word(), path)
+            path = f'/{self.generator.word()}{path}'
         return path
 
     def unix_device(self, prefix=None):

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -121,7 +121,7 @@ class Provider(BaseProvider):
     @lowercase
     def email(self, domain=None):
         if domain:
-            email = '{}@{}'.format(self.user_name(), domain)
+            email = f'{self.user_name()}@{domain}'
         else:
             pattern = self.random_element(self.email_formats)
             email = "".join(self.generator.parse(pattern).split(" "))
@@ -270,10 +270,7 @@ class Provider(BaseProvider):
         if schemes is None:
             schemes = ['http', 'https']
 
-        pattern = '{}://{}'.format(
-            self.random_element(schemes) if schemes else "",
-            self.random_element(self.url_formats),
-        )
+        pattern = f'{self.random_element(schemes) if schemes else ""}://{self.random_element(self.url_formats)}'
 
         return self.generator.parse(pattern)
 
@@ -285,14 +282,14 @@ class Provider(BaseProvider):
         """
         # If `address_class` has an unexpected value, use the whole IPv4 pool
         if address_class in _IPv4Constants._network_classes.keys():
-            networks_attr = '_cached_all_class_{}_networks'.format(address_class)
+            networks_attr = f'_cached_all_class_{address_class}_networks'
             all_networks = [_IPv4Constants._network_classes[address_class]]
         else:
             networks_attr = '_cached_all_networks'
             all_networks = [ip_network('0.0.0.0/0')]
 
         # Return cached network and weight data if available
-        weights_attr = '{}_weights'.format(networks_attr)
+        weights_attr = f'{networks_attr}_weights'
         if hasattr(self, networks_attr) and hasattr(self, weights_attr):
             return getattr(self, networks_attr), getattr(self, weights_attr)
 
@@ -321,8 +318,8 @@ class Provider(BaseProvider):
             address_class = self.ipv4_network_class()
 
         # Return cached network and weight data if available for a specific address class
-        networks_attr = '_cached_private_class_{}_networks'.format(address_class)
-        weights_attr = '{}_weights'.format(networks_attr)
+        networks_attr = f'_cached_private_class_{address_class}_networks'
+        weights_attr = f'{networks_attr}_weights'
         if hasattr(self, networks_attr) and hasattr(self, weights_attr):
             return getattr(self, networks_attr), getattr(self, weights_attr)
 
@@ -356,8 +353,8 @@ class Provider(BaseProvider):
             address_class = self.ipv4_network_class()
 
         # Return cached network and weight data if available for a specific address class
-        networks_attr = '_cached_public_class_{}_networks'.format(address_class)
-        weights_attr = '{}_weights'.format(networks_attr)
+        networks_attr = f'_cached_public_class_{address_class}_networks'
+        weights_attr = f'{networks_attr}_weights'
         if hasattr(self, networks_attr) and hasattr(self, weights_attr):
             return getattr(self, networks_attr), getattr(self, weights_attr)
 

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -556,8 +556,7 @@ class Provider(BaseProvider):
                     raise TypeError('Invalid arguments type. Must be a dictionary')
 
                 result = self._value_format_selection(definition, **kwargs)
-                field = "{0:%s%s}" % (align_map.get(align, '<'), width)
-                row.append(field.format(result)[:width])
+                row.append(f'{result:{align_map.get(align, "<")}{width}}'[:width])
 
             data.append(''.join(row))
         return '\n'.join(data)

--- a/faker/providers/person/pl_PL/__init__.py
+++ b/faker/providers/person/pl_PL/__init__.py
@@ -721,10 +721,8 @@ class Provider(PersonProvider):
         if date_of_birth is None:
             date_of_birth = self.generator.date_of_birth()
 
-        pesel_date = '{year}{month:02d}{day:02d}'.format(
-            year=date_of_birth.year, day=date_of_birth.day,
-            month=date_of_birth.month if date_of_birth.year < 2000 else date_of_birth.month + 20)
-        pesel_date = pesel_date[2:]
+        month = date_of_birth.month if date_of_birth.year < 2000 else date_of_birth.month + 20
+        pesel_date = f'{date_of_birth:%y}{month:02d}{date_of_birth:%d}'
 
         pesel_core = ''.join(map(str, (self.random_digit() for _ in range(3))))
         pesel_sex = self.random_digit()
@@ -732,7 +730,7 @@ class Provider(PersonProvider):
         if (sex == 'M' and pesel_sex % 2 == 0) or (sex == 'F' and pesel_sex % 2 == 1):
             pesel_sex = (pesel_sex + 1) % 10
 
-        pesel = '{date}{core}{sex}'.format(date=pesel_date, core=pesel_core, sex=pesel_sex)
+        pesel = f'{pesel_date}{pesel_core}{pesel_sex}'
         pesel += str(self.pesel_compute_check_digit(pesel))
 
         return pesel
@@ -755,7 +753,7 @@ class Provider(PersonProvider):
             core[-1] = (core[-1] + 1) % 10
             check_digit = self.pwz_doctor_compute_check_digit(core)
 
-        return '{}{}'.format(check_digit, ''.join(map(str, core)))
+        return f'{check_digit}{"".join(map(str, core))}'
 
     def pwz_nurse(self, kind='nurse'):
         """
@@ -771,7 +769,7 @@ class Provider(PersonProvider):
         core = [self.random_digit() for _ in range(5)]
         kind_char = 'A' if kind == 'midwife' else 'P'
 
-        return '{:02d}{}{}'.format(region, ''.join(map(str, core)), kind_char)
+        return f'{region:02d}{"".join(map(str, core))}{kind_char}'
 
     tax_office_codes = (
         '101', '102', '103', '104', '105', '106', '107', '108', '109', '111', '112', '113', '114', '115', '116', '117',

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -87,11 +87,7 @@ class Provider(BaseProvider):
             sign = '+' if positive else self.random_element(('+', '-'))
             left_number = self.random_number(left_digits)
 
-        return float("{}{}.{}".format(
-            sign,
-            left_number,
-            self.random_number(right_digits),
-        ))
+        return float(f'{sign}{left_number}.{self.random_number(right_digits)}')
 
     def _safe_random_int(self, min_value, max_value, positive):
         orig_min_value = min_value
@@ -156,7 +152,7 @@ class Provider(BaseProvider):
     def _random_type(self, type_list):
         value_type = self.random_element(type_list)
 
-        method_name = "py{}".format(value_type)
+        method_name = f'py{value_type}'
         if hasattr(self, method_name):
             value_type = method_name
 

--- a/faker/providers/ssn/cs_CZ/__init__.py
+++ b/faker/providers/ssn/cs_CZ/__init__.py
@@ -26,17 +26,17 @@ class Provider(BaseProvider):
         https://en.wikipedia.org/wiki/National_identification_number#Czech_Republic_and_Slovakia
         """
         birthdate = self.generator.date_of_birth()
-        year = '%.2d' % (birthdate.year % 100)
+        year = f'{birthdate:%y}'
         month = self.random_element(self.national_id_months)
-        day = '%.2d' % birthdate.day
+        day = f'{birthdate:%d}'
         if birthdate.year > 1953:
             sn = self.random_number(4, True)
         else:
             sn = self.random_number(3, True)
-        number = int('{}{}{}{}'.format(year, month, day, sn))
+        number = int(f'{year}{month}{day}{sn}')
         birth_number = str(ceil(number / 11) * 11)
         if year == '00':
             birth_number = '00' + birth_number
         elif year[0] == '0':
             birth_number = '0' + birth_number
-        return '{}/{}'.format(birth_number[:6], birth_number[6::])
+        return f'{birth_number[:6]}/{birth_number[6:]}'

--- a/faker/providers/ssn/en_IN/__init__.py
+++ b/faker/providers/ssn/en_IN/__init__.py
@@ -23,6 +23,6 @@ class Provider(BaseProvider):
         aadhaar_digits = self.numerify(self.random_element(self.aadhaar_id_formats))
         checksum = checksums.calculate_luhn(aadhaar_digits)
 
-        aadhaar_number = '{}{}'.format(aadhaar_digits, checksum)
+        aadhaar_number = f'{aadhaar_digits}{checksum}'
 
         return aadhaar_number

--- a/faker/providers/ssn/en_US/__init__.py
+++ b/faker/providers/ssn/en_US/__init__.py
@@ -26,7 +26,7 @@ class Provider(BaseProvider):
         # The group number must be between 70 and 99 inclusively but not 89 or 93
         group = self.random_element([x for x in range(70, 100) if x not in [89, 93]])
 
-        itin = "{:03d}-{:02d}-{:04d}".format(area, group, serial)
+        itin = f'{area:03d}-{group:02d}-{serial:04d}'
         return itin
 
     def ein(self):
@@ -133,7 +133,7 @@ class Provider(BaseProvider):
         ein_prefix = self.random_element(ein_prefix_choices)
         sequence = self.random_int(min=0, max=9999999)
 
-        ein = "{:s}-{:07d}".format(ein_prefix, sequence)
+        ein = f'{ein_prefix:s}-{sequence:07d}'
         return ein
 
     def invalid_ssn(self):
@@ -195,7 +195,7 @@ class Provider(BaseProvider):
             group = self.random_element([x for x in range(0, 100) if x not in itin_group_numbers])
             serial = self.random_int(0, 9999)
 
-        invalid_ssn = "{:03d}-{:02d}-{:04d}".format(area, group, serial)
+        invalid_ssn = f'{area:03d}-{group:02d}-{serial:04d}'
         return invalid_ssn
 
     def ssn(self, taxpayer_identification_number_type=SSN_TYPE):
@@ -223,7 +223,7 @@ class Provider(BaseProvider):
             group = self.random_int(1, 99)
             serial = self.random_int(1, 9999)
 
-            ssn = "{:03d}-{:02d}-{:04d}".format(area, group, serial)
+            ssn = f'{area:03d}-{group:02d}-{serial:04d}'
             return ssn
 
         else:

--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -156,12 +156,7 @@ class Provider(BaseProvider):
         start_year = self.random_int(min=0, max=99)
         serial = self.random_int(min=1, max=9999)
 
-        num = "{:02d}{:02d}{:02d}{:04d}".format(
-            office,
-            start_year,
-            birth_year,
-            serial,
-        )
+        num = f'{office:02d}{start_year:02d}{birth_year:02d}{serial:04d}'
 
         check = ssn_checksum(map(int, num))
         num += str(check)

--- a/faker/providers/ssn/hu_HU/__init__.py
+++ b/faker/providers/ssn/hu_HU/__init__.py
@@ -114,10 +114,9 @@ class Provider(SsnProvider):
 
         H = zfix(H)
         N = zfix(N)
-        S = "{}{}{}".format(self.generator.random_digit(
-        ), self.generator.random_digit(), self.generator.random_digit())
+        S = f'{self.generator.random_digit()}{self.generator.random_digit()}{self.generator.random_digit()}'
 
-        vdig = "{M}{E}{H}{N}{S}".format(M=M, E=E, H=H, N=N, S=S)
+        vdig = f'{M}{E}{H}{N}{S}'
 
         if 17 < E < 97:
             cum = [(k + 1) * int(v) for k, v in enumerate(vdig)]

--- a/faker/providers/ssn/nl_BE/__init__.py
+++ b/faker/providers/ssn/nl_BE/__init__.py
@@ -41,7 +41,7 @@ class Provider(SsnProvider):
         # Simulate the gender/sequence - should be 3 digits
         seq = self.generator.random_int(1, 998)
         # Right justify sequence and append to list
-        seq_str = "{:0>3}".format(seq)
+        seq_str = f'{seq:0>3}'
         elms.append(seq_str)
         # Now convert list to an integer so the checksum can be calculated
         date_as_int = int("".join(elms))
@@ -49,7 +49,7 @@ class Provider(SsnProvider):
             date_as_int += 2000000000
         # Generate checksum
         s = _checksum(date_as_int)
-        s_rjust = "{:0>2}".format(s)
+        s_rjust = f'{s:0>2}'
         # return result as a string
         elms.append(s_rjust)
         return "".join(elms)

--- a/faker/providers/ssn/no_NO/__init__.py
+++ b/faker/providers/ssn/no_NO/__init__.py
@@ -77,5 +77,5 @@ class Provider(SsnProvider):
             # https://no.wikipedia.org/wiki/F%C3%B8dselsnummer
             if k1 == 10 or k2 == 10:
                 continue
-            pnr += '{}{}'.format(k1, k2)
+            pnr += f'{k1}{k2}'
             return pnr

--- a/faker/providers/ssn/sk_SK/__init__.py
+++ b/faker/providers/ssn/sk_SK/__init__.py
@@ -28,17 +28,17 @@ class Provider(BaseProvider):
         https://en.wikipedia.org/wiki/National_identification_number#Czech_Republic_and_Slovakia
         """
         birthdate = self.generator.date_of_birth()
-        year = '%.2d' % (birthdate.year % 100)
+        year = f'{birthdate:%y}'
         month = self.random_element(self.national_id_months)
-        day = '%.2d' % birthdate.day
+        day = f'{birthdate:%d}'
         if birthdate.year > 1953:
             sn = self.random_number(4, True)
         else:
             sn = self.random_number(3, True)
-        number = int('{}{}{}{}'.format(year, month, day, sn))
+        number = int(f'{year}{month}{day}{sn}')
         birth_number = str(ceil(number / 11) * 11)
         if year == '00':
             birth_number = '00' + birth_number
         elif year[0] == '0':
             birth_number = '0' + birth_number
-        return '{}/{}'.format(birth_number[:6], birth_number[6::])
+        return f'{birth_number[:6]}/{birth_number[6::]}'

--- a/faker/providers/ssn/sv_SE/__init__.py
+++ b/faker/providers/ssn/sv_SE/__init__.py
@@ -13,7 +13,7 @@ class Provider(SsnProvider):
         org_id = org_id.replace('-', '')
         if len(org_id) == 10:
             org_id = '16' + org_id
-        return 'SE{}01'.format(org_id)
+        return f'SE{org_id}01'
 
     def ssn(self, min_age=18, max_age=90, long=False, dash=True):
         """
@@ -33,12 +33,12 @@ class Provider(SsnProvider):
             days=self.generator.random.randrange(min_age * 365, max_age * 365))
         birthday = datetime.datetime.now() - age
         yr_fmt = '%Y' if long else '%y'
-        pnr_date = birthday.strftime('{}%m%d'.format(yr_fmt))
+        pnr_date = f'{birthday:{yr_fmt}%m%d}'
         chk_date = pnr_date[2:] if long else pnr_date
-        suffix = str(self.generator.random.randrange(0, 999)).zfill(3)
+        suffix = f'{self.generator.random.randrange(0, 999):03}'
         luhn_checksum = str(calculate_luhn(chk_date + suffix))
         hyphen = '-' if dash else ''
-        pnr = '{}{}{}{}'.format(pnr_date, hyphen, suffix, luhn_checksum)
+        pnr = f'{pnr_date}{hyphen}{suffix}{luhn_checksum}'
 
         return pnr
 
@@ -61,7 +61,7 @@ class Provider(SsnProvider):
         prefix = '16' if long else ''
         hyphen = '-' if dash else ''
 
-        org_id = '{}{}{}{}{}'.format(prefix, onr_one, hyphen, onr_two, luhn_checksum)
+        org_id = f'{prefix}{onr_one}{hyphen}{onr_two}{luhn_checksum}'
         return org_id
 
     def vat_id(self):

--- a/faker/providers/ssn/th_TH/__init__.py
+++ b/faker/providers/ssn/th_TH/__init__.py
@@ -27,9 +27,7 @@ class Provider(BaseProvider):
         birth_book = randint(1, 99999)
         birth_sheet = randint(1, 99)
 
-        digits = "{:01d}{:02d}{:02d}{:05d}{:02d}".format(
-            category, province, amphoe, birth_book, birth_sheet,
-        )
+        digits = f'{category:01d}{province:02d}{amphoe:02d}{birth_book:05d}{birth_sheet:02d}'
         checksum = (
             (int(digits[0]) * 13)
             + (int(digits[1]) * 12)
@@ -49,9 +47,7 @@ class Provider(BaseProvider):
         if checksum > 9:
             checksum = checksum - 10
 
-        nat_id = "{:01d}-{:02d}{:02d}-{:05d}-{:02d}-{:01d}".format(
-            category, province, amphoe, birth_book, birth_sheet, checksum,
-        )
+        nat_id = f'{category:01d}-{province:02d}{amphoe:02d}-{birth_book:05d}-{birth_sheet:02d}-{checksum:01d}'
 
         return nat_id
 

--- a/faker/providers/ssn/tr_TR/__init__.py
+++ b/faker/providers/ssn/tr_TR/__init__.py
@@ -14,5 +14,5 @@ class Provider(BaseProvider):
         """
         first_part = self.random_element((1, 2, 3, 4, 5, 6, 7, 8, 9))
         middle_part = self.bothify('#########')
-        last_part = sum(list(map(lambda x: int(x), '{}{}'.format(first_part, middle_part)))) % 10
-        return '{}{}{}'.format(first_part, middle_part, last_part)
+        last_part = sum(int(x) for x in f'{first_part}{middle_part}') % 10
+        return f'{first_part}{middle_part}{last_part}'

--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -53,8 +53,7 @@ class Provider(BaseProvider):
     def chrome(self, version_from=13, version_to=63,
                build_from=800, build_to=899):
         """Generate a Chrome web browser user agent string."""
-        saf = '{}.{}'.format(self.generator.random.randint(531, 536),
-                             self.generator.random.randint(0, 2))
+        saf = f'{self.generator.random.randint(531, 536)}.{self.generator.random.randint(0, 2)}'
         bld = self.lexify(self.numerify('##?###'), string.ascii_uppercase)
         tmplt = '({0}) AppleWebKit/{1} (KHTML, like Gecko)' \
                 ' Chrome/{2}.0.{3}.0 Safari/{4}'
@@ -93,20 +92,11 @@ class Provider(BaseProvider):
     def firefox(self):
         """Generate a Mozilla Firefox web browser user agent string."""
         ver = (
-            'Gecko/{} Firefox/{}.0'.format(
-                self.generator.date_time_between(
-                    datetime(2011, 1, 1),
-                ),
-                self.generator.random.randint(4, 15),
-            ),
-            'Gecko/{} Firefox/3.6.{}'.format(
-                self.generator.date_time_between(
-                    datetime(2010, 1, 1),
-                ),
-                self.generator.random.randint(1, 20)),
-            'Gecko/{} Firefox/3.8'.format(
-                self.generator.date_time_between(datetime(2010, 1, 1)),
-            ),
+            (f'Gecko/{self.generator.date_time_between(datetime(2011, 1, 1))} '
+             f'Firefox/{self.generator.random.randint(4, 15)}.0'),
+            (f'Gecko/{self.generator.date_time_between(datetime(2010, 1, 1))} '
+             f'Firefox/3.6.{self.generator.random.randint(1, 20)}'),
+            f'Gecko/{self.generator.date_time_between(datetime(2010, 1, 1))} Firefox/3.8',
         )
         tmplt_win = '({0}; {1}; rv:1.9.{2}.20) {3}'
         tmplt_lin = '({0}; rv:1.9.{1}.20) {2}'
@@ -141,15 +131,13 @@ class Provider(BaseProvider):
 
     def safari(self):
         """Generate a Safari web browser user agent string."""
-        saf = "{}.{}.{}".format(self.generator.random.randint(531, 535),
-                                self.generator.random.randint(1, 50),
-                                self.generator.random.randint(1, 7))
+        saf = (f'{self.generator.random.randint(531, 535)}.'
+               f'{self.generator.random.randint(1, 50)}.'
+               f'{self.generator.random.randint(1, 7)}')
         if not self.generator.random.getrandbits(1):
-            ver = "{}.{}".format(self.generator.random.randint(4, 5),
-                                 self.generator.random.randint(0, 1))
+            ver = f'{self.generator.random.randint(4, 5)}.{self.generator.random.randint(0, 1)}'
         else:
-            ver = "{}.0.{}".format(self.generator.random.randint(4, 5),
-                                   self.generator.random.randint(1, 5))
+            ver = f'{self.generator.random.randint(4, 5)}.0.{self.generator.random.randint(1, 5)}'
         tmplt_win = '(Windows; U; {0}) AppleWebKit/{1} (KHTML, like Gecko)' \
                     ' Version/{2} Safari/{3}'
         tmplt_mac = '({0} rv:{1}.0; {2}) AppleWebKit/{3} (KHTML, like Gecko)' \
@@ -182,29 +170,17 @@ class Provider(BaseProvider):
 
     def opera(self):
         """Generate an Opera web browser user agent string."""
-        platform = '({}; {}) Presto/2.9.{} Version/{}.00'.format(
-            (
-                self.linux_platform_token()
-                if self.generator.random.getrandbits(1)
-                else self.windows_platform_token()
-            ),
-            self.generator.locale().replace('_', '-'),
-            self.generator.random.randint(160, 190),
-            self.generator.random.randint(10, 12),
-        )
-        return 'Opera/{}.{}.{}'.format(
-            self.generator.random.randint(8, 9),
-            self.generator.random.randint(10, 99),
-            platform,
-        )
+        token = self.linux_platform_token() if self.generator.random.getrandbits(1) else self.windows_platform_token()
+        locale = self.generator.locale().replace('_', '-')
+        platform = (f'({token}; {locale}) Presto/2.9.{self.generator.random.randint(160, 190)} '
+                    f'Version/{self.generator.random.randint(10, 12)}.00')
+        return f'Opera/{self.generator.random.randint(8, 9)}.{self.generator.random.randint(10, 99)}.{platform}'
 
     def internet_explorer(self):
         """Generate an IE web browser user agent string."""
-        tmplt = 'Mozilla/5.0 (compatible; MSIE {0}.0; {1}; Trident/{2}.{3})'
-        return tmplt.format(self.generator.random.randint(5, 9),
-                            self.windows_platform_token(),
-                            self.generator.random.randint(3, 5),
-                            self.generator.random.randint(0, 1))
+        return (f'Mozilla/5.0 (compatible; MSIE {self.generator.random.randint(5, 9)}.0; '
+                f'{self.windows_platform_token()}; '
+                f'Trident/{self.generator.random.randint(3, 5)}.{self.generator.random.randint(0, 1)})')
 
     def windows_platform_token(self):
         """Generate a Windows platform token used in user agent strings."""
@@ -212,24 +188,19 @@ class Provider(BaseProvider):
 
     def linux_platform_token(self):
         """Generate a Linux platform token used in user agent strings."""
-        return 'X11; Linux {}'.format(
-            self.random_element(self.linux_processors))
+        return f'X11; Linux {self.random_element(self.linux_processors)}'
 
     def mac_platform_token(self):
         """Generate a MacOS platform token used in user agent strings."""
-        return 'Macintosh; {} Mac OS X 10_{}_{}'.format(
-            self.random_element(self.mac_processors),
-            self.generator.random.randint(5, 12),
-            self.generator.random.randint(0, 9),
-        )
+        return (f'Macintosh; {self.random_element(self.mac_processors)} Mac OS X 10 '
+                f'{self.generator.random.randint(5, 12)}_{self.generator.random.randint(0, 9)}')
 
     def android_platform_token(self):
         """Generate an Android platform token used in user agent strings."""
-        return 'Android {}'.format(self.random_element(self.android_versions))
+        return f'Android {self.random_element(self.android_versions)}'
 
     def ios_platform_token(self):
         """Generate an iOS platform token used in user agent strings."""
-        return '{0}; CPU {0} OS {1} like Mac OS X'.format(
-            self.random_element(self.apple_devices),
-            self.random_element(self.ios_versions).replace('.', '_'),
-        )
+        apple_device = self.random_element(self.apple_devices)
+        return (f'{apple_device}; CPU {apple_device} '
+                f'OS {self.random_element(self.ios_versions).replace(".", "_")} like Mac OS X')

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -127,7 +127,7 @@ class Faker:
 
         factories, weights = self._map_provider_method(method_name)
         if len(factories) == 0:
-            msg = "No generator object has attribute '{}'".format(method_name)
+            msg = f'No generator object has attribute {method_name!r}'
             raise AttributeError(msg)
         elif len(factories) == 1:
             return factories[0]
@@ -150,7 +150,7 @@ class Faker:
         """
 
         # Return cached mapping if it exists for given method
-        attr = '_cached_{}_mapping'.format(method_name)
+        attr = f'_cached_{method_name}_mapping'
         if hasattr(self, attr):
             return getattr(self, attr)
 
@@ -282,7 +282,7 @@ class UniqueProxy:
                     break
                 retval = function(*args, **kwargs)
             else:
-                raise UniquenessException("Got duplicated values after {0:,} iterations.".format(_UNIQUE_ATTEMPTS))
+                raise UniquenessException(f'Got duplicated values after {_UNIQUE_ATTEMPTS:,} iterations.')
 
             generated.add(retval)
 

--- a/faker/sphinx/docstring.py
+++ b/faker/sphinx/docstring.py
@@ -60,9 +60,7 @@ class ProviderMethodDocstring:
         self._parsed_lines = []
         self._samples = []
         self._skipped = True
-        self._log_prefix = '{path}:docstring of {name}: WARNING:'.format(
-            path=inspect.getfile(obj), name=name,
-        )
+        self._log_prefix = f'{inspect.getfile(obj)}:docstring of {name}: WARNING:'
 
         if what != 'method':
             return
@@ -90,8 +88,7 @@ class ProviderMethodDocstring:
         self._generate_samples()
 
     def _log_warning(self, warning):
-        msg = '{prefix} {warning}'.format(prefix=self._log_prefix, warning=warning)
-        logger.warning(msg)
+        logger.warning(f'{self._log_prefix} {warning}')
 
     def _parse(self):
         while True:
@@ -137,7 +134,7 @@ class ProviderMethodDocstring:
 
         # Discard sample section if malformed
         if not match:
-            msg = 'The section `{section}` is malformed and will be discarded.'.format(section=section)
+            msg = f'The section `{section}` is malformed and will be discarded.'
             self._log_warning(msg)
             return
 
@@ -197,10 +194,8 @@ class ProviderMethodDocstring:
             validator = SampleCodeValidator(command)
             if validator.errors:
                 msg = (
-                    'Invalid code elements detected. Sample generation will be '
-                    'skipped for method `{method}` with arguments `{kwargs}`.'
-                ).format(
-                    method=self._method, kwargs=sample.kwargs,
+                    f'Invalid code elements detected. Sample generation will be '
+                    f'skipped for method `{self._method}` with arguments `{sample.kwargs}`.'
                 )
                 self._log_warning(msg)
                 continue
@@ -212,9 +207,7 @@ class ProviderMethodDocstring:
                     for _ in range(sample.size)
                 ])
             except Exception:
-                msg = 'Sample generation failed for method `{method}` with arguments `{kwargs}`.'.format(
-                    method=self._method, kwargs=sample.kwargs,
-                )
+                msg = f'Sample generation failed for method `{self._method}` with arguments `{sample.kwargs}`.'
                 self._log_warning(msg)
                 continue
             else:

--- a/faker/sphinx/documentor.py
+++ b/faker/sphinx/documentor.py
@@ -44,13 +44,13 @@ def _get_localized_provider_info(locale):
     info = []
     for provider_name in STANDARD_PROVIDER_NAMES:
         try:
-            locale_module_path = '{}.{}'.format(provider_name, locale)
+            locale_module_path = f'{provider_name}.{locale}'
             locale_module = importlib.import_module(locale_module_path)
             provider = getattr(locale_module, 'Provider')
         except (ModuleNotFoundError, AttributeError):
             continue
         else:
-            provider_class = '{}.Provider'.format(provider.__module__)
+            provider_class = f'{provider.__module__}.Provider'
             info.append((provider_class, provider_name))
     return info
 
@@ -69,7 +69,7 @@ def _write_title(fh, title, level=1):
     if level <= 2:
         _write(fh, SECTION_ADORNMENTS[level - 1] * len(title))
         _write(fh, '\n')
-    _write(fh, '{}\n'.format(title))
+    _write(fh, f'{title}\n')
     _write(fh, SECTION_ADORNMENTS[level - 1] * len(title))
     _write(fh, '\n\n')
 
@@ -87,7 +87,7 @@ def _write_standard_provider_index():
         _write(fh, '   :maxdepth: 2\n\n')
         _write(fh, '   providers/baseprovider\n')
         for provider_name in STANDARD_PROVIDER_NAMES:
-            _write(fh, '   providers/{}\n'.format(provider_name))
+            _write(fh, f'   providers/{provider_name}\n')
 
 
 def _write_base_provider_docs():
@@ -103,11 +103,11 @@ def _write_base_provider_docs():
 
 def _write_standard_provider_docs():
     for provider_name in STANDARD_PROVIDER_NAMES:
-        with (DOCS_ROOT / 'providers' / '{}.rst'.format(provider_name)) as fh:
-            provider_class = '{}.Provider'.format(provider_name)
+        with (DOCS_ROOT / 'providers' / f'{provider_name}.rst') as fh:
+            provider_class = f'{provider_name}.Provider'
             provider_methods = _get_provider_methods(provider_class)
             _hide_edit_on_github(fh)
-            _write_title(fh, '``{}``'.format(provider_name))
+            _write_title(fh, f'``{provider_name}``')
             _write_includes(fh)
             _write(fh, PROVIDER_AUTODOC_TEMPLATE.format(
                 provider_class=provider_class,
@@ -122,7 +122,7 @@ def _write_localized_provider_index():
         _write(fh, '.. toctree::\n')
         _write(fh, '   :maxdepth: 2\n\n')
         for locale in AVAILABLE_LOCALES:
-            _write(fh, '   locales/{}\n'.format(locale))
+            _write(fh, f'   locales/{locale}\n')
 
 
 def _write_localized_provider_docs():
@@ -130,11 +130,11 @@ def _write_localized_provider_docs():
         info = _get_localized_provider_info(locale)
         with (DOCS_ROOT / 'locales' / '{}.rst'.format(locale)).open('wb') as fh:
             _hide_edit_on_github(fh)
-            _write_title(fh, 'Locale {}'.format(locale))
+            _write_title(fh, f'Locale {locale}')
             _write_includes(fh)
             for provider_class, standard_provider_name in info:
                 provider_methods = _get_provider_methods(provider_class)
-                _write_title(fh, '``{}``'.format(standard_provider_name), level=2)
+                _write_title(fh, f'``{standard_provider_name}``', level=2)
                 _write(fh, PROVIDER_AUTODOC_TEMPLATE.format(
                     provider_class=provider_class,
                     provider_methods=provider_methods,

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -13,7 +13,7 @@ class TestBaseProvider:
 
     def test_locale(self, faker, num_samples):
         locales = [
-            '{}_{}'.format(language, region)
+            f'{language}_{region}'
             for language, regions in BaseProvider.language_locale_codes.items()
             for region in regions
         ]
@@ -218,7 +218,7 @@ class TestBaseProvider:
         for _ in range(num_samples):
             res = faker.randomize_nb_elements(number=number, le=True)
             assert res >= lower_bound
-            assert res <= number, "'{}' is not <= than '{}'".format(res, number)
+            assert res <= number, f'{res!r} is not <= than {number!r}'
 
         for _ in range(num_samples):
             res = faker.randomize_nb_elements(number=number, ge=True)

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -19,7 +19,7 @@ def _class_locale_faker(request):
     match = LOCALE_TEST_CLASS_NAME_REGEX.fullmatch(class_name)
     if not match:
         return None
-    locale = '{language}_{region}'.format(**match.groupdict())
+    locale = f'{match.group("language")}_{match.group("region")}'
     locale = pylocale.normalize(locale).split('.')[0]
     return Faker(locale=locale)
 

--- a/tests/providers/test_barcode.py
+++ b/tests/providers/test_barcode.py
@@ -72,8 +72,8 @@ def provider_class(request):
         _provider_class = request.cls.get_provider_class()
         if isinstance(_provider_class, type):
             return _provider_class
-    raise NotImplementedError("Using the provider_class requires {}.get_provider_class() to be present, which has to "
-                              "return the Provider class it uses.".format(request.cls.__name__))
+    raise NotImplementedError(f'Using the provider_class requires {request.cls.__name__}.get_provider_class() '
+                              'to be present, which has to return the Provider class it uses.')
 
 
 @pytest.fixture()
@@ -90,10 +90,9 @@ class _LocaleCommonMixin:
         for prefix in prefixes:
             if all(a == b for a, b in zip(barcode_digits, map(int, prefix))):
                 return
-        raise AssertionError("{} doesn't match any of the prefixes: {}".format(
-            ''.join(map(str, barcode_digits)),
-            ', '.join(map(lambda _prefix: ''.join(map(str, _prefix)), prefixes)),
-        ))
+        str_barc = ''.join(str(x) for x in barcode_digits)
+        str_pref = ', '.join(map(lambda _prefix: ''.join(str(x) for x in _prefix)), prefixes)
+        raise AssertionError(f"{str_barc} doesn't match any of the prefixes: {str_pref}")
 
     def test_localized_ean(self, faker, num_samples, provider):
         for _ in range(num_samples):
@@ -167,7 +166,7 @@ class _LocaleNorthAmericaMixin(_LocaleCommonMixin):
         # so we do not have to wait for RNG to produce the right combinations.
         for _ in range(100):
             # Be aware that there are other unsafe combinations
-            unsafe_base = '{:02}000{}'.format(faker.random_int(0, 99), faker.random_int(3, 4))
+            unsafe_base = f'{faker.random_int(0, 99):02}000{faker.random_int(3, 4)}'
             safe_base = unsafe_base[:2] + '0000'
             number_system_digit = faker.random_int(0, 1)
 

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -61,7 +61,7 @@ class TestInternetProvider:
         my_width = 500
         my_height = 1024
         url = faker.image_url(my_width, my_height)
-        assert 'https://dummyimage.com/{}x{}'.format(my_width, my_height) == url
+        assert f'https://dummyimage.com/{my_width}x{my_height}' == url
         url = faker.image_url()
         assert 'https://dummyimage.com/' in url
 
@@ -105,8 +105,8 @@ class TestInternetProvider:
             if address_class is None:
                 networks_attr = '_cached_all_networks'
             else:
-                networks_attr = '_cached_all_class_{}_networks'.format(address_class)
-            weights_attr = '{}_weights'.format(networks_attr)
+                networks_attr = f'_cached_all_class_{address_class}_networks'
+            weights_attr = f'{networks_attr}_weights'
             provider = InternetProvider(faker)
 
             # First, test cache creation
@@ -168,8 +168,8 @@ class TestInternetProvider:
         from faker.providers.internet import _IPv4Constants
 
         for address_class in _IPv4Constants._network_classes.keys():
-            networks_attr = '_cached_public_class_{}_networks'.format(address_class)
-            weights_attr = '{}_weights'.format(networks_attr)
+            networks_attr = f'_cached_public_class_{address_class}_networks'
+            weights_attr = f'{networks_attr}_weights'
             provider = InternetProvider(faker)
 
             # First, test cache creation
@@ -308,7 +308,7 @@ class TestInternetProviderUrl:
 
     @staticmethod
     def is_correct_scheme(url, schemes):
-        return any(url.startswith('{}://'.format(scheme)) for scheme in schemes)
+        return any(url.startswith(f'{scheme}://') for scheme in schemes)
 
     def test_url_default_schemes(self, faker):
         for _ in range(100):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -60,7 +60,7 @@ class TestSvSE(unittest.TestCase):
             return False
 
         try:
-            if date_str != datetime.strptime(date_str, '{}%m%d'.format(year_fmt)).strftime('{}%m%d'.format(year_fmt)):
+            if date_str != datetime.strptime(date_str, f'{year_fmt}%m%d').strftime(f'{year_fmt}%m%d'):
                 raise ValueError
             return True
         except ValueError:
@@ -758,10 +758,9 @@ class TestHuHU(unittest.TestCase):
             assert len(ssn) <= 12
 
         for _ in range(100):
-            dob_val = '{:02d}{:02d}{:02d}'.format(
-                self.fake.random_int(0, 99),
-                self.fake.random_int(1, 12),
-                self.fake.random_int(1, 31))
+            dob_val = (f'{self.fake.random_int(0, 99):02d}'
+                       f'{self.fake.random_int(1, 12):02d}'
+                       f'{self.fake.random_int(1, 31):02d}')
             dob = self.fake.random.choice([None, dob_val])
             gender = self.fake.random.choice([None, 'F', 'M', 'z'])
             try:
@@ -976,7 +975,7 @@ class TestTrTr(unittest.TestCase):
         for sample in self.samples:
             first_ten_number = sample[:-1]
             last_part = sample[-1]
-            assert sum(list(map(lambda x: int(x), '{}'.format(first_ten_number)))) % 10 == last_part
+            assert sum(int(x) for x in f'{first_ten_number}') % 10 == last_part
 
 
 class TestEnIn(unittest.TestCase):

--- a/tests/pytest/session_overrides/conftest.py
+++ b/tests/pytest/session_overrides/conftest.py
@@ -4,9 +4,9 @@ import pytest
 
 EXCLUSIVE_SESSION_FLAG = '--exclusive-faker-session'
 SKIP_REASON = (
-    'This test is skipped by default since it depends on changes in the behavior of session-scoped fixtures. '
-    'Use a separate pytest run for tests like this with the "{flag}" flag specified.'
-).format(flag=EXCLUSIVE_SESSION_FLAG)
+    f'This test is skipped by default since it depends on changes in the behavior of session-scoped fixtures. '
+    f'Use a separate pytest run for tests like this with the "{EXCLUSIVE_SESSION_FLAG}" flag specified.'
+)
 
 
 def pytest_addoption(parser):

--- a/tests/sphinx/test_docstring.py
+++ b/tests/sphinx/test_docstring.py
@@ -63,7 +63,7 @@ class TestProviderMethodDocstring:
         docstring._log_warning('Test Warning 1')
         docstring._log_warning('Test Warning 2')
 
-        assert docstring._log_prefix == '{path}:docstring of {name}: WARNING:'.format(path=path, name=name)
+        assert docstring._log_prefix == f'{path}:docstring of {name}: WARNING:'
 
         calls = mock_logger_warning.call_args_list
         assert len(calls) == 2
@@ -72,13 +72,13 @@ class TestProviderMethodDocstring:
         args, kwargs = calls[0]
         assert len(args) == 1
         assert not kwargs
-        assert args[0] == '{path}:docstring of {name}: WARNING: Test Warning 1'.format(path=path, name=name)
+        assert args[0] == f'{path}:docstring of {name}: WARNING: Test Warning 1'
 
         # 2nd call to logger.warning
         args, kwargs = calls[1]
         assert len(args) == 1
         assert not kwargs
-        assert args[0] == '{path}:docstring of {name}: WARNING: Test Warning 2'.format(path=path, name=name)
+        assert args[0] == f'{path}:docstring of {name}: WARNING: Test Warning 2'
 
     def test_stringify_results(self, faker):
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -37,12 +37,12 @@ class TestGenerator:
     def test_get_formatter_with_unknown_formatter(self, generator):
         with pytest.raises(AttributeError) as excinfo:
             generator.get_formatter('barFormatter')
-        assert str(excinfo.value) == 'Unknown formatter "barFormatter"'
+        assert str(excinfo.value) == "Unknown formatter 'barFormatter'"
 
         fake = Faker('it_IT')
         with pytest.raises(AttributeError) as excinfo:
             fake.get_formatter('barFormatter')
-        assert str(excinfo.value) == 'Unknown formatter "barFormatter" with locale "it_IT"'
+        assert str(excinfo.value) == "Unknown formatter 'barFormatter' with locale 'it_IT'"
 
     def test_format_calls_formatter_on_provider(self, generator):
         assert generator.format('foo_formatter') == 'foobar'
@@ -95,12 +95,12 @@ class TestGenerator:
     def test_parse_with_unknown_arguments_group(self, generator):
         with pytest.raises(AttributeError) as excinfo:
             generator.parse('This is "{{foo_formatter_with_arguments:unknown}}"')
-        assert str(excinfo.value) == 'Unknown argument group "unknown"'
+        assert str(excinfo.value) == "Unknown argument group 'unknown'"
 
     def test_parse_with_unknown_formatter_token(self, generator):
         with pytest.raises(AttributeError) as excinfo:
             generator.parse('{{barFormatter}}')
-        assert str(excinfo.value) == 'Unknown formatter "barFormatter"'
+        assert str(excinfo.value) == "Unknown formatter 'barFormatter'"
 
     def test_magic_call_calls_format(self, generator):
         assert generator.foo_formatter() == 'foobar'


### PR DESCRIPTION
We are at Python 3.6+, so replace (most) string formatting with f-strings.
This is based on the current master, so some file names built in #1339 will be added after their merge and this rebase. 