### PR TITLE
Prevent "non-integer arguments to randrange()" warnings on Python 3.10

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -155,7 +155,7 @@ class Provider(BaseProvider):
 
         return result
 
-    def _safe_random_int(self, min_value, max_value, positive):
+    def _safe_random_int(self, min_value: float, max_value: float, positive: bool) -> int:
         orig_min_value = min_value
         orig_max_value = max_value
 
@@ -169,7 +169,7 @@ class Provider(BaseProvider):
         if min_value == max_value:
             return self._safe_random_int(orig_min_value, orig_max_value, positive)
         else:
-            return self.random_int(min_value, max_value - 1)
+            return self.random_int(int(min_value), int(max_value - 1))
 
     def pyint(self, min_value: int = 0, max_value: int = 9999, step: int = 1) -> int:
         return self.generator.random_int(min_value, max_value, step=step)

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -216,6 +216,17 @@ class TestPyfloat(unittest.TestCase):
         result = self.fake.pyfloat(positive=True, right_digits=0, max_value=1)
         self.assertGreater(result, 0)
 
+    @pytest.mark.filterwarnings(
+        # Convert the warning to an error for this test
+        r"error:non-integer arguments to randrange\(\):DeprecationWarning"
+    )
+    def test_float_min_and_max_value_does_not_warn(self):
+        """
+        Float arguments to randrange are deprecated from Python 3.10. This is a regression
+        test to check that `pyfloat` does not cause a deprecation warning.
+        """
+        self.fake.pyfloat(min_value=-1.0, max_value=1.0)
+
 
 class TestPydecimal(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -216,6 +216,7 @@ class TestPyfloat(unittest.TestCase):
         result = self.fake.pyfloat(positive=True, right_digits=0, max_value=1)
         self.assertGreater(result, 0)
 
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="Only relevant for Python 3.10 and later.")
     @pytest.mark.filterwarnings(
         # Convert the warning to an error for this test
         r"error:non-integer arguments to randrange\(\):DeprecationWarning"


### PR DESCRIPTION
### What does this changes

From Python 3.10, non-integer arguments to `randrange()` produce a warning. This PR removes a path in which `pyfloat` can emit that warning.

### What was wrong

The existing implementation of `faker.providers.python.Provider.pyfloat` may pass float values to `random_int`, which in turn passes them directly to `randrange`.

### How this fixes it

`random_int` is already annotated to only accept integers, so I've made the fix in the `pyfloat` implementation (casting the arguments to `int` first).

An alternative would be to annotate `pyfloat` as only accepting integers, but this could be seen as a breaking change.

Related: https://github.com/joke2k/faker/issues/1538
