### PR TITLE
Solving broken pipe error when interrupting cli output

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -275,9 +275,9 @@ def execute_from_command_line(argv=None) -> None:
         command = Command(argv)
         argv = argv or sys.argv[:]
         if len(argv) < 2:
-            print("Please provide a command or type '?' or  'help'")
+            print("Please use a provider or type '?' for help")
             sys.exit(1)
-        elif argv[1] == 'help' or argv[1] == '?':
+        elif argv[1] == '?':
             command.parser.print_help()
         else:
             command.execute()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,19 @@
+import pytest
+import unittest
+
+from importlib import import_module
+from pathlib import Path
+
+from faker.cli import execute_from_command_line
+
+
+class TestingCli(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
+
+    def test_using_no_command(self):
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            execute_from_command_line(['faker'])
+
+


### PR DESCRIPTION
### What does this changes

- When using faker through the cli with no provider given now faker outputs this useful text: 'Please use a provider or type '?' for help'. 
- It also solves the broken pipe error issue reported in issue #1482. 
- And it actually prints the promised help message shown in the first change.
- A test case for the cli has been added in order to keep faker from failing when no provider given (ie: typing just 'faker', instead of 'faker name').

### What was wrong

- There was no broken pipe except catch in case something failed during execution.
- Using faker with no params produced a weird string, that was reported with the broken pipe error in issue #1482 
- There were no help message.

### How this fixes it

- Takes into account the received arguments in case none given.
- It try catches the broken pip exception, in case something goes wrong executing faker.
- It displays a message when no argument(no provider and/or options) is given.
- It actually print a help message according to the previous point, when you type '?'.
- The the parameters is being accessed as a public property and it's initialization with the argparser definition has been changed to an specific method of the Command class, in order to be able to access the parameters defined without needing to call the execute() method and also to be able to use the print_help() method of the argparse module.
