### PR TITLE
Fix coveralls in GitHub workflow

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
         # Run tox using the version of Python in `PATH`
         run: tox -e py
       - name: Publish coverage
-        run: coveralls
+        run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
### What does this changes

set `coveralls --service=github` in GitHub action for test-ubuntu

### What was wrong

coveralls does not working

### How this fixes it

set `coveralls --service=github`
according to https://github.com/TheKevJames/coveralls-python/issues/251
