### PR TITLE
Shorten IBANs for `pl_PL` to 28 chars. Fix #1568

### DIFF
--- a/faker/providers/bank/pl_PL/__init__.py
+++ b/faker/providers/bank/pl_PL/__init__.py
@@ -4,5 +4,5 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``pl_PL`` locale."""
 
-    bban_format = "#" * 26
+    bban_format = "#" * 24
     country_code = "PL"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -80,7 +80,7 @@ class TestPlPl:
             iban = faker.iban()
             assert is_valid_iban(iban)
             assert iban[:2] == PlPlBankProvider.country_code
-            assert re.fullmatch(r"\d{2}\d{26}", iban[2:])
+            assert re.fullmatch(r"\d{2}\d{24}", iban[2:])
 
 
 class TestEnGb:

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -73,7 +73,7 @@ class TestPlPl:
 
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):
-            assert re.fullmatch(r"\d{26}", faker.bban())
+            assert re.fullmatch(r"\d{24}", faker.bban())
 
     def test_iban(self, faker, num_samples):
         for _ in range(num_samples):


### PR DESCRIPTION
### What does this changes

Shorten `bban_format` for `pl_PL` Bank provider by 2 characters

### What was wrong

IBANs generated for `pl_PL` locales are 30 characters long. This is too many. Valid PL IBAN should have 28 characters (including country code).

### How this fixes it

Description of how the changes fix the issue.

Fixes #1568 
