### PR TITLE
Fix bug in pydecimal when returning max/min

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -198,9 +198,9 @@ class Provider(BaseProvider):
         # Because the random result might have the same number of decimals as max_value the random number
         # might be above max_value or below min_value
         if max_value is not None and result > max_value:
-            result = max_value
+            result = Decimal(max_value)
         if min_value is not None and result < min_value:
-            result = min_value
+            result = Decimal(min_value)
 
         return result
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -256,6 +256,13 @@ class TestPydecimal(unittest.TestCase):
             result = self.fake.pydecimal(min_value=min_value)
             self.assertGreaterEqual(result, min_value)
 
+    def test_min_value_always_returns_a_decimal(self):
+        min_values = (0, 10, -1000, 1000, 999999)
+
+        for min_value in min_values:
+            result = self.fake.pydecimal(min_value=min_value)
+            self.assertIsInstance(result, decimal.Decimal)
+
     def test_min_value_and_left_digits(self):
         """
         Combining the min_value and left_digits keyword arguments produces
@@ -272,6 +279,13 @@ class TestPydecimal(unittest.TestCase):
         for max_value in max_values:
             result = self.fake.pydecimal(max_value=max_value)
             self.assertLessEqual(result, max_value)
+
+    def test_max_value_always_returns_a_decimal(self):
+        max_values = (0, 10, -1000, 1000, 999999)
+
+        for max_value in max_values:
+            result = self.fake.pydecimal(max_value=max_value)
+            self.assertIsInstance(result, decimal.Decimal)
 
     def test_max_value_zero_and_left_digits(self):
         """


### PR DESCRIPTION
When pydecimal returns the max or min values, it returns the exact
value provided by the user. The problem is that these arguments are
usually provided as float/int literals in tests, making the return
value not decimals sometimes.



### What does this changes

This patch makes sure we return a Decimal when returning the min or max.

### What was wrong

We were returning ints/floats if the user provided them as arguments.
