### PR TITLE
Add city_name() and cities to support .city() for th_TH

### DIFF
--- a/faker/providers/address/th_TH/__init__.py
+++ b/faker/providers/address/th_TH/__init__.py
@@ -7,25 +7,84 @@ class Provider(AddressProvider):
     street_name_formats = ("{{street_prefix}}{{last_name}}",)
     street_address_formats = ("{{building_number}} {{street_name}}",)
 
-    address_formats = OrderedDict((
-        ("{{street_address}} {{tambon}} {{amphoe}} {{province}} {{postcode}}", 50),
-        ("{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 50),
-        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}", 50),
-        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 40),
-        ("{{street_address}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 30),
-        ("{{street_address}} อ.{{amphoe}} {{province}} {{postcode}}", 30),
-        ("{{street_address}} {{amphoe}} {{province}} {{postcode}}", 30),
-        ("{{street_address}} {{tambon}} {{province}} {{postcode}}", 15),
-        ("{{street_address}} {{amphoe}} จ.{{province}} {{postcode}}", 15),
-        ("{{street_address}} {{tambon}} จ.{{province}} {{postcode}}", 15),
-        ("{{street_address}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 15),
-        ("{{street_address}} ต.{{tambon}} จ.{{province}} {{postcode}}", 15),
-        ("{{street_address}} {{province}} {{postcode}}", 15),
-        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}}", 15),
-        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}}", 15),
-        ("{{building_number}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}", 10),
-        ("{{building_number}} หมู่บ้าน{{first_name}} {{amphoe}} {{province}} {{postcode}}", 10),
-    ))
+    address_formats = OrderedDict(
+        (
+            ("{{street_address}} {{tambon}} {{amphoe}} {{province}} {{postcode}}", 50),
+            (
+                "{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} {{province}} {{postcode}}",
+                50,
+            ),
+            (
+                "{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}",
+                50,
+            ),
+            (
+                "{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}} {{postcode}}",
+                40,
+            ),
+            ("{{street_address}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 30),
+            ("{{street_address}} อ.{{amphoe}} {{province}} {{postcode}}", 30),
+            ("{{street_address}} {{amphoe}} {{province}} {{postcode}}", 30),
+            ("{{street_address}} {{tambon}} {{province}} {{postcode}}", 15),
+            ("{{street_address}} {{amphoe}} จ.{{province}} {{postcode}}", 15),
+            ("{{street_address}} {{tambon}} จ.{{province}} {{postcode}}", 15),
+            ("{{street_address}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 15),
+            ("{{street_address}} ต.{{tambon}} จ.{{province}} {{postcode}}", 15),
+            ("{{street_address}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}", 15),
+            (
+                "{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}",
+                10,
+            ),
+            ("{{street_address}} {{province}} {{postcode}}", 15),
+            ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}}", 15),
+            ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}}", 15),
+            ("{{street_address}} ตำบล{{tambon}} จังหวัด{{province}} {{postcode}}", 10),
+            (
+                "{{building_number}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}",
+                10,
+            ),
+            (
+                "{{building_number}} หมู่บ้าน{{first_name}} {{amphoe}} {{province}} {{postcode}}",
+                10,
+            ),
+        )
+    )
+
+    city_formats = ("{{city_name}}",)
+    cities = (
+        "กรุงเทพมหานคร",
+        "นนทบุรี",
+        "ปากเกร็ด",
+        "หาดใหญ่",
+        "เจ้าพระยาสุรศักดิ์",
+        "สุราษฎร์ธานี",
+        "อุดรธานี",
+        "เชียงใหม่",
+        "นครราชสีมา",
+        "พัทยา",
+        "ขอนแก่น",
+        "นครศรีธรรมราช",
+        "แหลมฉบัง",
+        "รังสิต",
+        "นครสวรรค์",
+        "ภูเก็ต",
+        "เชียงราย",
+        "อุบลราชธานี",
+        "นครปฐม",
+        "เกาะสมุย",
+        "สมุทรสาคร",
+        "พิษณุโลก",
+        "ระยอง",
+        "สงขลา",
+        "ยะลา",
+        "ตรัง",
+        "อ้อมน้อย",
+        "สกลนคร",
+        "ลำปาง",
+        "สมุทรปราการ",
+        "พระนครศรีอยุธยา",
+        "แม่สอด",
+    )
 
     building_number_formats = (
         "###",
@@ -39,12 +98,14 @@ class Provider(AddressProvider):
         "## หมู่ #",
     )
 
