### PR TITLE
Ensures pytuple returns the correct number of items

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -123,7 +123,7 @@ class Provider(BaseProvider):
 
     def pytuple(self, nb_elements=10, variable_nb_elements=True, value_types=None, *allowed_types):
         return tuple(
-            self.pyset(
+            self._pyiterable(
                 nb_elements,
                 variable_nb_elements,
                 value_types,

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -195,6 +195,21 @@ class TestPython(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.factory.pystr(min_chars=5, max_chars=5)
 
+    def test_pytuple(self):
+        with warnings.catch_warnings(record=True) as w:
+            some_tuple = Faker().pytuple()
+            assert len(w) == 0
+        assert some_tuple
+        assert isinstance(some_tuple, tuple)
+
+    def test_pytuple_size(self):
+        def mock_pyint(self, *args, **kwargs):
+            return 1
+
+        with patch('faker.providers.python.Provider.pyint', mock_pyint):
+            some_tuple = Faker().pytuple(nb_elements=3, variable_nb_elements=False, value_types=[int])
+            assert some_tuple == (1, 1, 1,)
+
     def test_pylist(self):
         with warnings.catch_warnings(record=True) as w:
             some_list = self.factory.pylist()

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -208,7 +208,7 @@ class TestPython(unittest.TestCase):
 
         with patch('faker.providers.python.Provider.pyint', mock_pyint):
             some_tuple = Faker().pytuple(nb_elements=3, variable_nb_elements=False, value_types=[int])
-            assert some_tuple == (1, 1, 1,)
+            assert some_tuple == (1, 1, 1)
 
     def test_pylist(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
### What does this changes

Currently, pytuple uses pyset, which means that if the generates happens
to generate duplicate items, the resulting set will only include on
instances of that item. When asking for explicitly n items, it is
possible to get a number of items that is anywhere between 1 and n inc.

By changing to use a _pyiterable as the pyset and pylist methods do, the
uniqueness of the values generated is no longer required and it behaves
correctly.

### What was wrong

The pytuple() method was incorrectly using pyset() to generate values 
instead of the more appropriate _pyiterable().

### How this fixes it

Ensures the values generated are passed to `tuple` directly, without 
being reduced in number by pyset.

Fixes #1415 
