### PR TITLE
Skip UnsupportedFeature's on the command line

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TextIO
 
-from faker import VERSION, Faker, documentor
+from faker import VERSION, Faker, documentor, exceptions
 from faker.config import AVAILABLE_LOCALES, DEFAULT_LOCALE, META_PROVIDERS_MODULES
 
 __author__ = 'joke2k'
@@ -86,8 +86,15 @@ def print_doc(provider_or_field=None,
 
     else:
         doc = documentor.Documentor(fake)
+        unsupported = []
 
-        formatters = doc.get_formatters(with_args=True, with_defaults=True)
+        while True:
+            try:
+                formatters = doc.get_formatters(with_args=True, with_defaults=True, excludes=unsupported)
+            except exceptions.UnsupportedFeature as e:
+                unsupported.append(e.name)
+            else:
+                break
 
         for provider, fakers in formatters:
 
@@ -104,7 +111,7 @@ def print_doc(provider_or_field=None,
 
             for p, fs in d.get_formatters(with_args=True, with_defaults=True,
                                           locale=language,
-                                          excludes=base_provider_formatters):
+                                          excludes=base_provider_formatters + unsupported):
                 print_provider(d, p, fs, output=output)
 
 

--- a/faker/exceptions.py
+++ b/faker/exceptions.py
@@ -10,3 +10,6 @@ class UniquenessException(BaseFakerException):
 
 class UnsupportedFeature(BaseFakerException):
     """The requested feature is not available on this system."""
+    def __init__(self, msg, name):
+        self.name = name
+        super().__init__(msg)

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -305,7 +305,7 @@ class Provider(BaseProvider):
             import PIL.Image
             import PIL.ImageDraw
         except ImportError:
-            raise UnsupportedFeature("`image` requires the `Pillow` python library.")
+            raise UnsupportedFeature("`image` requires the `Pillow` python library.", "image")
 
         (width, height) = size
         image = PIL.Image.new('RGB', size, self.generator.color(hue=hue, luminosity=luminosity))

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -326,8 +326,10 @@ class TestMiscProvider:
 
     def test_image_no_pillow(self, faker):
         with patch.dict("sys.modules", {"PIL": None}):
-            with pytest.raises(exceptions.UnsupportedFeature):
+            with pytest.raises(exceptions.UnsupportedFeature) as excinfo:
                 faker.image()
+
+            assert excinfo.value.name == "image"
 
     def test_dsv_with_invalid_values(self, faker):
         with pytest.raises(ValueError):


### PR DESCRIPTION
### What does this changes

Catches UnsupportedFeature exception when running the `faker` command without specifying a fake if Pillow isn't installed.

### What was wrong

UnsupportedFeature was raised by the `image` faker if Pillow wasn't installed (see #1474)

### How this fixes it

Calls `get_formatters`, building up a list of excluded fakers if UnsupportedFeature is raised.

Fixes #1474
