### PR TITLE
Fix #1466 Bug in mac_platform_token

### DIFF
--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -192,7 +192,7 @@ class Provider(BaseProvider):
 
     def mac_platform_token(self):
         """Generate a MacOS platform token used in user agent strings."""
-        return (f'Macintosh; {self.random_element(self.mac_processors)} Mac OS X 10 '
+        return (f'Macintosh; {self.random_element(self.mac_processors)} Mac OS X 10_'
                 f'{self.generator.random.randint(5, 12)}_{self.generator.random.randint(0, 9)}')
 
     def android_platform_token(self):

--- a/tests/providers/test_user_agent.py
+++ b/tests/providers/test_user_agent.py
@@ -8,6 +8,7 @@ class TestUserAgentProvider:
     num_samples = 1000
     android_token_pattern = re.compile(r'Android (?P<android_version>\d+(?:\.\d){0,2})')
     ios_token_pattern = re.compile(r'^(?P<apple_device>.*?); CPU \1 OS (?P<ios_version>\d+(?:_\d){0,2}) like Mac OS X')
+    mac_token_pattern = re.compile(r'Macintosh; (?P<mac_processor>.*?) Mac OS X 10_([5-9]|1[0-2])_(\d)')
 
     def test_android_platform_token(self, faker, num_samples):
         for _ in range(num_samples):
@@ -19,3 +20,8 @@ class TestUserAgentProvider:
             match = self.ios_token_pattern.fullmatch(faker.ios_platform_token())
             assert match.group('apple_device') in UaProvider.apple_devices
             assert match.group('ios_version').replace('_', '.') in UaProvider.ios_versions
+    
+    def test_mac_platform_token(self, faker, num_samples):
+        for _ in range(num_samples):
+            match = self.mac_token_pattern.fullmatch(faker.mac_platform_token())
+            assert match.group('mac_processor') in UaProvider.mac_processors

--- a/tests/providers/test_user_agent.py
+++ b/tests/providers/test_user_agent.py
@@ -20,7 +20,7 @@ class TestUserAgentProvider:
             match = self.ios_token_pattern.fullmatch(faker.ios_platform_token())
             assert match.group('apple_device') in UaProvider.apple_devices
             assert match.group('ios_version').replace('_', '.') in UaProvider.ios_versions
-    
+
     def test_mac_platform_token(self, faker, num_samples):
         for _ in range(num_samples):
             match = self.mac_token_pattern.fullmatch(faker.mac_platform_token())


### PR DESCRIPTION
### What does this changes

Fix #1466 

### What was wrong

mac_platform_token generates a MacOS platform token used in user agent strings. However, during da1ae11#diff-7d7f34af58b0ae686b413e6ed3463229243aacfb0891fbc544cb951224c5af97L220, looks like it got missing underscore. Now, it generates Macintosh; PPC Mac OS X 10 6_5 where as it should be Macintosh; PPC Mac OS X 10_6_5

### How this fixes it

Output of mac_platform_token should be Macintosh; PPC Mac OS X 10_6_5

Fixes #...
