### PR TITLE
Arabic names for Egypt and Jordan

### DIFF
--- a/faker/providers/person/ar_EG/__init__.py
+++ b/faker/providers/person/ar_EG/__init__.py
@@ -1,0 +1,5 @@
+from ..ar_AA import Provider as ArabicPersonProvider
+
+
+class Provider(ArabicPersonProvider):
+    pass

--- a/faker/providers/person/ar_JO/__init__.py
+++ b/faker/providers/person/ar_JO/__init__.py
@@ -1,0 +1,5 @@
+from ..ar_AA import Provider as ArabicPersonProvider
+
+
+class Provider(ArabicPersonProvider):
+    pass


### PR DESCRIPTION
### What does this changes

Egypt and Jordan use Arabic names now.

### What was wrong

```
>>> Faker("ar_EG").first_name()
'Jenna'
```

### How this fixes it

Inherit from ar_AA

Fixes #1470 