-    street_prefixes = OrderedDict((
-        ("ถนน", 0.5),
-        ("ถ.", 0.4),
-        ("ซอย", 0.02),
-        ("ซ.", 0.02),
-    ))
+    street_prefixes = OrderedDict(
+        (
+            ("ถนน", 0.5),
+            ("ถ.", 0.4),
+            ("ซอย", 0.02),
+            ("ซ.", 0.02),
+        )
+    )
 
     postcode_formats = (
         # as per https://en.wikipedia.org/wiki/Postal_codes_in_Thailand
@@ -202,7 +263,7 @@ class Provider(AddressProvider):
         "ดอนสมบูรณ์",
         "หัวงัว",
         "นาเชือก",
-        "วัดเทพศิรินทร์",
+        "เทพศิรินทร์",
         "อุ่มเม่า",
         "คลองขาม",
         "บัวบาน",
@@ -216,7 +277,6 @@ class Provider(AddressProvider):
         "หนองอิเฒ่า",
         "โนนศิลา",
         "หนองปลาหมอ",
-        "บ้านหัน",
         "เปือยใหญ่",
         "โนนแดง",
         "ก้อนแก้ว",
@@ -240,7 +300,6 @@ class Provider(AddressProvider):
         "บางกุ้ง",
         "นาวง",
         "เขากอบ",
-        "ห้วยนาง",
         "เขาขาว",
         "ในเตา",
         "เขาปูน",
@@ -255,14 +314,32 @@ class Provider(AddressProvider):
         "นาหินลาด",
     )
 
-    tambon_suffixes = OrderedDict((
-        ("", 30),
-        ("เหนือ", 3),
-        ("ใต้", 3),
-        ("ใหญ่", 2),
-        ("กลาง", 1),
-        ("เล็ก", 1),
-    ))
+    tambon_prefixes = OrderedDict(
+        (
+            ("", 40),
+            ("วัด", 2),
+            ("บ้าน", 2),
+            ("บ่อ", 2),
+            ("บึง", 2),
+            ("ป่า", 1),
+            ("ห้วย", 1),
+        )
+    )
+
+    tambon_suffixes = OrderedDict(
+        (
+            ("", 30),
+            ("เหนือ", 3),
+            ("ใต้", 3),
+            ("ใหญ่", 2),
+            ("กลาง", 1),
+            ("เล็ก", 1),
+            ("ใหม่", 1),
+            ("เดิม", 0.1),
+        )
+    )
+
+    city_suffixes = ("นคร",)
 
     def street_prefix(self):
         """
@@ -292,4 +369,11 @@ class Provider(AddressProvider):
         Currently it's total random and not necessarily matched with an amphoe or province.
         :example 'ห้วยนาง'
         """
-        return self.random_element(self.tambons) + self.random_element(self.tambon_suffixes)
+        return (
+            self.random_element(self.tambon_prefixes)
+            + self.random_element(self.tambons)
+            + self.random_element(self.tambon_suffixes)
+        )
+
+    def city_name(self):
+        return self.random_element(self.cities)

--- a/faker/providers/address/th_TH/__init__.py
+++ b/faker/providers/address/th_TH/__init__.py
@@ -7,48 +7,28 @@ class Provider(AddressProvider):
     street_name_formats = ("{{street_prefix}}{{last_name}}",)
     street_address_formats = ("{{building_number}} {{street_name}}",)
 
-    address_formats = OrderedDict(
-        (
-            ("{{street_address}} {{tambon}} {{amphoe}} {{province}} {{postcode}}", 50),
-            (
-                "{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} {{province}} {{postcode}}",
-                50,
-            ),
-            (
-                "{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}",
-                50,
-            ),
-            (
-                "{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}} {{postcode}}",
-                40,
-            ),
-            ("{{street_address}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 30),
-            ("{{street_address}} อ.{{amphoe}} {{province}} {{postcode}}", 30),
-            ("{{street_address}} {{amphoe}} {{province}} {{postcode}}", 30),
-            ("{{street_address}} {{tambon}} {{province}} {{postcode}}", 15),
-            ("{{street_address}} {{amphoe}} จ.{{province}} {{postcode}}", 15),
-            ("{{street_address}} {{tambon}} จ.{{province}} {{postcode}}", 15),
-            ("{{street_address}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 15),
-            ("{{street_address}} ต.{{tambon}} จ.{{province}} {{postcode}}", 15),
-            ("{{street_address}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}", 15),
-            (
-                "{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}",
-                10,
-            ),
-            ("{{street_address}} {{province}} {{postcode}}", 15),
-            ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}}", 15),
-            ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}}", 15),
-            ("{{street_address}} ตำบล{{tambon}} จังหวัด{{province}} {{postcode}}", 10),
-            (
-                "{{building_number}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}",
-                10,
-            ),
-            (
-                "{{building_number}} หมู่บ้าน{{first_name}} {{amphoe}} {{province}} {{postcode}}",
-                10,
-            ),
-        )
-    )
+    address_formats = OrderedDict((
+        ("{{street_address}} {{tambon}} {{amphoe}} {{province}} {{postcode}}", 50),
+        ("{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 50),
+        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}", 50),
+        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 40),
+        ("{{street_address}} อำเภอ{{amphoe}} {{province}} {{postcode}}", 30),
+        ("{{street_address}} อ.{{amphoe}} {{province}} {{postcode}}", 30),
+        ("{{street_address}} {{amphoe}} {{province}} {{postcode}}", 30),
+        ("{{street_address}} {{tambon}} {{province}} {{postcode}}", 15),
+        ("{{street_address}} {{amphoe}} จ.{{province}} {{postcode}}", 15),
+        ("{{street_address}} {{tambon}} จ.{{province}} {{postcode}}", 15),
+        ("{{street_address}} อ.{{amphoe}} จ.{{province}} {{postcode}}", 15),
+        ("{{street_address}} ต.{{tambon}} จ.{{province}} {{postcode}}", 15),
+        ("{{street_address}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}", 15),
+        ("{{street_address}} ตำบล{{tambon}} อำเภอ{{amphoe}} จังหวัด{{province}} {{postcode}}", 10),
+        ("{{street_address}} {{province}} {{postcode}}", 15),
+        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} {{province}}", 15),
+        ("{{street_address}} ต.{{tambon}} อ.{{amphoe}} จ.{{province}}", 15),
+        ("{{street_address}} ตำบล{{tambon}} จังหวัด{{province}} {{postcode}}", 10),
+        ("{{building_number}} ต.{{tambon}} อ.{{amphoe}} {{province}} {{postcode}}", 10),
+        ("{{building_number}} หมู่บ้าน{{first_name}} {{amphoe}} {{province}} {{postcode}}", 10),
+    ))
 
     city_formats = ("{{city_name}}",)
     cities = (
@@ -96,16 +76,15 @@ class Provider(AddressProvider):
         "##/##",
         "#/#",
         "## หมู่ #",
+        "## หมู่ ##",
     )
 
