### PR TITLE
Add UAE phone numbers [ar_AE]

### DIFF
--- a/faker/providers/phone_number/ar_AE/__init__.py
+++ b/faker/providers/phone_number/ar_AE/__init__.py
@@ -1,0 +1,91 @@
+from .. import Provider as PhoneNumberProvider
+
+
+class Provider(PhoneNumberProvider):
+    # Source: https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Arab_Emirates
+
+    cellphone_formats = (
+        '{{area_code}} {{cellphone_provider_code}} ### ####',
+        '{{area_code}}{{cellphone_provider_code}}#######',
+        '0{{cellphone_provider_code}} ### ####',
+        '0{{cellphone_provider_code}}#######',
+    )
+
+    telephone_formats = (
+        '{{area_code}} {{telephone_provider_code}} ### ####',
+        '{{area_code}}{{telephone_provider_code}}#######',
+        '0{{telephone_provider_code}} ### ####',
+        '0{{telephone_provider_code}}#######',
+    )
+
+    toll_foramts = (
+        '200####',
+        '600######',
+        '800###',
+        '800####',
+        '800#####',
+        '800######',
+        '800#######',
+    )
+
+    services_phones_formats = (
+        '999',
+        '901',
+        '998',
+        '997',
+        '996',
+        '991',
+        '922',
+    )
+
+    formats = cellphone_formats + \
+        telephone_formats + \
+        services_phones_formats + \
+        toll_foramts
+
+    def cellphone_provider_code(self):
+        return self.random_element([
+            '50',
+            '52',
+            '54',
+            '55',
+            '56',
+            '58',
+        ])
+
+    def telephone_provider_code(self):
+        return self.random_element([
+            '1',
+            '2',
+            '3',
+            '4',
+            '6',
+            '7',
+            '9',
+        ])
+
+    def area_code(self):
+        return self.random_element([
+            '00971',
+            '+971',
+        ])
+
+    def cellphone_number(self):
+        pattern = self.random_element(self.cellphone_formats)
+        return self.numerify(self.generator.parse(pattern))
+
+    def telephone_number(self):
+        pattern = self.random_element(self.telephone_formats)
+        return self.numerify(self.generator.parse(pattern))
+
+    def service_phone_number(self):
+        pattern = self.random_element(self.services_phones_formats)
+        return self.numerify(self.generator.parse(pattern))
+
+    def toll_number(self):
+        pattern = self.random_element(self.toll_foramts)
+        return self.numerify(self.generator.parse(pattern))
+
+    def phone_number(self):
+        pattern = self.random_element(self.formats)
+        return self.numerify(self.generator.parse(pattern))

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -246,3 +246,59 @@ class TestEsEs:
         for _ in range(num_samples):
             phone_number = faker.phone_number()
             assert pattern.fullmatch(phone_number)
+
+
+class TestArAe:
+    """Test ar_AE phone number provider methods"""
+
+    cellphone_pattern = (
+        r'(?:\+|00)971\s?5[024568]\s?\d{3}\s?\d{4}|'
+        r'05[024568]\s?\d{3}\s?\d{4}'
+    )
+    telephone_pattern = (
+        r'(?:\+|00)971\s?[1234679]\s?\d{3}\s?\d{4}|'
+        r'0[1234679]\s?\d{3}\s?\d{4}'
+    )
+    toll_pattern = (
+        r'200\d{4}|'
+        r'600\d{6}|'
+        r'800\d{3,7}'
+    )
+    service_pattern = (
+        r'9(?:9(?:9|8|7|6|1)|01|22)'
+    )
+
+    def test_cellphone_number(self, faker, num_samples):
+        pattern = re.compile(self.cellphone_pattern)
+        for _ in range(num_samples):
+            cellphone = faker.cellphone_number()
+            assert pattern.fullmatch(cellphone)
+
+    def test_telephone_number(self, faker, num_samples):
+        pattern = re.compile(self.telephone_pattern)
+        for _ in range(num_samples):
+            telephone = faker.telephone_number()
+            assert pattern.fullmatch(telephone)
+
+    def test_toll_number(self, faker, num_samples):
+        pattern = re.compile(self.toll_pattern)
+        for _ in range(num_samples):
+            toll = faker.toll_number()
+            assert pattern.fullmatch(toll)
+
+    def test_service_number(self, faker, num_samples):
+        pattern = re.compile(self.service_pattern)
+        for _ in range(num_samples):
+            service = faker.service_phone_number()
+            assert pattern.fullmatch(service)
+
+    def test_phone_number(self, faker, num_samples):
+        pattern = re.compile(
+            rf'{self.cellphone_pattern}|'
+            rf'{self.telephone_pattern}|'
+            rf'{self.toll_pattern}|'
+            rf'{self.service_pattern}',
+        )
+        for _ in range(num_samples):
+            phone = faker.phone_number()
+            assert pattern.fullmatch(phone)

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -264,7 +264,7 @@ class TestArAe:
         r'600\d{6}|'
         r'800\d{3,7}'
     )
-    service_pattern = (
+    service_phone_pattern = (
         r'9(?:9(?:9|8|7|6|1)|01|22)'
     )
 
@@ -286,8 +286,8 @@ class TestArAe:
             toll = faker.toll_number()
             assert pattern.fullmatch(toll)
 
-    def test_service_number(self, faker, num_samples):
-        pattern = re.compile(self.service_pattern)
+    def test_service_phone_number(self, faker, num_samples):
+        pattern = re.compile(self.service_phone_pattern)
         for _ in range(num_samples):
             service = faker.service_phone_number()
             assert pattern.fullmatch(service)
@@ -297,7 +297,7 @@ class TestArAe:
             rf'{self.cellphone_pattern}|'
             rf'{self.telephone_pattern}|'
             rf'{self.toll_pattern}|'
-            rf'{self.service_pattern}',
+            rf'{self.service_phone_pattern}',
         )
         for _ in range(num_samples):
             phone = faker.phone_number()


### PR DESCRIPTION
### What does this changes

Add UAE cellphone, telephone, service and toll numbers

### What was wrong

There were no localized phone numbers for UAE region

### How this fixes it

UAE localization is added for `phone_number` provider

---
NOTE: I am using `f-strings` in the generation of full regex for `phone_number` test. Please check if it is okay, or should the `format` be used instead.
