### PR TITLE
Fixes #1352 Missing tests in various address providers

### DIFF
--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -402,22 +402,6 @@ class TestEnAu:
             assert state_abbr.isupper()
 
 
-class TestEnNz:
-    """Test en_NZ address provider methods"""
-
-    def test_state(self, faker, num_samples):
-        for _ in range(num_samples):
-            # No states in New Zealand
-            with pytest.raises(AttributeError):
-                faker.state()
-
-    def test_postcode(self, faker, num_samples):
-        for _ in range(num_samples):
-            postcode = faker.postcode()
-            assert isinstance(postcode, str)
-            assert re.fullmatch(r"\d{4}", postcode)
-
-
 class TestEnCa:
     """Test en_CA address provider methods"""
 
@@ -935,66 +919,6 @@ class TestHrHr:
             state = faker.state()
             assert isinstance(state, str)
             assert state in HrHrAddressProvider.states
-
-
-class TestHuHu:
-    """Test hu_HU address provider methods"""
-
-    def test_postcode(self, faker, num_samples):
-        # Hungarian postcodes begin with 'H-' followed by 4 digits.
-        # The first digit may not begin with a zero.
-        for _ in range(num_samples):
-            pcd = faker.postcode()
-            assert re.fullmatch(r"H-[1-9]\d{3}", pcd)
-
-    def test_street_address(self, faker, num_samples):
-        """
-        Tests street address.
-
-        A street address must consist of a street name, a place type and a number, and end in a period point.
-        """
-        for _ in range(num_samples):
-            address = faker.street_address()
-            assert address[-1] == "."
-            # Check for correct capitalisation of place type
-            assert address.split(" ")[-2][0].islower()
-            # Check for street number format
-            assert re.fullmatch(r"\d{1,4}\.", address.split(" ")[-1])
-
-    def test_street_address_with_county(self, faker, num_samples):
-        """Tests street address with country. A street address must be:
-        - in three rows,
-        - starting with a valid street address,
-        - contain a valid post code,
-        - contain the place name validly capitalized.
-        """
-        for _ in range(num_samples):
-            address = faker.street_address_with_county()
-            # Number of rows
-            assert len(address.split("\n")) == 3
-            first, second, last = address.split("\n")
-
-            # Test street address
-            assert first[0].isupper()
-            assert first.split(" ")[-2][0].islower()
-            assert re.fullmatch(r"\d{1,4}\.", first.split(" ")[-1])
-
-            # Test county line
-            assert second.split(" ")[-1][0].islower()
-            assert second.split(" ")[0][0].isupper()
-
-            # Test postcode
-            assert re.fullmatch(r"H-[1-9]\d{3}", last.split(" ")[0])
-
-            # Test place name capitalization
-            assert last.split(" ")[-1][0].isupper()
-
-    def test_address(self, faker, num_samples):
-        for _ in range(num_samples):
-            address = faker.address()
-            assert isinstance(address, str)
-            address_with_county = faker.street_address_with_county()
-            assert isinstance(address_with_county, str)
 
 
 class TestHyAm:
@@ -1675,7 +1599,6 @@ class TestFilPh(TestEnPh):
             assert province in self.provinces or province == "Metro Manila"
 
 
-
 class TestTlPh(TestEnPh):
     """Test tl_PH address provider methods"""
 
@@ -2045,8 +1968,9 @@ class TestEnNz:
         for _ in range(num_samples):
             secondary_address = faker.secondary_address()
             assert isinstance(secondary_address, str)
-            assert secondary_address.split(" ")[0] in \
-                   [i.split(" ")[0] for i in EnNzAddressProvider.secondary_address_formats]
+            assert secondary_address.split(" ")[0] in [
+                i.split(" ")[0] for i in EnNzAddressProvider.secondary_address_formats
+            ]
 
 
 class TestFrCh:

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -2078,7 +2078,7 @@ class TestHuHu:
         for _ in range(num_samples):
             administrative_unit = faker.administrative_unit()
             assert isinstance(administrative_unit, str)
-            assert administrative_unit in FrAddressProvider.counties
+            assert administrative_unit in HuHuAddressProvider.counties
 
     def test_street_address_with_county(self, faker, num_samples):
         for _ in range(num_samples):
