### PR TITLE
Update README to not use Python 2.7 prefixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ Examples:
     94812 Biedenkopf
 
     $ faker profile ssn,birthdate
-    {'ssn': u'628-10-1085', 'birthdate': '2008-03-29'}
+    {'ssn': '628-10-1085', 'birthdate': '2008-03-29'}
 
     $ faker -r=3 -s=";" name
     Willam Kertzmann;


### PR DESCRIPTION
### What does this changes

Remove the `u` prefix from the sample output.  As 2.7 doesn't appear to be supported (anymore?) I figure this must have been missed in the update.

### What was wrong

The docs included output that didn't happen when actually using the program.

### How this fixes it

It's a documentation fix.