### PR TITLE
Fix spelling in ar_AE and ar_PS phone number providers

### DIFF
--- a/faker/providers/phone_number/ar_AE/__init__.py
+++ b/faker/providers/phone_number/ar_AE/__init__.py
@@ -18,7 +18,7 @@ class Provider(PhoneNumberProvider):
         '0{{telephone_provider_code}}#######',
     )
 
-    toll_foramts = (
+    toll_formats = (
         '200####',
         '600######',
         '800###',
@@ -41,7 +41,7 @@ class Provider(PhoneNumberProvider):
     formats = cellphone_formats + \
         telephone_formats + \
         services_phones_formats + \
-        toll_foramts
+        toll_formats
 
     def cellphone_provider_code(self):
         return self.random_element([
@@ -83,7 +83,7 @@ class Provider(PhoneNumberProvider):
         return self.numerify(self.generator.parse(pattern))
 
     def toll_number(self):
-        pattern = self.random_element(self.toll_foramts)
+        pattern = self.random_element(self.toll_formats)
         return self.numerify(self.generator.parse(pattern))
 
     def phone_number(self):

--- a/faker/providers/phone_number/ar_PS/__init__.py
+++ b/faker/providers/phone_number/ar_PS/__init__.py
@@ -90,7 +90,7 @@ class Provider(PhoneNumberProvider):
 
     )
 
-    toll_foramts = (
+    toll_formats = (
         '1 700 ### ###',
         '1-700-###-###',
         '1 800 ### ###',
@@ -106,7 +106,7 @@ class Provider(PhoneNumberProvider):
     formats = cellphone_formats + \
         telephone_formats + \
         services_phones_formats + \
-        toll_foramts
+        toll_formats
 
     def provider_code(self):
         return self.random_element([
@@ -135,7 +135,7 @@ class Provider(PhoneNumberProvider):
         return self.numerify(self.generator.parse(pattern))
 
     def toll_number(self):
-        pattern = self.random_element(self.toll_foramts)
+        pattern = self.random_element(self.toll_formats)
         return self.numerify(self.generator.parse(pattern))
 
     def phone_number(self):


### PR DESCRIPTION
### What does this changes

Fix spelling of attributes in phone number providers.

### What was wrong

Spelling was not correct.

### How this fixes it

This fixes the spelling but this may be a breaking change in case someone relies on these attributes.
