### PR TITLE
Add current_country, current_country_code and administrative_unit

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 
 
 class Documentor:
@@ -86,7 +87,8 @@ class Documentor:
             try:
                 # make a fake example
                 example = self.generator.format(name, *faker_args, **faker_kwargs)
-            except (AttributeError, ValueError):
+            except (AttributeError, ValueError) as e:
+                warnings.warn(str(e))
                 continue
             formatters[signature] = example
 

--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -83,9 +83,11 @@ class Documentor:
             # build fake method signature
             signature = f"{prefix}{name}({', '.join(arguments)})"
 
-            # make a fake example
-            example = self.generator.format(name, *faker_args, **faker_kwargs)
-
+            try:
+                # make a fake example
+                example = self.generator.format(name, *faker_args, **faker_kwargs)
+            except (AttributeError, ValueError):
+                continue
             formatters[signature] = example
 
             self.max_name_len = max(self.max_name_len, len(signature))

--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -82,3 +82,21 @@ class Provider(BaseProvider):
             return self.random_element(self.alpha_3_country_codes)
         else:
             raise ValueError("`representation` must be one of `alpha-2` or `alpha-3`.")
+
+    def current_country_code(self):
+        try:
+            return self.__lang__.split("_")[1]
+        except IndexError:
+            raise AttributeError("Country code cannot be determined from locale")
+
+    def current_country(self):
+        current_country_code = self.current_country_code()
+        current_country = [tz['name']
+                           for tz in date_time.Provider.countries
+                           if tz['alpha-2-code'] == current_country_code]
+        if len(current_country) == 1:
+            return current_country[0]
+        elif len(current_country) > 1:
+            raise ValueError(f"Ambiguous country for country code {current_country_code}: {current_country}")
+        else:
+            raise ValueError(f"No appropriate country for country code {current_country_code}")

--- a/faker/providers/address/cs_CZ/__init__.py
+++ b/faker/providers/address/cs_CZ/__init__.py
@@ -760,8 +760,10 @@ class Provider(AddressProvider):
     def street_name(self):
         return self.random_element(self.streets)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def city_with_postcode(self):
         return self.postcode() + " " + self.random_element(self.cities)

--- a/faker/providers/address/da_DK/__init__.py
+++ b/faker/providers/address/da_DK/__init__.py
@@ -103,5 +103,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/de_AT/__init__.py
+++ b/faker/providers/address/de_AT/__init__.py
@@ -79,8 +79,10 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def city_with_postcode(self):
         pattern = self.random_element(self.city_with_postcode_formats)

--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -122,8 +122,10 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def city_with_postcode(self):
         pattern = self.random_element(self.city_with_postcode_formats)

--- a/faker/providers/address/el_GR/__init__.py
+++ b/faker/providers/address/el_GR/__init__.py
@@ -75,8 +75,10 @@ class Provider(AddressProvider):
     def city(self):
         return self.random_element(self.cities)
 
-    def region(self):
+    def administrative_unit(self):
         return self.random_element(self.regions)
