### PR TITLE
Fix faker module loader to use strings rather than Paths

### DIFF
--- a/faker/utils/loading.py
+++ b/faker/utils/loading.py
@@ -22,7 +22,7 @@ def get_path(module: ModuleType) -> str:
     else:
         # unfrozen
         path = Path(module.__file__).parent
-    return path
+    return str(path)
 
 
 def list_module(module: ModuleType) -> List[str]:


### PR DESCRIPTION
### What does this changes

Fix faker.utils.loading.get_path() to return str rather than Path subtype.

### What was wrong

Faker incorrectly adding Path instances to `sys.path_importer_cache` that broke other packages, namely astroid. The return value was also inconsistent with its type declaration.

### How this fixes it

Err, by calling `str()` on the path? ;-)

Fixes #1421