@@ -2232,7 +2232,7 @@ class TestSvSe:
 
     def test_administrative_unit(self, faker, num_samples):
         for _ in range(num_samples):
-            street = faker.administrative_unit()
+            administrative_unit = faker.administrative_unit()
             assert isinstance(administrative_unit, str)
             assert administrative_unit in SvSeAddressProvider.states
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -18,6 +18,7 @@ from faker.providers.address.en_CA import Provider as EnCaAddressProvider
 from faker.providers.address.en_GB import Provider as EnGbAddressProvider
 from faker.providers.address.en_IE import Provider as EnIeAddressProvider
 from faker.providers.address.en_IN import Provider as EnInAddressProvider
+from faker.providers.address.en_NZ import Provider as EnNzAddressProvider
 from faker.providers.address.en_PH import Provider as EnPhAddressProvider
 from faker.providers.address.en_US import Provider as EnUsAddressProvider
 from faker.providers.address.es_CO import Provider as EsCoAddressProvider
@@ -25,13 +26,19 @@ from faker.providers.address.es_ES import Provider as EsEsAddressProvider
 from faker.providers.address.es_MX import Provider as EsMxAddressProvider
 from faker.providers.address.fa_IR import Provider as FaIrAddressProvider
 from faker.providers.address.fi_FI import Provider as FiFiAddressProvider
+from faker.providers.address.fil_PH import Provider as FilPhAddressProvider
+from faker.providers.address.fr_CH import Provider as FrChAddressProvider
 from faker.providers.address.fr_FR import Provider as FrFrAddressProvider
 from faker.providers.address.he_IL import Provider as HeIlAddressProvider
 from faker.providers.address.hi_IN import Provider as HiInAddressProvider
 from faker.providers.address.hr_HR import Provider as HrHrAddressProvider
+from faker.providers.address.hu_HU import Provider as HuHuAddressProvider
 from faker.providers.address.hy_AM import Provider as HyAmAddressProvider
+from faker.providers.address.id_ID import Provider as IdIdAddressProvider
 from faker.providers.address.it_IT import Provider as ItItAddressProvider
 from faker.providers.address.ja_JP import Provider as JaJpAddressProvider
+from faker.providers.address.ka_GE import Provider as KaGeAddressProvider
+from faker.providers.address.ko_KR import Provider as KoKrAddressProvider
 from faker.providers.address.ne_NP import Provider as NeNpAddressProvider
 from faker.providers.address.no_NO import Provider as NoNoAddressProvider
 from faker.providers.address.pt_BR import Provider as PtBrAddressProvider
@@ -39,21 +46,14 @@ from faker.providers.address.pt_PT import Provider as PtPtAddressProvider
 from faker.providers.address.ro_RO import Provider as RoRoAddressProvider
 from faker.providers.address.ru_RU import Provider as RuRuAddressProvider
 from faker.providers.address.sk_SK import Provider as SkSkAddressProvider
-from faker.providers.address.ta_IN import Provider as TaInAddressProvider
-from faker.providers.address.th_TH import Provider as ThThAddressProvider
-from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
-from faker.providers.address.zh_TW import Provider as ZhTwAddressProvider
-from faker.providers.address.en_NZ import Provider as EnNzAddressProvider
-from faker.providers.address.fil_PH import Provider as FilPhAddressProvider
-from faker.providers.address.fr_CH import Provider as FrChAddressProvider
-from faker.providers.address.hu_HU import Provider as HuHuAddressProvider
-from faker.providers.address.id_ID import Provider as IdIdAddressProvider
-from faker.providers.address.ka_GE import Provider as KaGeAddressProvider
-from faker.providers.address.ko_KR import Provider as KoKrAddressProvider
 from faker.providers.address.sl_SI import Provider as SlSiAddressProvider
 from faker.providers.address.sv_SE import Provider as SvSeAddressProvider
+from faker.providers.address.ta_IN import Provider as TaInAddressProvider
+from faker.providers.address.th_TH import Provider as ThThAddressProvider
 from faker.providers.address.tl_PH import Provider as TlPhAddressProvider
 from faker.providers.address.uk_UA import Provider as UkUaAddressProvider
