### PR TITLE
Limit typing_extensions dependency to Python < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     install_requires=[
         "python-dateutil>=2.4",
         "text-unidecode==1.3",
-        "typing-extensions>=3.10.0.2",
+        "typing-extensions>=3.10.0.2;python_version<'3.8'",
     ],
 )


### PR DESCRIPTION
### What does this changes

`typing_extensions` are only required for Python versions that do not provide `typing.Literal`, i.e. Python < 3.8. See https://docs.python.org/3/library/typing.html#typing.Literal

### What was wrong

`typing_extensions` was listed as a dependency unconditionally.

### How this fixes it

Makes the dependency conditional to Python version.