### PR TITLE
Avoid too many digits problem with `pyfloat()`

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -70,10 +70,24 @@ class Provider(BaseProvider):
             raise ValueError(
                 'Cannot combine positive=True with negative or zero min_value')
 
-        left_digits = left_digits if left_digits is not None else (
-            self.random_int(1, sys.float_info.dig))
-        right_digits = right_digits if right_digits is not None else (
-            self.random_int(0, sys.float_info.dig - left_digits))
+        # Make sure at least either left or right is set
+        if left_digits is None and right_digits is None:
+            left_digits = self.random_int(1, sys.float_info.dig - 1)
+
+        # If only one side is set, choose #digits for other side
+        if (left_digits is None) ^ (right_digits is None):
+            if left_digits is None:
+                left_digits = max(1, sys.float_info.dig - right_digits)
+            else:
+                right_digits = max(1, sys.float_info.dig - left_digits)
+
+        # Make sure we don't ask for too many digits!
+        if left_digits + right_digits > sys.float_info.dig:
+            raise ValueError(
+                f'Asking for too many digits ({left_digits} + {right_digits} == {left_digits + right_digits} > '
+                f'{sys.float_info.dig})',
+            )
+
         sign = ''
         if (min_value is not None) or (max_value is not None):
             if max_value is not None and max_value < 0:


### PR DESCRIPTION
### What does this change

It was possible for someone to call `pyfloat(left_digits=10, right_digits=10)`, and get back a value that did not have that many digits on left- and right-hand side of the decimal point.

On my system, a typical result of this kind of call would be something like `1234567890.1234567`, with 10 digits on the left hand side, but only 7 on the right hand.

### What was wrong

This is due to the limitations (on most (all, really) systems) w.r.t. implementation of floating point numbers. On my system, the maximum amount of numbers ensured to be properly kept is 15. The example above would ask for 20 numbers.

"But, in the example above are 17 digits total!" I hear you say. Well, yeah. but this is about "guaranteed" accurate number of digits. Highly recommend reading up on the IEEE 754 standard (https://ciechanow.ski/exposing-floating-point/ and https://en.wikipedia.org/wiki/IEEE_754 for those interested).

### How this fixes it

It makes `pyfloat()` raise an exception if the user explicitly calls for a float with more digits than the system can even represent.

### Notes

@fcurella : This isn't precisely the bug I had reported on the side here https://github.com/joke2k/faker/issues/1402 , but it seemed pertinent to just send this PR out rather than repeating this in an issue as well. I can 100% do so though if you'd prefer, for "keeping to the process"' sake.

On that side-issue reported (not being able to get values such as `0.01`, I'm planning to follow this up with a PR no that, but saw this opportunity to harden the function a bit first.

Added as 2 commits as before: First one to add a test showcasing the issue, second that brings in the fix. Can squash if preferred, tho it seems you do indeed do that upon merging in.