+from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
+from faker.providers.address.zh_TW import Provider as ZhTwAddressProvider
 
 
 class TestBaseProvider:

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -43,6 +43,17 @@ from faker.providers.address.ta_IN import Provider as TaInAddressProvider
 from faker.providers.address.th_TH import Provider as ThThAddressProvider
 from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
 from faker.providers.address.zh_TW import Provider as ZhTwAddressProvider
+from faker.providers.address.en_NZ import Provider as EnNzAddressProvider
+from faker.providers.address.fil_PH import Provider as FilPhAddressProvider
+from faker.providers.address.fr_CH import Provider as FrChAddressProvider
+from faker.providers.address.hu_HU import Provider as HuHuAddressProvider
+from faker.providers.address.id_ID import Provider as IdIdAddressProvider
+from faker.providers.address.ka_GE import Provider as KaGeAddressProvider
+from faker.providers.address.ko_KR import Provider as KoKrAddressProvider
+from faker.providers.address.sl_SI import Provider as SlSiAddressProvider
+from faker.providers.address.sv_SE import Provider as SvSeAddressProvider
+from faker.providers.address.tl_PH import Provider as TlPhAddressProvider
+from faker.providers.address.uk_UA import Provider as UkUaAddressProvider
 
 
 class TestBaseProvider:
@@ -1114,6 +1125,31 @@ class TestItIt:
             assert match.group("city") in ItItAddressProvider.cities
             assert match.group("province") in ItItAddressProvider.states_abbr
 
+    def test_city_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_prefix = faker.city_prefix()
+            assert isinstance(city_prefix, str)
+            assert city_prefix in ItItAddressProvider.city_prefixes
+
+    def test_secondary_address(self, faker, num_samples):
+        for _ in range(num_samples):
+            secondary_address = faker.secondary_address()
+            assert isinstance(secondary_address, str)
+            match = re.findall(r".* \d{1,2}", secondary_address)
+            assert match
+
+    def test_administrative_unit(self, faker, num_samples):
+        for _ in range(num_samples):
+            administrative_unit = faker.administrative_unit()
+            assert isinstance(administrative_unit, str)
+            assert administrative_unit in ItItAddressProvider.states
+
+    def test_state_abbr(self, faker, num_samples):
+        for _ in range(num_samples):
+            state_abbr = faker.state_abbr()
+            assert isinstance(state_abbr, str)
+            assert state_abbr in ItItAddressProvider.states_abbr
+
 
 class TestJaJp:
     """Test ja_JP address provider methods"""
@@ -1210,6 +1246,44 @@ class TestKoKr:
             postcode = faker.postcode()
             assert isinstance(postcode, str)
             assert re.fullmatch(r"\d{5}", postcode)
