### PR TITLE
Replace rfc name initials when they are forbidden words

### DIFF
--- a/faker/providers/ssn/es_MX/__init__.py
+++ b/faker/providers/ssn/es_MX/__init__.py
@@ -221,6 +221,7 @@ class Provider(BaseProvider):
             second_surname = random.choice(ALPHABET)
             given_name = random.choice(ALPHABET)
             name_initials = first_surname + second_surname + given_name
+            name_initials = FORBIDDEN_WORDS.get(name_initials, name_initials)
         else:
             name_initials = (
                 self.random_uppercase_letter() +


### PR DESCRIPTION
### What does this changes

This PR modifies the RFC generation so it will never return one with forbidden words.

### What was wrong

Fake natural person RFCs were being generated with forbidden words in them.

### How this fixes it

If the name initials are among the forbidden words, they are replaced with their corresponding alternative.