### PR TITLE
Fix factory selection when Faker has been seeded

### DIFF
--- a/faker/generator.py
+++ b/faker/generator.py
@@ -11,6 +11,9 @@ random = random_module.Random()
 mod_random = random  # compat with name released in 0.8
 
 
+Sentinel = object()
+
+
 class Generator:
 
     __config: Dict[str, Dict[Hashable, Any]] = {
@@ -18,6 +21,7 @@ class Generator:
     }
 
     _is_seeded = False
+    _global_seed = Sentinel
 
     def __init__(self, **config: Dict) -> None:
         self.providers: List["BaseProvider"] = []
@@ -74,6 +78,7 @@ class Generator:
     @classmethod
     def seed(cls, seed: Optional[Hashable] = None) -> None:
         random.seed(seed)
+        cls._global_seed = seed
         cls._is_seeded = True
 
     def format(self, formatter: str, *args: Any, **kwargs: Any) -> str:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -128,6 +128,14 @@ class TestFakerProxyClass:
             Faker.seed(0)
             mock_seed.assert_called_once_with(0)
 
+    def test_seed_class_locales(self):
+        Faker.seed(2043)
+        fake = Faker(["en_GB", "fr_FR", "en_IN"])
+        name = fake.name()
+
+        for _ in range(5):
+            assert fake.name() == name
+
     def test_seed_instance(self):
         locale = ["de_DE", "en-US", "en-PH", "ja_JP"]
         fake = Faker(locale)
@@ -232,51 +240,48 @@ class TestFakerProxyClass:
                 # So each call to name() accesses the cached mapping twice
                 assert mock_cached_map.call_count == 200
 
-    @patch("faker.proxy.random.choice")
-    @patch("faker.proxy.choices_distribution")
-    def test_multiple_locale_factory_selection_no_weights(self, mock_choices_fn, mock_random_choice):
+    @patch("faker.proxy.Faker._select_factory_choice")
+    @patch("faker.proxy.Faker._select_factory_distribution")
+    def test_multiple_locale_factory_selection_no_weights(self, mock_factory_distribution, mock_factory_choice):
         fake = Faker(["de_DE", "en-US", "en-PH", "ja_JP"])
 
         # There are no distribution weights, so factory selection logic will use `random.choice`
         # if multiple factories have the specified provider method
         with patch("faker.proxy.Faker._select_factory", wraps=fake._select_factory) as mock_select_factory:
             mock_select_factory.assert_not_called()
-            mock_choices_fn.assert_not_called()
-            mock_random_choice.assert_not_called()
+            mock_factory_distribution.assert_not_called()
+            mock_factory_choice.assert_not_called()
 
             # All factories for the listed locales have the `name` provider method
             fake.name()
             mock_select_factory.assert_called_once_with("name")
-            mock_choices_fn.assert_not_called()
-            mock_random_choice.assert_called_once_with(fake.factories)
+            mock_factory_distribution.assert_not_called()
+            mock_factory_choice.assert_called_once_with(fake.factories)
             mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
+            mock_factory_distribution.reset_mock()
+            mock_factory_choice.reset_mock()
 
             # Only `en_PH` factory has provider method `luzon_province`, so there is no
             # need for `random.choice` factory selection logic to run
             fake.luzon_province()
             mock_select_factory.assert_called_with("luzon_province")
-            mock_choices_fn.assert_not_called()
-            mock_random_choice.assert_not_called()
+            mock_factory_distribution.assert_not_called()
+            mock_factory_choice.assert_not_called()
             mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
+            mock_factory_distribution.reset_mock()
+            mock_factory_choice.reset_mock()
 
             # Both `en_US` and `ja_JP` factories have provider method `zipcode`
             fake.zipcode()
             mock_select_factory.assert_called_once_with("zipcode")
