### PR TITLE
Relax ElementsType to admit e.g. Sets

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -2,7 +2,7 @@ import re
 import string
 
 from collections import OrderedDict
-from typing import Any, Dict, KeysView, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Collection, List, Optional, Sequence, TypeVar, Union
 
 from ..generator import Generator
 from ..utils.distribution import choices_distribution, choices_distribution_unique
@@ -15,7 +15,7 @@ _re_qm = re.compile(r"\?")
 _re_cir = re.compile(r"\^")
 
 T = TypeVar("T")
-ElementsType = Union[Sequence[T], Dict[T, float], KeysView[T]]
+ElementsType = Collection[T]
 
 
 class BaseProvider:


### PR DESCRIPTION
### What does this changes

The type `ElementsType` to permit a broader range of arguments.

### What was wrong

`random_element` could not be called with an argument that was a set of choices, for example.

### How this fixes it

By relaxing the annotation to a `Collection`, we allow the `Sequence`, `Dict`, and `KeysView` that previously worked (this change is backwards compatible) but also allow `Set`, `MutableSet`, `ItemsView`, and `ValuesView`.

https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes

The ultimate relaxation might be `Iterable[T] + Sized` - but that would only benefit something custom, nothing in `collections` today has `Iterable` & `Sized` but not `Container` (the three being `Collection`), and I haven't tested it.

Fixes #1565
