### PR TITLE
fix #1471

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -48,7 +48,7 @@ class Provider(BaseProvider):
             )
 
     def pystr_format(self, string_format='?#-###{{random_int}}{{random_letter}}', letters=string.ascii_letters):
-        return self.bothify(self.generator.parse(string_format), letters=letters)
+        return self.lexify(self.generator.parse(string_format), letters=letters)
 
     def pyfloat(self, left_digits=None, right_digits=None, positive=False,
                 min_value=None, max_value=None):


### PR DESCRIPTION
### What does this changes

get rid of bothify in pystr_format

### What was wrong

numerify which is in bothify replaces "@" to a digit or empty string and make email addresses wrong 

### How this fixes it

Each formatter already calls numerify, so there is no need to call bothify at the end. 
If it doesn't work, please let me know.

Fixes #1471 