### PR TITLE
doc: add OptionalProvider to community maintained providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -28,6 +28,10 @@ Here's a list of Providers written by the community:
 | Airtravel     | Airport names, airport   | `faker_airtravel`_               |
 |               | codes, and flights.      |                                  |
 +---------------+--------------------------+----------------------------------+
+| Optional      | Wrap over other          | `faker_optional`_                |
+|               | providers to return      |                                  |
+|               | their value or `None`.   |                                  |
++---------------+--------------------------+----------------------------------+
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -49,3 +53,4 @@ In order to be inlcuded, your provider must satisfy these requirement:
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/
 .. _mdgen: https://pypi.org/project/mdgen/
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
+.. _faker_optional: https://pypi.org/project/faker-optional


### PR DESCRIPTION
### What does this changes

Add the [OptionalProvider](https://lyz-code.github.io/faker-optional/) to the community providers.

### What was wrong

It was "not easy" create data of type `Optional[Any]` with the existent providers.

### How this fixes it

This provider gives a wrapper over existent providers to return `None` some of the times.

```python
from faker import Faker
from faker_optional import OptionalProvider

fake = Faker()
fake.add_provider(OptionalProvider)

fake.optional_int()
# None

fake.optional_int()
# 1234
```