### PR TITLE
Fix postcode format for es_ES locale

### DIFF
--- a/faker/providers/address/es_ES/__init__.py
+++ b/faker/providers/address/es_ES/__init__.py
@@ -135,6 +135,6 @@ class Provider(AddressProvider):
         return self.random_element(self.regions)
 
     def postcode(self) -> str:
-        return str(self.generator.random.randint(3000, 52100)).zfill(5)
+        return str(self.generator.random.randint(1000, 52100)).zfill(5)
 
     autonomous_community = region

--- a/faker/providers/address/es_ES/__init__.py
+++ b/faker/providers/address/es_ES/__init__.py
@@ -24,7 +24,6 @@ class Provider(AddressProvider):
         "Paseo",
         "Camino",
     )
-    postcode_formats = ("#####",)
     states = (
         "Álava",
         "Albacete",
@@ -134,5 +133,8 @@ class Provider(AddressProvider):
 
     def region(self) -> str:
         return self.random_element(self.regions)
+
+    def postcode(self) -> str:
+        return str(self.generator.random.randint(3000, 52100)).zfill(5)
 
     autonomous_community = region

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -723,7 +723,7 @@ class TestEsEs:
             postcode = faker.postcode()
             assert isinstance(postcode, str)
             assert len(postcode) == 5
-            assert 3000 <= int(postcode) <= 52100
+            assert 1000 <= int(postcode) <= 52100
 
 
 class TestEsMx:

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -725,6 +725,7 @@ class TestEsEs:
             assert len(postcode) == 5
             assert 3000 <= int(postcode) <= 52100
 
+
 class TestEsMx:
     """Test es_MX address provider methods"""
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -718,6 +718,12 @@ class TestEsEs:
             assert isinstance(autonomous_community, str)
             assert autonomous_community in EsEsAddressProvider.regions
 
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            assert len(postcode) == 5
+            assert 3000 <= int(postcode) <= 52100
 
 class TestEsMx:
     """Test es_MX address provider methods"""


### PR DESCRIPTION
### What does this changes

Change generation of es_ES postcodes.

### What was wrong

Postcode formats in es_ES locale is generating invalid values.

### How this fixes it

The implementation is not exhaustive. Postal codes in Spain usually are in the range from ~~3000~~ 1000 to 52100 but not all codes are used, so this implementation generates a random number between that range. It still generates invalid fakes postcodes, but at least looks like valid ones. See ["List of postal codes in Spain" (wikipedia)](https://en.wikipedia.org/wiki/List_of_postal_codes_in_Spain).

Fixes #1596.