+
+    region = administrative_unit
 
     # Ονόματα πρωτευουσών νομών
     cities = (

--- a/faker/providers/address/en_AU/__init__.py
+++ b/faker/providers/address/en_AU/__init__.py
@@ -131,8 +131,10 @@ class Provider(AddressProvider):
             self.random_element(
                 self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def state_abbr(self):
         return self.random_element(self.states_abbr)

--- a/faker/providers/address/en_CA/__init__.py
+++ b/faker/providers/address/en_CA/__init__.py
@@ -305,10 +305,12 @@ class Provider(AddressProvider):
     )
     secondary_address_formats = ('Apt. ###', 'Suite ###')
 
-    def province(self):
+    def administrative_unit(self):
         """
         """
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def province_abbr(self):
         return self.random_element(self.provinces_abbr)

--- a/faker/providers/address/en_GB/__init__.py
+++ b/faker/providers/address/en_GB/__init__.py
@@ -426,5 +426,7 @@ class Provider(AddressProvider):
     def secondary_address(self):
         return self.bothify(self.random_element(self.secondary_address_formats))
 
-    def county(self):
+    def administrative_unit(self):
         return self.random_element(self.counties)
+
+    county = administrative_unit

--- a/faker/providers/address/en_IE/__init__.py
+++ b/faker/providers/address/en_IE/__init__.py
@@ -25,5 +25,7 @@ class Provider(AddressProvider):
             postcode += self.random_element(self._postcode_sets[placeholder])
         return postcode
 
-    def county(self):
+    def administrative_unit(self):
         return self.random_element(self.counties)
+
+    county = administrative_unit

--- a/faker/providers/address/en_IN/__init__.py
+++ b/faker/providers/address/en_IN/__init__.py
@@ -395,5 +395,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/en_NZ/__init__.py
+++ b/faker/providers/address/en_NZ/__init__.py
@@ -224,10 +224,6 @@ class Provider(AddressProvider):
         'Level %',
     )
 
-    def state(self):
-        # New Zealand does not have states.
-        return ''
-
     def te_reo_part(self):
         return self.random_element(self.te_reo_parts)
 

--- a/faker/providers/address/en_PH/__init__.py
+++ b/faker/providers/address/en_PH/__init__.py
@@ -395,8 +395,10 @@ class Provider(AddressProvider):
     def mindanao_province(self):
         return self.random_element(self.mindanao_provinces)
 
-    def province(self):
+    def administrative_unit(self):
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def standalone_building_number(self):
         return str(self.random_int(min=1))

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -351,8 +351,10 @@ class Provider(AddressProvider):
             self.random_element(
                 self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def state_abbr(self, include_territories=True):
         """

--- a/faker/providers/address/es_ES/__init__.py
+++ b/faker/providers/address/es_ES/__init__.py
@@ -116,8 +116,10 @@ class Provider(AddressProvider):
             self.random_element(
                 self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def region(self):
         return self.random_element(self.regions)

--- a/faker/providers/address/es_MX/__init__.py
+++ b/faker/providers/address/es_MX/__init__.py
@@ -114,11 +114,13 @@ class Provider(AddressProvider):
             self.random_element(
                 self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         """
         example: u'Guerrero'
         """
         return self.random_element(self.states)[1]
+
+    state = administrative_unit
 
     def state_abbr(self):
         """

--- a/faker/providers/address/fa_IR/__init__.py
+++ b/faker/providers/address/fa_IR/__init__.py
@@ -82,5 +82,7 @@ class Provider(AddressProvider):
             self.random_element(
                 self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/fi_FI/__init__.py
+++ b/faker/providers/address/fi_FI/__init__.py
@@ -158,5 +158,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/fr_CH/__init__.py
+++ b/faker/providers/address/fr_CH/__init__.py
@@ -116,12 +116,14 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.cantons)
 
-    def canton_name(self):
+    def administrative_unit(self):
         """
         Randomly returns a Swiss canton name.
         :example 'Vaud'
         """
         return self.canton()[1]
+
+    canton_name = administrative_unit
 
     def canton_code(self):
         """

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -162,14 +162,12 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.departments)
 
-    def administrative_unit(self):
+    def department_name(self):
         """
         Randomly returns a french department name.
         :example 'Ardèche'
         """
         return self.department()[1]
-
-    department_name = administrative_unit
 
     def department_number(self):
         """

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -147,11 +147,13 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.city_prefixes)
 
-    def region(self):
+    def administrative_unit(self):
         """
         :example 'Guadeloupe'
         """
         return self.random_element(self.regions)
+
+    region = administrative_unit
 
     def department(self):
         """
@@ -160,12 +162,14 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.departments)
 
-    def department_name(self):
+    def administrative_unit(self):
         """
         Randomly returns a french department name.
         :example 'Ardèche'
         """
         return self.department()[1]
+
+    department_name = administrative_unit
 
     def department_number(self):
         """

