### PR TITLE
Return list instead of tuple in choices_distribution

### DIFF
--- a/faker/utils/distribution.py
+++ b/faker/utils/distribution.py
@@ -61,7 +61,7 @@ def choices_distribution(
 
     if hasattr(random, 'choices'):
         if length == 1 and p is None:
-            return (random.choice(a),)
+            return [random.choice(a)]
         else:
             return random.choices(a, weights=p, k=length)
     else:

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -152,6 +152,16 @@ class TestBaseProvider:
             letter = faker.random_letter()
             assert letter.isalpha()
 
+    @pytest.mark.parametrize('length', [0, 1, 2], ids=[
+        'empty_list', 'list_with_one_element', 'list_with_two_elements',
+    ])
+    def test_random_letters(self, faker, length):
+        letters = faker.random_letters(length=length)
+        assert len(letters) == length
+        assert isinstance(letters, list)
+        for letter in letters:
+            assert letter.isalpha()
+
     def test_random_lowercase_letter(self, faker, num_samples):
         for _ in range(num_samples):
             letter = faker.random_lowercase_letter()


### PR DESCRIPTION
### What does this changes

This is a proposed fix for https://github.com/joke2k/faker/issues/1484.

It appears this line has come up in the past: https://github.com/joke2k/faker/issues/1367#issuecomment-758345350 and https://github.com/joke2k/faker/pull/1368#pullrequestreview-566519393.

### What was wrong

We should not return a list here as that type is not the same as what `random.choices` (below it) would return (assuming the default implementation in the standard library). The `else` part below it also uses a `choices` list to return at the end.

### How this fixes it

This adds a test case for `random_letters` in general and it specifically asserts that the return value is a `list`, as mentioned in the docstring of `random_letters()`.