-            mock_choices_fn.assert_not_called()
-            mock_random_choice.assert_called_once_with(
+            mock_factory_distribution.assert_not_called()
+            mock_factory_choice.assert_called_once_with(
                 [fake["en_US"], fake["ja_JP"]],
             )
-            mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
 
-    @patch("faker.proxy.random.choice")
-    @patch("faker.proxy.choices_distribution")
-    def test_multiple_locale_factory_selection_with_weights(self, mock_choices_fn, mock_random_choice):
+    @patch("faker.proxy.Faker._select_factory_choice")
+    @patch("faker.proxy.Faker._select_factory_distribution")
+    def test_multiple_locale_factory_selection_with_weights(self, mock_factory_distribution, mock_factory_choice):
         locale = OrderedDict(
             [
                 ("de_DE", 3),
@@ -286,8 +291,8 @@ class TestFakerProxyClass:
             ]
         )
         fake = Faker(locale)
-        mock_choices_fn.assert_not_called()
-        mock_random_choice.assert_not_called()
+        mock_factory_distribution.assert_not_called()
+        mock_factory_choice.assert_not_called()
 
         # Distribution weights have been specified, so factory selection logic will use
         # `choices_distribution` if multiple factories have the specified provider method
@@ -296,34 +301,52 @@ class TestFakerProxyClass:
             # All factories for the listed locales have the `name` provider method
             fake.name()
             mock_select_factory.assert_called_once_with("name")
-            mock_choices_fn.assert_called_once_with(fake.factories, fake.weights, length=1)
-            mock_random_choice.assert_not_called()
-            mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
+            mock_factory_distribution.assert_called_once_with(fake.factories, fake.weights)
+            mock_factory_choice.assert_not_called()
+
+    @patch("faker.proxy.Faker._select_factory_choice")
+    @patch("faker.proxy.Faker._select_factory_distribution")
+    def test_multiple_locale_factory_selection_single_provider(self, mock_factory_distribution, mock_factory_choice):
+        locale = OrderedDict(
+            [
+                ("de_DE", 3),
+                ("en-US", 2),
+                ("en-PH", 1),
+                ("ja_JP", 5),
+            ]
+        )
+        fake = Faker(locale)
+
+        # Distribution weights have been specified, so factory selection logic will use
+        # `choices_distribution` if multiple factories have the specified provider method
+        with patch("faker.proxy.Faker._select_factory", wraps=fake._select_factory) as mock_select_factory:
 
             # Only `en_PH` factory has provider method `luzon_province`, so there is no
             # need for `choices_distribution` factory selection logic to run
             fake.luzon_province()
             mock_select_factory.assert_called_once_with("luzon_province")
-            mock_choices_fn.assert_not_called()
-            mock_random_choice.assert_not_called()
-            mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
+            mock_factory_distribution.assert_not_called()
+            mock_factory_choice.assert_not_called()
 
+    @patch("faker.proxy.Faker._select_factory_choice")
+    @patch("faker.proxy.Faker._select_factory_distribution")
+    def test_multiple_locale_factory_selection_shared_providers(self, mock_factory_distribution, mock_factory_choice):
+        locale = OrderedDict(
+            [
+                ("de_DE", 3),
+                ("en-US", 2),
+                ("en-PH", 1),
+                ("ja_JP", 5),
+            ]
+        )
+        fake = Faker(locale)
+
+        with patch("faker.proxy.Faker._select_factory", wraps=fake._select_factory) as mock_select_factory:
             # Both `en_US` and `ja_JP` factories have provider method `zipcode`
             fake.zipcode()
             mock_select_factory.assert_called_once_with("zipcode")
-            mock_choices_fn.assert_called_once_with(
-                [fake["en_US"], fake["ja_JP"]],
-                [2, 5],
-                length=1,
-            )
-            mock_random_choice.assert_not_called()
-            mock_select_factory.reset_mock()
-            mock_choices_fn.reset_mock()
-            mock_random_choice.reset_mock()
+            mock_factory_distribution.assert_called_once_with([fake["en_US"], fake["ja_JP"]], [2, 5])
+            mock_factory_choice.assert_not_called()
 
     def test_multiple_locale_factory_selection_unsupported_method(self):
         fake = Faker(["en_US", "en_PH"])


### PR DESCRIPTION
### What does this change

If `Faker.seed()` has been called, seed the `random` instance when selecting the factory

### What was wrong

When faker is seeded globally, and instantiated with multiple factories, ie: locales, the factory selection did not take the seed into account

### How this fixes it

We save the seed on the `Generator` class, and re-seed `random` upon factory selection.

Fixes #1392
