### PR TITLE
Add `date_time` provider for `el_GR`

### DIFF
--- a/faker/providers/date_time/el_GR/__init__.py
+++ b/faker/providers/date_time/el_GR/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as DateTimeProvider
+
+
+class Provider(DateTimeProvider):
+
+    DAY_NAMES = {
+        "0": "Κυριακή",
+        "1": "Δευτέρα",
+        "2": "Τρίτη",
+        "3": "Τετάρτη",
+        "4": "Πέμπτη",
+        "5": "Παρασκευή",
+        "6": "Σάββατο",
+    }
+
+    MONTH_NAMES = {
+        "01": "Ιανουάριος",
+        "02": "Φεβρουάριος",
+        "03": "Μάρτιος",
+        "04": "Απρίλιος",
+        "05": "Μάιος",
+        "06": "Ιούνιος",
+        "07": "Ιούλιος",
+        "08": "Αύγουστος",
+        "09": "Σεπτέμβριος",
+        "10": "Οκτώβριος",
+        "11": "Νοέμβριος",
+        "12": "Δεκέμβριος",
+    }
+
+    def day_of_week(self):
+        day = self.date("%w")
+        return self.DAY_NAMES[day]
+
+    def month_name(self):
+        month = self.month()
+        return self.MONTH_NAMES[month]

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -22,6 +22,7 @@ from faker.providers.date_time.bn_BD import Provider as BnBdProvider
 from faker.providers.date_time.cs_CZ import Provider as CsCzProvider
 from faker.providers.date_time.de_AT import Provider as DeAtProvider
 from faker.providers.date_time.de_DE import Provider as DeDeProvider
+from faker.providers.date_time.el_GR import Provider as ElGrProvider
 from faker.providers.date_time.es_ES import Provider as EsEsProvider
 from faker.providers.date_time.hy_AM import Provider as HyAmProvider
 from faker.providers.date_time.it_IT import Provider as ItItProvider
@@ -1179,3 +1180,17 @@ class TestNlNl(unittest.TestCase):
     def test_month(self):
         month = self.fake.month_name()
         assert month in NlProvider.MONTH_NAMES.values()
+
+
+class TestElGr(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker('el-GR')
+        Faker.seed(0)
+
+    def test_day(self):
+        day = self.fake.day_of_week()
+        assert day in ElGrProvider.DAY_NAMES.values()
+
+    def test_month(self):
+        month = self.fake.month_name()
+        assert month in ElGrProvider.MONTH_NAMES.values()


### PR DESCRIPTION
### What does this changes

Add date_time provider for Greek language

### What was wrong

There was no provider for days and months in Greek language

### How this fixes it

Implemented the provider
