### PR TITLE
fix: use strings to import providers, rather than Paths

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,12 +4,14 @@ import unittest
 from importlib import import_module
 from pathlib import Path
 
+import faker
+
 from faker.config import META_PROVIDERS_MODULES, PROVIDERS
 from faker.generator import random
 from faker.utils.checksums import calculate_luhn, luhn_checksum
 from faker.utils.datasets import add_dicts
 from faker.utils.distribution import choices_distribution, choices_distribution_unique
-from faker.utils.loading import find_available_locales, find_available_providers
+from faker.utils.loading import find_available_locales, find_available_providers, get_path
 
 TEST_DIR = Path(__file__).resolve().parent
 
@@ -58,6 +60,10 @@ class UtilsTestCase(unittest.TestCase):
 
         result = add_dicts(t1, t2, t3)
         assert result == {'a': 1, 'c': 3, 'b': 3, 'd': 4}
+
+    def test_get_path(self):
+        result = get_path(faker)
+        assert isinstance(result, str)
 
     def test_find_available_locales(self):
         result = find_available_locales(PROVIDERS)


### PR DESCRIPTION
wrong type breaks software relying on str methods being available, e.g. astroid

Close #1421

### What does this changes

Casts the `Path` objects to a `str`.

### What was wrong

`faker.utils.get_path` was returning a `Path` objects instead of a string

### How this fixes it

External code relying on imports being string will receive what they expect.
