### PR TITLE
add airtravel_faker provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -25,6 +25,9 @@ Here's a list of Providers written by the community:
 +---------------+--------------------------+----------------------------------+
 | Wi-Fi ESSID   | Fake Wi-Fi ESSIDs.       | `faker_wifi_essid`_              +
 +---------------+--------------------------+----------------------------------+
+| Airtravel     | Airport names, airport   | `faker_airtravel`_               |
+|               | codes, and flights.      |                                  |
++---------------+--------------------------+----------------------------------+
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -45,3 +48,4 @@ In order to be inlcuded, your provider must satisfy these requirement:
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/
 .. _mdgen: https://pypi.org/project/mdgen/
+.. _faker_airtravel: https://pypi.org/project/faker_airtravel/


### PR DESCRIPTION
Please add the airtravel faker provider to the list of community providers.  It has all the necessary tests, licenses , and other requirements listed

### What does this changes

Brief summary of the changes

### What was wrong

Description of what was the root cause of the issue.

### How this fixes it

Description of how the changes fix the issue.

Fixes #...
