### PR TITLE
Remove gmail.co.uk (Fix #1417)

### DIFF
--- a/faker/providers/internet/en_GB/__init__.py
+++ b/faker/providers/internet/en_GB/__init__.py
@@ -9,9 +9,9 @@ class Provider(InternetProvider):
         'gmail.com',
         'yahoo.com',
         'hotmail.com',
-        'gmail.co.uk',
         'yahoo.co.uk',
         'hotmail.co.uk',
+        'outlook.com',
     )
 
     tlds = ('com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'co.uk')


### PR DESCRIPTION
### What does this changes

in en_GB free email address in internet provider:
- Remove `gmail.co.uk`
- Add `outlook.com`

### What was wrong

gmail.co.uk is not a valid free email address

### How this fixes it

Remove gmail.co.uk

Fixes #1417 