--- a/faker/providers/address/hi_IN/__init__.py
+++ b/faker/providers/address/hi_IN/__init__.py
@@ -229,5 +229,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/hr_HR/__init__.py
+++ b/faker/providers/address/hr_HR/__init__.py
@@ -170,5 +170,7 @@ class Provider(AddressProvider):
     def street_name(self):
         return self.random_element(self.streets)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/hu_HU/__init__.py
+++ b/faker/providers/address/hu_HU/__init__.py
@@ -210,8 +210,10 @@ class Provider(AddressProvider):
         "Uruguay", "Üzbegisztán", "Vanuatu", "Venezuela", "Vietnam", "Wallis és Futuna", "Zambia", "Zimbabwe",
         "Zöld-foki szigetek")
 
-    def county(self):
+    def administrative_unit(self):
         return self.random_element(self.counties)
+
+    county = administrative_unit
 
     def street_address_with_county(self):
         return f'{self.street_address()}\n{self.county()} megye\n{self.postcode()} {self.city().capitalize()}'

--- a/faker/providers/address/hy_AM/__init__.py
+++ b/faker/providers/address/hy_AM/__init__.py
@@ -643,11 +643,13 @@ class Provider(AddressProvider):
         """
         return self.numerify(self.random_element(self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         """
         :example 'Կոտայք'
         """
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def state_abbr(self):
         """

--- a/faker/providers/address/id_ID/__init__.py
+++ b/faker/providers/address/id_ID/__init__.py
@@ -159,8 +159,10 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def state_abbr(self):
         return self.random_element(self.states_abbr)

--- a/faker/providers/address/it_IT/__init__.py
+++ b/faker/providers/address/it_IT/__init__.py
@@ -121,8 +121,10 @@ class Provider(AddressProvider):
         return self.numerify(
             self.random_element(self.secondary_address_formats))
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def state_abbr(self):
         return self.random_element(self.states_abbr)

--- a/faker/providers/address/ja_JP/__init__.py
+++ b/faker/providers/address/ja_JP/__init__.py
@@ -302,11 +302,13 @@ class Provider(AddressProvider):
         'パレス', 'ハイツ', 'コーポ', 'アーバン', 'クレスト', 'パーク', 'シティ', 'シャルム', 'コート',
     )
 
-    def prefecture(self):
+    def administrative_unit(self):
         """
         :example '東京都'
         """
         return self.random_element(self.prefectures)
+
+    prefecture = administrative_unit
 
     def city(self):
         """

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -374,11 +374,13 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.metropolitan_cities)
 
-    def province(self):
+    def administrative_unit(self):
         """
         :example 경기도
         """
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def city(self):
         """

--- a/faker/providers/address/ne_NP/__init__.py
+++ b/faker/providers/address/ne_NP/__init__.py
@@ -596,11 +596,13 @@ class Provider(AddressProvider):
         'सुदूरपश्चिम प्रदेश',
     )
 
