### PR TITLE
Changes default email generator to use safe domain names

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -119,9 +119,11 @@ class Provider(BaseProvider):
         return string
 
     @lowercase
-    def email(self, domain=None):
+    def email(self, safe=True, domain=None):
         if domain:
             email = f'{self.user_name()}@{domain}'
+        elif safe:
+            email = f'{self.user_name()}@{self.safe_domain_name}'
         else:
             pattern = self.random_element(self.email_formats)
             email = "".join(self.generator.parse(pattern).split(" "))

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -123,7 +123,7 @@ class Provider(BaseProvider):
         if domain:
             email = f'{self.user_name()}@{domain}'
         elif safe:
-            email = f'{self.user_name()}@{self.safe_domain_name}'
+            email = f'{self.user_name()}@{self.safe_domain_name()}'
         else:
             pattern = self.random_element(self.email_formats)
             email = "".join(self.generator.parse(pattern).split(" "))

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -39,6 +39,18 @@ class TestInternetProvider:
             email = faker.email()
             assert '@' in email
 
+    def test_safe_default_email(self, faker, num_samples):
+        expected_domains = ['example.com', 'example.org', 'example.net']
+        for _ in range(num_samples):
+            email = faker.email()
+            assert email.split('@')[1] in expected_domains
+
+    def test_unsafe_email(self, faker, num_samples):
+        not_expected_domains = ['example.com', 'example.org', 'example.net']
+        for _ in range(num_samples):
+            email = faker.email(safe=False)
+            assert email.split('@')[1] not in not_expected_domains
+
     def test_email_with_domain(self, faker):
         domain = 'example.com'
         email = faker.email(domain=domain)


### PR DESCRIPTION
### What does this changes

This PR changes the default behaviour of the `email()` provider by using the `safe_domain_names` list to seed new email addresses rather than the `free_email_domains` and `domain_name` lists.

### What was wrong

By default `email()` will generate email addresses that are potentially valid, especially considering `@gmail.com`, `@yahoo.com` and other free providers are included in the data.

This can be problematic considering there are a few potential outcomes that can come of this that can affect the developers using faker or the people who have unwittingly had their emails generated as part of a test suite.

### How this fixes it

This PR introduces a new `safe` optional argument that by default is set to `True`. 

The `email()` function now checks for this new optional argument -- if set to `True` an email will be generated in a similar way an email is generated for a provided domain -- by generating a username and then setting a random domain from the `safe_domain_names` list.

If `safe` is set to `False` the original generation flow is followed.

Fixes #1523
