### PR TITLE
Added non-geographic phone numbers and added services phones formats in pt_BR

### DIFF
--- a/faker/providers/phone_number/pt_BR/__init__.py
+++ b/faker/providers/phone_number/pt_BR/__init__.py
@@ -75,6 +75,14 @@ class Provider(PhoneNumberProvider):
         '71 ####-####',
         '81 ####-####',
         '84 ####-####',
+        '0300 ### ####',
+        '0500 ### ####',
+        '0800 ### ####',
+        '0900 ### ####',
+        '0300-###-####',
+        '0500-###-####',
+        '0800-###-####',
+        '0900-###-####',
     )
 
     msisdn_formats = (
@@ -102,6 +110,31 @@ class Provider(PhoneNumberProvider):
         '+55 (##) 9 ####-####',
     )
 
+    services_phones_formats = (
+        '100',
+        '128',
+        '151',
+        '152',
+        '153',
+        '156',
+        '180',
+        '181',
+        '185',
+        '188',
+        '190',
+        '191',
+        '192',
+        '193',
+        '194',
+        '197',
+        '198',
+        '199',
+    )
+
     def cellphone_number(self):
         pattern = self.random_element(self.cellphone_formats)
+        return self.numerify(self.generator.parse(pattern))
+
+    def service_phone_number(self):
+        pattern = self.random_element(self.services_phones_formats)
         return self.numerify(self.generator.parse(pattern))

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -37,7 +37,8 @@ class TestPtBr:
         pattern = re.compile(
             r'(?:\+55 )?'
             r'(?:[1-8]1|84|\((?:0[1-8]1|084)\))'
-            r' \d{4}[ -]\d{4}',
+            r' \d{4}[ -]\d{4}|'
+            r'\d{4}?[ -]\d{3}[ -]\d{4}',
         )
         for _ in range(num_samples):
             phone_number = faker.phone_number()
@@ -58,6 +59,12 @@ class TestPtBr:
         for _ in range(num_samples):
             cellphone = faker.cellphone_number()
             assert pattern.fullmatch(cellphone)
+
+    def test_service_phone(self, faker, num_samples):
+        pattern = re.compile(r'1(?:0|2|5|8|9)?(?:[0-9])')
+        for _ in range(num_samples):
+            service = faker.service_phone_number()
+            assert pattern.fullmatch(service)
 
 
 class TestHuHu:


### PR DESCRIPTION
What does this changes
 - Added non-geographic phone numbers ([source](https://pt.wikipedia.org/wiki/N%C3%BAmeros_de_telefone_no_Brasil#N%C3%A3o_Geogr%C3%A1ficos))
 - Added services phones formats ([source](https://pt.wikipedia.org/wiki/N%C3%BAmeros_de_telefone_no_Brasil#C%C3%B3digo_de_Acesso_a_Servi%C3%A7os_de_Utilidade_P%C3%BAblica_e_de_Apoio_ao_STFC))

What was wrong
 - Non-geographic phone number did not exist in valid pt_BR formats and services phones formats did not exist.

How this fixes it
 - Added non-geographic phone numbers in formats and change regex tests for this.
 - Added a new method called _`service_phone_number`_ in providers and added _`test_service_phone`_ test case for this.