### PR TITLE
enable faker instances to be unpickled

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -127,6 +127,9 @@ class Faker:
         }
         return result
 
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     @property
     def unique(self):
         return self._unique_proxy
@@ -279,6 +282,16 @@ class UniqueProxy:
             return self._wrap(name, obj)
         else:
             raise TypeError("Accessing non-functions through .unique is not supported.")
+
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
     def _wrap(self, name, function):
         @functools.wraps(function)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,5 @@
 import copy
+import pickle
 import random
 
 from collections import OrderedDict
@@ -396,3 +397,8 @@ class TestFakerProxyClass:
         fake2 = copy.deepcopy(fake)
         assert fake.locales == fake2.locales
         assert fake.locales is not fake2.locales
+
+    def test_pickle(self):
+        fake = Faker()
+        pickled = pickle.dumps(fake)
+        pickle.loads(pickled)


### PR DESCRIPTION
### What does this changes

add `__getstate__` and `__setstate__` emthods to Proxy and Faker classes

### What was wrong

Unpickling Faker instances resulted in a `RecursionError`. See #1479 

### How this fixes it

Correctly unpickle Fkaer instances by using the state from `__dict__`

Fixes #1479 
