### PR TITLE
Use os.urandom in binary if unseeded

### DIFF
--- a/faker/generator.py
+++ b/faker/generator.py
@@ -17,11 +17,12 @@ class Generator:
         "arguments": {},
     }
 
+    _is_seeded = False
+
     def __init__(self, **config: Dict) -> None:
         self.providers: List["BaseProvider"] = []
         self.__config = dict(list(self.__config.items()) + list(config.items()))
         self.__random = random
-        self._is_seeded = False
 
     def add_provider(self, provider: "BaseProvider") -> None:
 

--- a/faker/generator.py
+++ b/faker/generator.py
@@ -21,6 +21,7 @@ class Generator:
         self.providers: List["BaseProvider"] = []
         self.__config = dict(list(self.__config.items()) + list(config.items()))
         self.__random = random
+        self._is_seeded = False
 
     def add_provider(self, provider: "BaseProvider") -> None:
 
@@ -66,11 +67,13 @@ class Generator:
             # called
             self.__random = random_module.Random()
         self.__random.seed(seed)
+        self._is_seeded = True
         return self
 
     @classmethod
     def seed(cls, seed: Optional[Hashable] = None) -> None:
         random.seed(seed)
+        cls._is_seeded = True
 
     def format(self, formatter: str, *args: Any, **kwargs: Any) -> str:
         """

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -2,6 +2,7 @@ import csv
 import hashlib
 import io
 import json
+import os
 import re
 import string
 import tarfile
@@ -38,13 +39,23 @@ class Provider(BaseProvider):
             -1: False,
         }[self.generator.random.randint(-1, 1)]
 
-    def binary(self, length: int = (1 * 1024 * 1024)) -> bytes:
+    def binary_seeded(self, length: int = (1 * 1024 * 1024)) -> bytes:
         """Generate a random binary blob of ``length`` bytes.
+
+        This method is substantially slower than
+        :meth:`binary() <faker.providers.misc.Provider.binary>`, but allows for seeding.
 
         :sample: length=64
         """
         blob = [self.generator.random.randrange(256) for _ in range(length)]
         return bytes(blob)
+
+    def binary(self, length: int = (1 * 1024 * 1024)) -> bytes:
+        """Generate a random binary blob of ``length`` bytes.
+
+        :sample: length=64
+        """
+        return os.urandom(length)
 
     def md5(self, raw_output: bool = False) -> Union[bytes, str]:
         """Generate a random MD5 hash.

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -47,7 +47,6 @@ class Provider(BaseProvider):
 
         :sample: length=64
         """
-
         # If the generator has already been seeded, urandom can't be used
         if self.generator._is_seeded:
             blob = [self.generator.random.randrange(256) for _ in range(length)]

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -39,22 +39,21 @@ class Provider(BaseProvider):
             -1: False,
         }[self.generator.random.randint(-1, 1)]
 
-    def binary_seeded(self, length: int = (1 * 1024 * 1024)) -> bytes:
-        """Generate a random binary blob of ``length`` bytes.
-
-        This method is substantially slower than
-        :meth:`binary() <faker.providers.misc.Provider.binary>`, but allows for seeding.
-
-        :sample: length=64
-        """
-        blob = [self.generator.random.randrange(256) for _ in range(length)]
-        return bytes(blob)
-
     def binary(self, length: int = (1 * 1024 * 1024)) -> bytes:
         """Generate a random binary blob of ``length`` bytes.
 
+        If this faker instance has been seeded, performance will be signficiantly reduced, to conform
+        to the seeding.
+
         :sample: length=64
         """
+
+        # If the generator has already been seeded, urandom can't be used
+        if self.generator._is_seeded:
+            blob = [self.generator.random.randrange(256) for _ in range(length)]
+            return bytes(blob)
+
+        # Generator is unseeded anyway, just use urandom
         return os.urandom(length)
 
     def md5(self, raw_output: bool = False) -> Union[bytes, str]:


### PR DESCRIPTION
### What does this change

Updates the `binary` method, to increase performance.

### What was wrong

The existing code for the `binary` method is very slow (30-40x slower!) compared to `os.urandom`. For anything larger than a trivial amount of bytes, the list comprehension adds a very large amount of overhead.

### How this fixes it

If the instance is unseeded, `os.urandom` is used to generate random bytes in the `binary` method. Otherwise, the original method is used.
