### PR TITLE
Close #1367. Fix lorem provider `sentence` method

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -22,7 +22,7 @@ class Provider(BaseProvider):
     sentence_punctuation = '.'
 
     def words(self, nb=3, ext_word_list=None, unique=False):
-        """Generate a list of words.
+        """Generate a tuple of words.
 
         The ``nb`` argument controls the number of words in the resulting list,
         and if ``ext_word_list`` is provided, words from that list will be used
@@ -82,7 +82,7 @@ class Provider(BaseProvider):
         if variable_nb_words:
             nb_words = self.randomize_nb_elements(nb_words, min=1)
 
-        words = self.words(nb=nb_words, ext_word_list=ext_word_list)
+        words = list(self.words(nb=nb_words, ext_word_list=ext_word_list))
         words[0] = words[0].title()
 
         return self.word_connector.join(words) + self.sentence_punctuation

--- a/tests/providers/test_lorem.py
+++ b/tests/providers/test_lorem.py
@@ -88,6 +88,10 @@ class TestLoremProvider:
                 words = sentence.lower().replace('.', '').split()
                 assert all(isinstance(word, str) and word in self.custom_word_list for word in words)
 
+    def test_sentence_single_word(self, faker):
+        word = faker.sentence(1)
+        assert str.isupper(word[0])
+
     def test_paragraph_no_sentences(self, faker, num_samples):
         for _ in range(num_samples):
             assert faker.paragraph(0) == ''


### PR DESCRIPTION
### What does this changes

Cast the result of `words` in the `sentence` provider to a list.

### What was wrong

The `sentence` provider was trying to modify a tuple.

### How this fixes it

By casting to a list before mutating, we still keep the performance of having `words` returning a tuple.

Fixes #1367
