### PR TITLE
Remove redundant Python 2 int/float conversions

### DIFF
--- a/faker/providers/color/color.py
+++ b/faker/providers/color/color.py
@@ -272,11 +272,7 @@ class RandomColor:
         h = 1 if h == 0 else h
         h = 359 if h == 360 else h
 
-        h = float(h)/360
-        s = float(s)/100
-        v = float(v)/100
-
-        rgb = colorsys.hsv_to_rgb(h, s, v)
+        rgb = colorsys.hsv_to_rgb(h / 360, s / 100, v / 100)
         return (int(c * 255) for c in rgb)
 
     @classmethod
@@ -288,8 +284,8 @@ class RandomColor:
         """
         h, s, v = hsv
 
-        s = float(s)/100
-        v = float(v)/100
+        s = s / 100
+        v = v / 100
         l = 0.5 * v * (2 - s)   # noqa: E741
 
         if l in [0, 1]:

--- a/faker/providers/geo/__init__.py
+++ b/faker/providers/geo/__init__.py
@@ -979,7 +979,7 @@ class Provider(BaseProvider):
         Optionally center the coord and pick a point within radius.
         """
         if center is None:
-            return Decimal(str(self.generator.random.randint(-180000000, 180000000) / 1000000.0)).quantize(
+            return Decimal(str(self.generator.random.randint(-180000000, 180000000) / 1000000)).quantize(
                 Decimal(".000001"),
             )
         else:

--- a/faker/providers/geo/el_GR/__init__.py
+++ b/faker/providers/geo/el_GR/__init__.py
@@ -18,9 +18,9 @@ class Provider(GeoProvider):
     def local_latitude(self):
         latitudes = list(map(lambda t: int(t[0] * 10000000), self.poly))
         return Decimal(str(self.generator.random.randint(
-            min(latitudes), max(latitudes)) / 10000000.0)).quantize(Decimal('.000001'))
+            min(latitudes), max(latitudes)) / 10000000)).quantize(Decimal('.000001'))
 
     def local_longitude(self):
         longitudes = list(map(lambda t: int(t[1] * 10000000), self.poly))
         return Decimal(str(self.generator.random.randint(
-            min(longitudes), max(longitudes)) / 10000000.0)).quantize(Decimal('.000001'))
+            min(longitudes), max(longitudes)) / 10000000)).quantize(Decimal('.000001'))

--- a/faker/utils/distribution.py
+++ b/faker/utils/distribution.py
@@ -40,7 +40,7 @@ def choices_distribution_unique(
     for i in range(length):
         cdf = tuple(cumsum(probabilities))
         normal = cdf[-1]
-        cdf2 = [float(i) / float(normal) for i in cdf]
+        cdf2 = [i / normal for i in cdf]
         uniform_sample = random_sample(random=random)
         idx = bisect.bisect_right(cdf2, uniform_sample)
         item = items[idx]
@@ -72,7 +72,7 @@ def choices_distribution(
 
         cdf = list(cumsum(p))
         normal = cdf[-1]
-        cdf2 = [float(i) / float(normal) for i in cdf]
+        cdf2 = [i / normal for i in cdf]
         for i in range(length):
             uniform_sample = random_sample(random=random)
             idx = bisect.bisect_right(cdf2, uniform_sample)

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -438,13 +438,13 @@ class TestDateTime(unittest.TestCase):
 
         td = timedelta(days=7)
         seconds = Provider._parse_timedelta(td)
-        assert seconds == 604800.0
+        assert seconds == 604800
 
         seconds = Provider._parse_timedelta('+1w')
-        assert seconds == 604800.0
+        assert seconds == 604800
 
         seconds = Provider._parse_timedelta('+1y')
-        assert seconds == 31556736.0
+        assert seconds == 31556736
 
         with pytest.raises(ValueError):
             Provider._parse_timedelta('foobar')

--- a/tests/providers/test_geo.py
+++ b/tests/providers/test_geo.py
@@ -59,7 +59,7 @@ class TestEnUS(unittest.TestCase):
 
     def test_coordinate_rounded(self):
         loc = self.fake.coordinate(center=23, radius=3)
-        assert round(loc) >= 20 <= 26
+        assert 20 <= round(loc) <= 26
 
     def test_location_on_land(self):
         loc = self.fake.location_on_land()


### PR DESCRIPTION
### What does this changes

Remove some useless int/float conversions from the code.

### What was wrong

`a / b` for two integers always returns a float in Python 3, so there's no need to convert `a` or `b` to a `float` beforehand. 

### How this fixes it

There's less astonishment for someone who has never seen Python 2 code before.