-    street_prefixes = OrderedDict(
-        (
-            ("ถนน", 0.5),
-            ("ถ.", 0.4),
-            ("ซอย", 0.02),
-            ("ซ.", 0.02),
-        )
-    )
+    street_prefixes = OrderedDict((
+        ("ถนน", 0.5),
+        ("ถ.", 0.4),
+        ("ซอย", 0.02),
+        ("ซ.", 0.02),
+    ))
 
     postcode_formats = (
         # as per https://en.wikipedia.org/wiki/Postal_codes_in_Thailand
@@ -314,30 +293,26 @@ class Provider(AddressProvider):
         "นาหินลาด",
     )
 
-    tambon_prefixes = OrderedDict(
-        (
-            ("", 40),
-            ("วัด", 2),
-            ("บ้าน", 2),
-            ("บ่อ", 2),
-            ("บึง", 2),
-            ("ป่า", 1),
-            ("ห้วย", 1),
-        )
-    )
+    tambon_prefixes = OrderedDict((
+        ("", 40),
+        ("วัด", 2),
+        ("บ้าน", 2),
+        ("บ่อ", 2),
+        ("บึง", 2),
+        ("ป่า", 1),
+        ("ห้วย", 1),
+    ))
 
-    tambon_suffixes = OrderedDict(
-        (
-            ("", 30),
-            ("เหนือ", 3),
-            ("ใต้", 3),
-            ("ใหญ่", 2),
-            ("กลาง", 1),
-            ("เล็ก", 1),
-            ("ใหม่", 1),
-            ("เดิม", 0.1),
-        )
-    )
+    tambon_suffixes = OrderedDict((
+        ("", 30),
+        ("เหนือ", 3),
+        ("ใต้", 3),
+        ("ใหญ่", 2),
+        ("กลาง", 1),
+        ("เล็ก", 1),
+        ("ใหม่", 1),
+        ("เดิม", 0.1),
+    ))
 
     city_suffixes = ("นคร",)
 

--- a/faker/providers/address/th_TH/__init__.py
+++ b/faker/providers/address/th_TH/__init__.py
@@ -30,6 +30,8 @@ class Provider(AddressProvider):
         ("{{building_number}} หมู่บ้าน{{first_name}} {{amphoe}} {{province}} {{postcode}}", 10),
     ))
 
+    # city names are actual city municipalities in Thailand
+    # source: Wikipedia: https://th.wikipedia.org/wiki/เทศบาลนครในประเทศไทย
     city_formats = ("{{city_name}}",)
     cities = (
         "กรุงเทพมหานคร",

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1514,6 +1514,12 @@ class TestThTh:
             assert isinstance(country, str)
             assert country in ThThAddressProvider.countries
 
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city = faker.city_name()
+            assert isinstance(city, str)
+            assert city in ThThAddressProvider.cities
+
     def test_province(self, faker, num_samples):
         for _ in range(num_samples):
             province = faker.province()


### PR DESCRIPTION
### What does this changes

- Add list of cities and `city_name()` to support the `city()` in parent class.
- Add few more prefixes and suffixes for tambon

### What was wrong

`city()` was not get implemented before.

### How this fixes it

Implement `city()` using actual list of cities from 
https://th.wikipedia.org/wiki/%E0%B9%80%E0%B8%97%E0%B8%A8%E0%B8%9A%E0%B8%B2%E0%B8%A5%E0%B8%99%E0%B8%84%E0%B8%A3%E0%B9%83%E0%B8%99%E0%B8%9B%E0%B8%A3%E0%B8%B0%E0%B9%80%E0%B8%97%E0%B8%A8%E0%B9%84%E0%B8%97%E0%B8%A2
