### PR TITLE
FW and JSON Improvements

### DIFF
--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -477,11 +477,13 @@ class TestMiscProvider:
 
         assert isinstance(json_data, list) and len(json_data) == 2
 
-    def test_json_passthrough_int_float(self, faker_with_foobar):
+    def test_json_passthrough_values(self, faker_with_foobar):
         kwargs = {
             'data_columns': {
                 'item1': 1,
                 'item2': 1.0,
+                'item3': True,
+                'item4': '@fixed',
             },
             'num_rows': 1,
         }
@@ -489,6 +491,8 @@ class TestMiscProvider:
 
         assert json_data['item1'] == 1
         assert json_data['item2'] == 1.0
+        assert json_data['item3']
+        assert json_data['item4'] == 'fixed'
 
     def test_json_type_integrity_int(self, faker_with_foobar):
         kwargs = {

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -491,7 +491,7 @@ class TestMiscProvider:
 
         assert json_data['item1'] == 1
         assert json_data['item2'] == 1.0
-        assert json_data['item3']
+        assert json_data['item3'] is True
         assert json_data['item4'] == 'fixed'
 
     def test_json_type_integrity_int(self, faker_with_foobar):


### PR DESCRIPTION
### What does this changes
The Format Value Selector was a bit clunky, and needed some updating.  It now allows for strings to be fixed or pinned to a static value by using '@', to begin with.

**Example:**
```python
fake.json({"Spec": "@2.1b", "Source": "@host.example.com", "ID": "pyint:min-max"})
```
This will fix the values Spec, and Source, so they are not generated, but the ID will using the parameter group 'min-max'

### What was wrong
Because values in JSON can be non-string types, like integer, float, and boolean, it's important that PyStr selected only when needed.  This is the role of the value format selector.

**Example:**
```python
fake.json({"ID": "{{ pyint }}"})  # This returns a string value with quotes in the JSON
fake.json({"ID": "pyint"})         # This returns a integer value without quotes in the JSON.
```
The down fall of this though is when you need data with fixed values in some fields for things like event specification values to a Data Stream.  The JSON provider lacked an easy and obvious way to do this.