### PR TITLE
Remove period/fullstop from en_GB prefixes

### DIFF
--- a/faker/providers/person/en_GB/__init__.py
+++ b/faker/providers/person/en_GB/__init__.py
@@ -588,5 +588,5 @@ class Provider(PersonProvider):
         ('Watkins', 0.06),
     ))
 
-    prefixes_female = ('Mrs.', 'Ms.', 'Miss', 'Dr.')
-    prefixes_male = ('Mr.', 'Dr.')
+    prefixes_female = ('Mrs', 'Ms', 'Miss', 'Dr')
+    prefixes_male = ('Mr', 'Dr')


### PR DESCRIPTION
### What does this changes

Removes periods/fullstops from titles/prefixes in en_GB as these are not used in British English, unlike American English

### What was wrong

Titles includes period/fullstop:
Mr.
Dr.
etc

### How this fixes it

Fullstops removed

Fixes #...

