### PR TITLE
fix: typo faker_locale -> faker_seed in pytest-fixtures,rst

### DIFF
--- a/docs/pytest-fixtures.rst
+++ b/docs/pytest-fixtures.rst
@@ -117,7 +117,7 @@ selection logic.
 
 Like briefly mentioned above, defining an autouse session-scoped ``faker_seed`` fixture will affect
 all relevant tests in the session, but if you want to use a certain seed for a specific set of tests
-and just like ``faker_locale``, you will just need to define and activate a ``faker_locale`` fixture
+and just like ``faker_locale``, you will just need to define and activate a ``faker_seed`` fixture
 in the appropriate place in accordance to how ``pytest`` handles fixtures. For example, if you declare
 this in a submodule's ``conftest.py``, the ``faker`` fixture will return an instance seeded using
 ``12345`` for all relevant tests under that submodule.


### PR DESCRIPTION
### What does this changes

fix a typo mistake

### What was wrong

document mention **faker_locale** but it should be **faker_seed** instead

### How this fixes it

changed text to fix.
