### PR TITLE
Fix error in currency provider

### DIFF
--- a/faker/providers/currency/__init__.py
+++ b/faker/providers/currency/__init__.py
@@ -85,7 +85,7 @@ class Provider(BaseProvider):
         ("KHR", "Cambodian riel"),
         ("KMF", "Comorian franc"),
         ("KPW", "North Korean won"),
-        ("KRW", "Western Krahn language"),
+        ("KRW", "South Korean won"),
         ("KWD", "Kuwaiti dinar"),
         ("KYD", "Cayman Islands dollar"),
         ("KZT", "Kazakhstani tenge"),


### PR DESCRIPTION
### What does this change

Fixed an error in the currency provider.

### What was wrong

The currency with the code KRW should be the South Korean won, not "Western Krahn Language"
