### PR TITLE
Fix pydecimal with left_digits=0 not setting the left digit to 0

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -193,14 +193,16 @@ class Provider(BaseProvider):
                 left_number = str(self.random_int(max(min_value or 0, 0), max_value))
             else:
                 min_left_digits = math.ceil(math.log10(max(min_value or 1, 1)))
-                left_digits = left_digits or self.random_int(min_left_digits, max_left_random_digits)
+                if left_digits is None:
+                    left_digits = self.random_int(min_left_digits, max_left_random_digits)
                 left_number = "".join([str(self.random_digit()) for i in range(0, left_digits)]) or "0"
         else:
             if min_value is not None:
                 left_number = str(self.random_int(max(max_value or 0, 0), abs(min_value)))
             else:
                 min_left_digits = math.ceil(math.log10(abs(min(max_value or 1, 1))))
-                left_digits = left_digits or self.random_int(min_left_digits, max_left_random_digits)
+                if left_digits is None:
+                    left_digits = self.random_int(min_left_digits, max_left_random_digits)
                 left_number = "".join([str(self.random_digit()) for i in range(0, left_digits)]) or "0"
 
         if right_digits is None:

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -235,6 +235,14 @@ class TestPydecimal(unittest.TestCase):
         left_digits = len(str(abs(int(result))))
         self.assertGreaterEqual(expected_left_digits, left_digits)
 
+    def test_left_digits_can_be_zero(self):
+        expected_left_digits = 0
+
+        result = self.fake.pydecimal(left_digits=expected_left_digits)
+
+        left_digits = int(result)
+        self.assertEqual(expected_left_digits, left_digits)
+
     def test_right_digits(self):
         expected_right_digits = 10
 


### PR DESCRIPTION
Fix `pydecimal` not setting the digit left of the decimal point to 0 when given `left_digits=0`.
