### PR TITLE
Fix a problem with pyfloat where it can return `sys.epsilon` when `right_digits=N` and `positive=True`

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -89,7 +89,10 @@ class Provider(BaseProvider):
 
         result = float(f'{sign}{left_number}.{self.random_number(right_digits)}')
         if positive and result == 0:
-            result += sys.float_info.epsilon
+            if right_digits:
+                result = float('0.' + '0' * (right_digits - 1) + '1')
+            else:
+                result += sys.float_info.epsilon
         return result
 
     def _safe_random_int(self, min_value, max_value, positive):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -3,7 +3,31 @@ import warnings
 
 from unittest.mock import patch
 
+import pytest
+
 from faker import Faker
+
+
+@pytest.mark.parametrize(
+    'mock_random_number_source, right_digits, expected_decimal_part',
+    (
+        ('1234567', 5, '12345'),
+        ('1234567', 0, '1'),  # This is kinda interesting - same as 1 digit
+        ('1234567', 1, '1'),
+        ('1234567', 2, '12'),
+        ('0123', 1, '220446049250313e-16'),
+    ),
+)
+def test_pyfloat_right_and_left_digits_positive(mock_random_number_source, right_digits, expected_decimal_part):
+
+    # Remove the randomness from the test by mocking the `BaseProvider.random_number` value
+    def mock_random_number(self, digits=None, fix_len=False):
+        return int(mock_random_number_source[:digits or 1])
+
+    with patch('faker.providers.BaseProvider.random_number', mock_random_number):
+        result = Faker().pyfloat(left_digits=1, right_digits=right_digits, positive=True)
+        decimal_part = str(result).split('.')[1]
+        assert decimal_part == expected_decimal_part
 
 
 class TestPyint(unittest.TestCase):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -15,7 +15,7 @@ from faker import Faker
         ('1234567', 0, '1'),  # This is kinda interesting - same as 1 digit
         ('1234567', 1, '1'),
         ('1234567', 2, '12'),
-        ('0123', 1, '220446049250313e-16'),
+        ('0123', 1, '1'),
     ),
 )
 def test_pyfloat_right_and_left_digits_positive(mock_random_number_source, right_digits, expected_decimal_part):


### PR DESCRIPTION
### What does this changes

Fixes issue https://github.com/joke2k/faker/issues/1402, where a call to `pyfloat` (or other methods that call it, i.e. pydecimal) can result in the smallest possible float value the system can reprisent, even if the end user had set `right_digits` to some particular number.

I.e. could end up with `2.220446049250313e-16` (number with 15 leading zeroes on the right-hand side of the dot), even if `right_digits` had been, say, `2`.

### What was wrong

Calling pytest with `right_digits=2` should never result in any number where the right-hand side goes beyond `.01`.

### How this fixes it

If we hit that odd/rare situation where we're about to return the epsilon, the function does a quick check to see if we had limits on the # of right-hand-side digits, and if so, instead of using epsilon, we go for the next-best thing - the smallest possible right-hand-side number, i.e. `.01` for N=2. Or `0.0000001` for N=7.

It's not necessarily the perfect solution, but should do the trick.

# Notes

* I did implement this in 2 commits - but I'm more than happy to squash these into a single comment if you like. The first commit highlights the issue by adding a test that showcases the behavior. The second commit is the fix.
* I noticed that the tests in the module I was editing are written in the "old-school" `unittest.TestCase` form. I figured I could write it how I usually see pytest tests written, while leaving the original set of tests be. I can also definitely change this, and add the new test(s) to fit in the style that the test module is using.

Tagging @fcurella since we discussed the problem in the issue (https://github.com/joke2k/faker/issues/1402).

B.S.: I still am aiming to fix the problem of never actually getting a leading zero in the right-hand side, but I'll tackle that once this bug has been squashed.