+
+    def test_city(self, faker, num_samples):
+        for _ in range(num_samples):
+            city = faker.city()
+            assert isinstance(city, str)
+
+    def test_borough(self, faker, num_samples):
+        for _ in range(num_samples):
+            borough = faker.borough()
+            assert isinstance(borough, str)
+            assert borough in KoKrAddressProvider.boroughs
+
+    def test_town(self, faker, num_samples):
+        for _ in range(num_samples):
+            town = faker.town()
+            assert isinstance(town, str)
+
+    def test_town_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            town_suffix = faker.town_suffix()
+            assert isinstance(town_suffix, str)
+            assert town_suffix in KoKrAddressProvider.town_suffixes
+
+    def test_building_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_name = faker.building_name()
+            assert isinstance(building_name, str)
+
+    def test_building_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_suffix = faker.building_suffix()
+            assert isinstance(building_suffix, str)
+            assert building_suffix in KoKrAddressProvider.building_suffixes
+
+    def test_building_dong(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_dong = faker.building_dong()
+            assert isinstance(building_dong, str)
 
 
 class TestNeNp:
@@ -1534,7 +1608,72 @@ class TestEnPh:
 class TestFilPh(TestEnPh):
     """Test fil_PH address provider methods"""
 
-    pass
+    @classmethod
+    def setup_class(cls):
+        cls.building_number_pattern: Pattern = re.compile(
+            r"(?:[1-9]|[1-9]\d{1,3})(?:[A-J]|\s[A-J]|-[A-J]|\sUnit\s[A-J])?",
+        )
+        cls.address_pattern: Pattern = re.compile(
+            r"(?P<street_address>.*), (?P<lgu>.*?), (?P<postcode>\d{4}) (?P<province>.*?)",
+        )
+        cls.metro_manila_postcodes = EnPhAddressProvider.metro_manila_postcodes
+        cls.luzon_province_postcodes = EnPhAddressProvider.luzon_province_postcodes
+        cls.visayas_province_postcodes = EnPhAddressProvider.visayas_province_postcodes
+        cls.mindanao_province_postcodes = EnPhAddressProvider.mindanao_province_postcodes
+        cls.postcodes = EnPhAddressProvider.postcodes
+        cls.provinces = EnPhAddressProvider.provinces
+        cls.province_lgus = EnPhAddressProvider.province_lgus
+        cls.metro_manila_lgus = EnPhAddressProvider.metro_manila_lgus
+
+    def test_metro_manila_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert int(faker.metro_manila_postcode()) in self.metro_manila_postcodes
+
+    def test_luzon_province_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert int(faker.luzon_province_postcode()) in self.luzon_province_postcodes
+
+    def test_visayas_province_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert int(faker.visayas_province_postcode()) in self.visayas_province_postcodes
+
+    def test_mindanao_province_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert int(faker.mindanao_province_postcode()) in self.mindanao_province_postcodes
+
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert int(faker.postcode()) in self.postcodes
+
+    def test_building_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert self.building_number_pattern.fullmatch(faker.building_number())
+
+    def test_floor_unit_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            number = faker.floor_unit_number()
+            assert 2 <= int(number[:-2]) <= 99
+            assert 1 <= int(number[-2:]) <= 40
+
+    def test_ordinal_floor_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            floor_number = faker.ordinal_floor_number()
+            assert floor_number[-2:] in ["th", "st", "nd", "rd"]
+
+    def test_address(self, faker, num_samples):
+        for _ in range(num_samples):
+            address = faker.address()
+            match = self.address_pattern.fullmatch(address)
+            street_address = match.group("street_address")
+            lgu = match.group("lgu")
+            postcode = match.group("postcode")
+            province = match.group("province")
+            assert match
+            assert street_address
+            assert lgu in self.province_lgus or lgu in self.metro_manila_lgus
+            assert int(postcode) in self.postcodes
+            assert province in self.provinces or province == "Metro Manila"
+
 
 
 class TestTlPh(TestEnPh):
@@ -1861,3 +2000,284 @@ class TestRoRo:
             assert isinstance(city_with_postcode, str)
             match = re.fullmatch(r"\d{6} (?P<city>.*)", city_with_postcode)
             assert match.group("city") in RoRoAddressProvider.cities
+
+
+class TestEnNz:
+    """Test en_NZ address provider methods"""
+
+    def test_te_reo_part(self, faker, num_samples):
+        for _ in range(num_samples):
+            to_reo_part = faker.te_reo_part()
+            assert isinstance(to_reo_part, str)
+            assert to_reo_part in EnNzAddressProvider.te_reo_parts
+
+    def test_reo_first(self, faker, num_samples):
+        for _ in range(num_samples):
+            te_reo_first = faker.te_reo_first()
+            assert isinstance(te_reo_first, str)
+            assert te_reo_first in [str(i).capitalize() for i in EnNzAddressProvider.te_reo_parts]
+
+    def test_reo_ending(self, faker, num_samples):
+        for _ in range(num_samples):
+            te_reo_ending = faker.te_reo_ending()
+            assert isinstance(te_reo_ending, str)
+            assert te_reo_ending in EnNzAddressProvider.te_reo_parts or EnNzAddressProvider.te_reo_endings
+
+    def test_city_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_prefix = faker.city_prefix()
+            assert isinstance(city_prefix, str)
+            assert city_prefix in EnNzAddressProvider.city_prefixes
+
+    def test_city_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_suffix = faker.city_suffix()
+            assert isinstance(city_suffix, str)
+            assert city_suffix in EnNzAddressProvider.city_suffixes
+
+    def test_rd_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            rd_number = faker.rd_number()
+            assert isinstance(rd_number, str)
+            assert rd_number in [str(i) for i in range(1, 11)]
+
+    def test_secondary_address(self, faker, num_samples):
+        for _ in range(num_samples):
+            secondary_address = faker.secondary_address()
+            assert isinstance(secondary_address, str)
+            assert secondary_address.split(" ")[0] in \
+                   [i.split(" ")[0] for i in EnNzAddressProvider.secondary_address_formats]
+
+
+class TestFrCh:
+    """Test fr_CH address provider methods"""
+
+    def test_canton_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            canton_name = faker.canton_name()
+            assert isinstance(canton_name, str)
+            assert any(canton_name == cantons[1] for cantons in FrChAddressProvider.cantons)
+
+    def test_canton_code(self, faker, num_samples):
+        for _ in range(num_samples):
+            canton_code = faker.canton_code()
+            assert isinstance(canton_code, str)
+            assert any(canton_code == cantons[0] for cantons in FrChAddressProvider.cantons)
+
+    def test_canton(self, faker, num_samples):
+        for _ in range(num_samples):
+            canton = faker.canton()
+            assert isinstance(canton, tuple)
+            assert canton in FrChAddressProvider.cantons
+
+
+class TestHuHu:
+    """Test hu_HU address provider methods"""
+
+    def test_administrative_unit(self, faker, num_samples):
+        for _ in range(num_samples):
+            administrative_unit = faker.administrative_unit()
+            assert isinstance(administrative_unit, str)
+            assert administrative_unit in FrAddressProvider.counties
+
+    def test_street_address_with_county(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_address_with_county = faker.street_address_with_county()
+            assert isinstance(street_address_with_county, str)
+            match = re.fullmatch(r".* \d*.\n.* [A-Za-zÀ-ȕ]*\nH-\d{4} [A-Za-zÀ-ȕ]*", street_address_with_county)
+            assert match
+
+    def test_city_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_prefix = faker.city_prefix()
+            assert isinstance(city_prefix, str)
+            assert city_prefix in HuHuAddressProvider.city_prefs
+
+    def test_city_part(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_part = faker.city_part()
+            assert isinstance(city_part, str)
+            assert city_part in HuHuAddressProvider.city_parts
+
+    def test_real_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            real_city_name = faker.real_city_name()
+            assert isinstance(real_city_name, str)
+            assert real_city_name in HuHuAddressProvider.real_city_names
+
+    def test_frequent_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            frequent_street_name = faker.frequent_street_name()
+            assert isinstance(frequent_street_name, str)
+            assert frequent_street_name in HuHuAddressProvider.frequent_street_names
+
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            match = re.fullmatch(r"H-\d{4}", postcode)
+            assert match
+
+    def test_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_name = faker.street_name()
+            assert isinstance(street_name, str)
+
+    def test_building_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number()
+            assert isinstance(building_number, str)
+            match = re.fullmatch(r"\d{0,3}.", building_number)
+            assert match
+
+
+class TestIdId:
+    """Test id_ID address provider methods"""
+
+    def test_street(self, faker, num_samples):
+        for _ in range(num_samples):
+            street = faker.street()
+            assert isinstance(street, str)
+            assert street in IdIdAddressProvider.streets
+
+    def test_street_prefix_short(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_prefix_short = faker.street_prefix_short()
+            assert isinstance(street_prefix_short, str)
+            assert street_prefix_short in IdIdAddressProvider.street_prefixes_short
+
+    def test_street_prefix_long(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_prefix_long = faker.street_prefix_long()
+            assert isinstance(street_prefix_long, str)
+            assert street_prefix_long in IdIdAddressProvider.street_prefixes_long
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in IdIdAddressProvider.cities
+
+    def test_administrative_unit(self, faker, num_samples):
+        for _ in range(num_samples):
+            administrative_unit = faker.administrative_unit()
+            assert isinstance(administrative_unit, str)
+            assert administrative_unit in IdIdAddressProvider.states
+
+    def test_state_abbr(self, faker, num_samples):
+        for _ in range(num_samples):
+            state_abbr = faker.state_abbr()
+            assert isinstance(state_abbr, str)
+            assert state_abbr in IdIdAddressProvider.states_abbr
+
+    def test_country(self, faker, num_samples):
+        for _ in range(num_samples):
+            country = faker.country()
+            assert isinstance(country, str)
+            assert country in IdIdAddressProvider.countries
+
+
+class TestKaGe:
+    """Test ka_GE address provider methods"""
+
+    def test_street_title(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_title = faker.street_title()
+            assert isinstance(street_title, str)
+            assert street_title in KaGeAddressProvider.street_titles
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in KaGeAddressProvider.city_names
+
+
+class TestSlSi:
+    """Test sl_SI address provider methods"""
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in SlSiAddressProvider.cities
+
+    def test_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_name = faker.street_name()
+            assert isinstance(street_name, str)
+            assert street_name in SlSiAddressProvider.streets
+
+    def test_administrative_unit(self, faker, num_samples):
+        for _ in range(num_samples):
+            administrative_unit = faker.administrative_unit()
+            assert isinstance(administrative_unit, str)
+            assert administrative_unit in SlSiAddressProvider.states
+
+
+class TestSvSe:
+    """Test sv_SE address provider methods"""
+
+    def test_street_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_prefix = faker.street_prefix()
+            assert isinstance(street_prefix, str)
+            assert street_prefix in SvSeAddressProvider.street_prefixes
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in SvSeAddressProvider.cities
+
+    def test_administrative_unit(self, faker, num_samples):
+        for _ in range(num_samples):
+            street = faker.administrative_unit()
+            assert isinstance(administrative_unit, str)
+            assert administrative_unit in SvSeAddressProvider.states
+
+
+class TestUkUa:
+    """Test uk_UA address provider methods"""
+
+    def test_city_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_prefix = faker.city_prefix()
+            assert isinstance(city_prefix, str)
+            assert city_prefix in UkUaAddressProvider.city_prefixes
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in UkUaAddressProvider.city_names
+
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            match = re.findall(r"\d{5}", postcode)
+            assert match
+
+    def test_street_prefix(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_prefix = faker.street_prefix()
+            assert isinstance(street_prefix, str)
+            assert street_prefix in UkUaAddressProvider.street_prefixes
+
+    def test_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_name = faker.street_name()
+            assert isinstance(street_name, str)
+            assert street_name in UkUaAddressProvider.street_titles
+
+    def test_street_title(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_title = faker.street_title()
+            assert isinstance(street_title, str)
+
+    def test_region(self, faker, num_samples):
+        for _ in range(num_samples):
+            region = faker.region()
+            assert isinstance(region, str)
+            assert region in UkUaAddressProvider.region_names

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -26,7 +26,6 @@ from faker.providers.address.es_ES import Provider as EsEsAddressProvider
 from faker.providers.address.es_MX import Provider as EsMxAddressProvider
 from faker.providers.address.fa_IR import Provider as FaIrAddressProvider
 from faker.providers.address.fi_FI import Provider as FiFiAddressProvider
-from faker.providers.address.fil_PH import Provider as FilPhAddressProvider
 from faker.providers.address.fr_CH import Provider as FrChAddressProvider
 from faker.providers.address.fr_FR import Provider as FrFrAddressProvider
 from faker.providers.address.he_IL import Provider as HeIlAddressProvider
@@ -50,7 +49,6 @@ from faker.providers.address.sl_SI import Provider as SlSiAddressProvider
 from faker.providers.address.sv_SE import Provider as SvSeAddressProvider
 from faker.providers.address.ta_IN import Provider as TaInAddressProvider
 from faker.providers.address.th_TH import Provider as ThThAddressProvider
-from faker.providers.address.tl_PH import Provider as TlPhAddressProvider
 from faker.providers.address.uk_UA import Provider as UkUaAddressProvider
 from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
 from faker.providers.address.zh_TW import Provider as ZhTwAddressProvider


### PR DESCRIPTION
The following changes were made see #1352:
- en_NZ: Adding tests
- fil_PH: Already implemented
- fr_CH: Adding tests
- hu_HU: Adding tests
- id_ID: Adding tests
- it_IT: Adding more tests
- ka_GE: Adding tests
- ko_KR: Adding more tests
- sk_SK: Already implemented
- sl_SI: Adding tests
- sv_SE: Adding tests
- tl_PH: Already implemented
- uk_UA: Adding tests 
