### PR TITLE
Change to secondary address format in en_AU locale to reflect the common usage

### DIFF
--- a/faker/providers/address/en_AU/__init__.py
+++ b/faker/providers/address/en_AU/__init__.py
@@ -114,14 +114,14 @@ class Provider(AddressProvider):
 
     street_address_formats = (
         '{{building_number}} {{street_name}}',
-        '{{secondary_address}}\n {{building_number}} {{street_name}}',
+        '{{secondary_address}}{{building_number}} {{street_name}}',
     )
 
     address_formats = (
         "{{street_address}}\n{{city}}, {{state_abbr}}, {{postcode}}", )
 
-    secondary_address_formats = ('Apt. ###', 'Flat ##', 'Suite ###', 'Unit ##',
-                                 'Level #', '### /', '## /', '# /')
+    secondary_address_formats = ('Apt. ### ', 'Flat ## ', 'Suite ### ', 'Unit ## ',
+                                 'Level # ', '###/', '##/', '#/')
 
     def city_prefix(self):
         return self.random_element(self.city_prefixes)


### PR DESCRIPTION
When prefixing unit, appt, etc to a street address in Australia, it is usually done on the same line and without spaces in the case of the "../" notation

### What does this changes

The change ensures that a secondary address prefix is on the same line as the building number, and without added white spaces when using the "../" notation
### What was wrong
Addresses with a unit prefix where generated over 3 lines and with extra whitespace at the beginning of the second line.


### How this fixes it

Modified `street_address_formats` to remove the additional line break in between `secondary_address` and `building number`.
Also modified `secondary_address_formats` to have a trailing whitespace only when appropriate

For example: 

Before:
````
2 / 
 6 COLLINS TRACK
SOUTH  BRIAN, NSW, 2982
````

After:
````
2/6 COLLINS TRACK
SOUTH BRIAN, NSW, 2982
````

### Fixes issue 
https://github.com/joke2k/faker/issues/1546