### PR TITLE
Support distant past dates on windows

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -19,10 +19,10 @@ def datetime_to_timestamp(dt):
 
 def timestamp_to_datetime(timestamp, tzinfo):
     if tzinfo is None:
-        pick = datetime.fromtimestamp(timestamp, tzlocal())
+        pick = convert_timestamp_to_datetime(timestamp, tzlocal())
         pick = pick.astimezone(tzutc()).replace(tzinfo=None)
     else:
-        pick = datetime.fromtimestamp(timestamp, tzinfo)
+        pick = convert_timestamp_to_datetime(timestamp, tzinfo)
 
     return pick
 
@@ -1697,8 +1697,11 @@ class Provider(BaseProvider):
         )
         try:
             if tzinfo is None:
-                pick = datetime.fromtimestamp(timestamp, tzlocal())
-                pick = pick.astimezone(tzutc()).replace(tzinfo=None)
+                pick = convert_timestamp_to_datetime(timestamp, tzlocal())
+                try:
+                    pick = pick.astimezone(tzutc()).replace(tzinfo=None)
+                except OSError:
+                    pass
             else:
                 pick = datetime.fromtimestamp(timestamp, tzinfo)
         except OverflowError:
@@ -2045,3 +2048,11 @@ class Provider(BaseProvider):
         dob = self.date_time_ad(tzinfo=tzinfo, start_datetime=start_date, end_datetime=end_date).date()
 
         return dob if dob != start_date else dob + timedelta(days=1)
+
+def convert_timestamp_to_datetime(timestamp, tzinfo):
+    import datetime as dt
+    if timestamp >=0:
+        return dt.datetime.fromtimestamp(timestamp, tzinfo)
+    else:
+        return dt.datetime(1970, 1, 1, tzinfo=tzinfo) + dt.timedelta(seconds=int(timestamp))
+    

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -2049,10 +2049,10 @@ class Provider(BaseProvider):
 
         return dob if dob != start_date else dob + timedelta(days=1)
 
+
 def convert_timestamp_to_datetime(timestamp, tzinfo):
     import datetime as dt
-    if timestamp >=0:
+    if timestamp >= 0:
         return dt.datetime.fromtimestamp(timestamp, tzinfo)
     else:
         return dt.datetime(1970, 1, 1, tzinfo=tzinfo) + dt.timedelta(seconds=int(timestamp))
-    

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -15,7 +15,7 @@ import pytest
 
 from faker import Faker
 from faker.providers.date_time import Provider as DatetimeProvider
-from faker.providers.date_time import change_year, convert_timestamp_to_datetime
+from faker.providers.date_time import change_year
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
 from faker.providers.date_time.cs_CZ import Provider as CsCzProvider
@@ -231,7 +231,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_date_time_between_long_past_dates(self):
         random_date = self.fake.date_between("-100y", "-50y")
-
+        assert random_date
 
     def _datetime_to_time(self, value):
         return int(time.mktime(value.timetuple()))

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -15,7 +15,7 @@ import pytest
 
 from faker import Faker
 from faker.providers.date_time import Provider as DatetimeProvider
-from faker.providers.date_time import change_year
+from faker.providers.date_time import change_year, convert_timestamp_to_datetime
 from faker.providers.date_time.ar_AA import Provider as ArProvider
 from faker.providers.date_time.ar_EG import Provider as EgProvider
 from faker.providers.date_time.cs_CZ import Provider as CsCzProvider
@@ -228,6 +228,10 @@ class TestDateTime(unittest.TestCase):
         random_date = self.fake.date_between_dates(date_start, date_end)
         assert date_start <= random_date
         assert date_end >= random_date
+
+    def test_date_time_between_long_past_dates(self):
+        random_date = self.fake.date_between("-100y", "-50y")
+
 
     def _datetime_to_time(self, value):
         return int(time.mktime(value.timetuple()))


### PR DESCRIPTION
### What does this change

On Windows, dates before 1970 cause problems.

### What was wrong

Python itself has problems when it comes to distant dates on Windows.

### How this fixes it

Generate a date object wth a bit more code instead of relying entirely on operating system details.

Fixes #829

