### PR TITLE
Fix #1460: left_digits ignored if min_value given

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -97,8 +97,12 @@ class Provider(BaseProvider):
         sign = ''
         if (min_value is not None) or (max_value is not None):
             # Make sure left_digits still respected
-            if max_value is None and left_digits is not None:
-                max_value = 10 ** left_digits  # minus smallest representable, adjusted later
+            if left_digits is not None:
+                if max_value is None:
+                    max_value = 10 ** left_digits  # minus smallest representable, adjusted later
+                if min_value is None:
+                    min_value = -(10 ** left_digits)  # plus smallest representable, adjusted later
+
             if max_value is not None and max_value < 0:
                 max_value += 1  # as the random_int will be generated up to max_value - 1
             if min_value is not None and min_value < 0:
@@ -119,8 +123,10 @@ class Provider(BaseProvider):
 
         if right_digits:
             result = min(result, 10 ** left_digits - float(f'0.{"0" * (right_digits - 1)}1'))
+            result = max(result, -(10 ** left_digits + float(f'0.{"0" * (right_digits - 1)}1')))
         else:
             result = min(result, 10 ** left_digits - 1)
+            result = max(result, -(10 ** left_digits + 1))
 
         return result
 

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -70,8 +70,10 @@ class Provider(BaseProvider):
         if positive and min_value is not None and min_value <= 0:
             raise ValueError(
                 'Cannot combine positive=True with negative or zero min_value')
-        if left_digits is not None and max_value is not None and math.ceil(math.log10(max_value)) > left_digits:
+        if left_digits is not None and max_value and math.ceil(math.log10(abs(max_value))) > left_digits:
             raise ValueError('Max value must fit within left digits')
+        if left_digits is not None and min_value and math.ceil(math.log10(abs(min_value))) > left_digits:
+            raise ValueError('Min value must fit within left digits')
 
         # Make sure at least either left or right is set
         if left_digits is None and right_digits is None:

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -77,7 +77,7 @@ class Provider(BaseProvider):
 
         # Make sure at least either left or right is set
         if left_digits is None and right_digits is None:
-            needed_left_digits = max(1, math.ceil(math.log10(max(max_value or 1, min_value or 1))))
+            needed_left_digits = max(1, math.ceil(math.log10(max(abs(max_value or 1), abs(min_value or 1)))))
             right_digits = self.random_int(1, sys.float_info.dig - needed_left_digits)
 
         # If only one side is set, choose #digits for other side

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -180,6 +180,17 @@ class TestPyfloat(unittest.TestCase):
         self.assertLessEqual(result, 100)
         self.assertGreater(result, 0)
 
+    def test_max_and_min_value_negative(self):
+        """
+        Combining the max_value and min_value keyword arguments with
+        negative values for each produces numbers that obey both of
+        those constraints.
+        """
+
+        result = self.fake.pyfloat(max_value=-100, min_value=-200)
+        self.assertLessEqual(result, -100)
+        self.assertGreaterEqual(result, -200)
+
     def test_positive_and_min_value_incompatible(self):
         """
         An exception should be raised if positive=True is set, but

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -149,6 +149,16 @@ class TestPyfloat(unittest.TestCase):
             result = self.fake.pyfloat(max_value=max_value)
             self.assertLessEqual(result, max_value)
 
+    def test_max_value_zero_and_left_digits(self):
+        """
+        Combining the max_value and left_digits keyword arguments produces
+        numbers that obey both of those constraints.
+        """
+
+        result = self.fake.pyfloat(left_digits=2, max_value=0)
+        self.assertLessEqual(result, 0)
+        self.assertGreater(result, -100)
+
     def test_max_value_should_be_greater_than_min_value(self):
         """
         An exception should be raised if min_value is greater than max_value

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -132,6 +132,16 @@ class TestPyfloat(unittest.TestCase):
             result = self.fake.pyfloat(min_value=min_value)
             self.assertGreaterEqual(result, min_value)
 
+    def test_min_value_and_left_digits(self):
+        """
+        Combining the min_value and left_digits keyword arguments produces
+        numbers that obey both of those constraints.
+        """
+
+        result = self.fake.pyfloat(left_digits=1, min_value=0)
+        self.assertLess(result, 10)
+        self.assertGreaterEqual(result, 0)
+
     def test_max_value(self):
         max_values = (0, 10, -1000, 1000, 999999)
 


### PR DESCRIPTION
### What does this changes

Allows `left_digits` and (one or both of) `min_value` & `max_value` to work together.

### What was wrong

Specifying `min_value` or `max_value` would cause those values (even if `max_value is None`) to be used for generating the random int for the left of d.p. in pyfloat and pydecimals, ignoring `left_digits`. (#1460)

### How this fixes it

This sets `max_value` to the maximum representable within `left_digits`, if unspecified. If both are specified, we validate that they're consistent (i.e. the given `max_value` must fit within the given `left_digits`).