-    def province(self):
+    def administrative_unit(self):
         """
         :example सुदूरपश्चिम प्रदेश
         """
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def district(self):
         """

--- a/faker/providers/address/nl_BE/__init__.py
+++ b/faker/providers/address/nl_BE/__init__.py
@@ -570,8 +570,10 @@ class Provider(AddressProvider):
         "{{street_address}}\n{{postcode}} {{city}}",
     )
 
-    def province(self):
+    def administrative_unit(self):
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def city(self):
         return self.random_element(self.cities)

--- a/faker/providers/address/nl_NL/__init__.py
+++ b/faker/providers/address/nl_NL/__init__.py
@@ -580,8 +580,10 @@ class Provider(AddressProvider):
         "{{street_address}}\n{{postcode}}\n{{city}}",
     )
 
-    def province(self):
+    def administrative_unit(self):
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def city(self):
         return self.random_element(self.cities)

--- a/faker/providers/address/pl_PL/__init__.py
+++ b/faker/providers/address/pl_PL/__init__.py
@@ -180,8 +180,10 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.cities)
 
-    def region(self):
+    def administrative_unit(self):
         """
         :example 'Wielkopolskie'
         """
         return self.random_element(self.regions)
+
+    region = administrative_unit

--- a/faker/providers/address/pt_BR/__init__.py
+++ b/faker/providers/address/pt_BR/__init__.py
@@ -311,8 +311,10 @@ class Provider(AddressProvider):
     def neighborhood(self):
         return self.bairro()
 
-    def state(self):
+    def administrative_unit(self):
         return self.estado_nome()
+
+    state = administrative_unit
 
     def state_abbr(self):
         return self.estado_sigla()

--- a/faker/providers/address/pt_PT/__init__.py
+++ b/faker/providers/address/pt_PT/__init__.py
@@ -399,11 +399,13 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.cities)
 
-    def distrito(self):
+    def administrative_unit(self):
         """
         :example 'Bragança'
         """
         return self.random_element(self.distritos)
+
+    distrito = administrative_unit
 
     def concelho(self):
         """

--- a/faker/providers/address/ru_RU/__init__.py
+++ b/faker/providers/address/ru_RU/__init__.py
@@ -357,7 +357,7 @@ class Provider(AddressProvider):
     def country(self):
         return self.random_element(self.countries)
 
-    def region(self):
+    def administrative_unit(self):
         regions_suffix = self.random_element(self.region_suffixes)
         if regions_suffix == 'респ.':
             return regions_suffix + ' ' + self.random_element(self.region_republics)
@@ -367,6 +367,8 @@ class Provider(AddressProvider):
             return self.random_element(self.region_oblast) + ' ' + regions_suffix
         elif regions_suffix == 'АО':
             return self.random_element(self.region_ao) + ' ' + regions_suffix
+
+    region = administrative_unit
 
     def street_suffix(self):
         return self.random_element(self.street_suffixes)

--- a/faker/providers/address/sk_SK/__init__.py
+++ b/faker/providers/address/sk_SK/__init__.py
@@ -1159,8 +1159,10 @@ class Provider(AddressProvider):
     def street_name(self):
         return self.random_element(self.streets)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit
 
     def city_with_postcode(self):
         return self.postcode() + " " + self.random_element(self.cities)

--- a/faker/providers/address/sl_SI/__init__.py
+++ b/faker/providers/address/sl_SI/__init__.py
@@ -505,5 +505,7 @@ class Provider(AddressProvider):
     def street_name(self):
         return self.random_element(self.streets)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -106,5 +106,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/ta_IN/__init__.py
+++ b/faker/providers/address/ta_IN/__init__.py
@@ -414,5 +414,7 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def state(self):
+    def administrative_unit(self):
         return self.random_element(self.states)
+
+    state = administrative_unit

--- a/faker/providers/address/th_TH/__init__.py
+++ b/faker/providers/address/th_TH/__init__.py
@@ -270,11 +270,13 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.street_prefixes)
 
-    def province(self):
+    def administrative_unit(self):
         """
         :example 'อุบลราชธานี'
         """
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def amphoe(self):
         """

--- a/faker/providers/address/zh_CN/__init__.py
+++ b/faker/providers/address/zh_CN/__init__.py
@@ -80,8 +80,10 @@ class Provider(AddressProvider):
     def city_name(self):
         return self.random_element(self.cities)
 
-    def province(self):
+    def administrative_unit(self):
         return self.random_element(self.provinces)
+
+    province = administrative_unit
 
     def district(self):
         return self.random_element(self.districts)


### PR DESCRIPTION
### What does this changes

Add three new methods: current_country, current_country_code and administrative_unit

### What was wrong

1. There was no way to determine the name for the current country
2. There was no generic way to fake "states/provinces/adminastritive_unit" of various countries

Fixes #1386
