### PR TITLE
Add faker_biology as community provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -11,8 +11,8 @@ Here's a list of Providers written by the community:
 | Airtravel     | Airport names, airport   | `faker_airtravel`_               |
 |               | codes, and flights.      |                                  |
 +---------------+--------------------------+----------------------------------+
-| Biology       | Fake data from biology   | `faker_biology`_
-                | and life-science domains |
+| Biology       | Fake data from biology   | `faker_biology`_                 |
+|               | and life-science domains |                                  |
 |               | for testing purposes     |                                  |
 +---------------+--------------------------+----------------------------------+
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -54,7 +54,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _repo: https://github.com/joke2k/faker/
 .. _OSI-Approved: https://opensource.org/licenses/alphabetical
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
-.. _faker_airtravel: https://pypi.org/project/faker_biology/
+.. _faker_biology: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -11,6 +11,10 @@ Here's a list of Providers written by the community:
 | Airtravel     | Airport names, airport   | `faker_airtravel`_               |
 |               | codes, and flights.      |                                  |
 +---------------+--------------------------+----------------------------------+
+| Biology       | Fake data from biology   | `faker_biology`_
+                | and life-science domains |
+|               | for testing purposes     |                                  |
++---------------+--------------------------+----------------------------------+
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |
 |               | for testing purposes     |                                  |
 +---------------+--------------------------+----------------------------------+
@@ -50,6 +54,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _repo: https://github.com/joke2k/faker/
 .. _OSI-Approved: https://opensource.org/licenses/alphabetical
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
+.. _faker_airtravel: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/


### PR DESCRIPTION
### What does this change

Adds 'faker_biology' project to list of community providers

### What was wrong
Nothing was wrong, this is an addition to list of community providers
to enable easier inclusion of fake bio-data for testing purposes

### How this fixes it

For software in the life-science or biomedical domain it can be useful to use
realistic bio-data for testing. This can be awkward and time-consuming to extract from specialist databases. faker_biology aims to provide data-sets in a way that is easy to call using standard fake.xxx() method calls.

faker_biology has an open Apache2 license and is available on PyPi, and has good test coverage. I hope to expand the range of data included in future, and any suggestions or contributions are welcome.