### PR TITLE
feat: :globe_with_meridians: add it_IT automotive provider

### DIFF
--- a/faker/providers/automotive/it_IT/__init__.py
+++ b/faker/providers/automotive/it_IT/__init__.py
@@ -1,0 +1,15 @@
+from .. import Provider as AutomotiveProvider
+
+
+class Provider(AutomotiveProvider):
+    """Implement automotive provider for ``it_IT`` locale.
+
+    Sources:
+
+    - https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Italy
+    """
+
+    license_formats = (
+        # 1994-present
+        "??###??",
+    )

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -154,6 +154,12 @@ class TestFrFr(_SimpleAutomotiveTestMixin):
     license_plate_pattern: Pattern = re.compile(r"\d{3}-[A-Z]{3}-\d{2}|[A-Z]{2}-\d{3}-[A-Z]{2}")
 
 
+class TestItIt(_SimpleAutomotiveTestMixin):
+    """Test it_IT automotive provider methods"""
+
+    license_plate_pattern: Pattern = re.compile(r"[A-Z]{2}\d{3}[A-Z]{2}")
+
+
 class TestNoNo(_SimpleAutomotiveTestMixin):
     """Test no_NO automotive provider methods"""
 


### PR DESCRIPTION
Adding the ability to provide fake plates (automotive provider) for it_IT locale.

Refers to issue #1633.

Hope it can help. 

Thank you.