### PR TITLE
Fix/master/1618 firefox ua nondeterministic w fixed seed

### DIFF
--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -1,8 +1,11 @@
 import string
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from .. import BaseProvider, ElementsType
+
+
+_DT_ALMOST_MAX = datetime.max - timedelta(1.0)
 
 
 class Provider(BaseProvider):
@@ -187,14 +190,14 @@ class Provider(BaseProvider):
         """Generate a Mozilla Firefox web browser user agent string."""
         ver: ElementsType = (
             (
-                f"Gecko/{self.generator.date_time_between(datetime(2011, 1, 1))} "
+                f"Gecko/{self.generator.date_time_between(datetime(2011, 1, 1), _DT_ALMOST_MAX)} "
                 f"Firefox/{self.generator.random.randint(4, 15)}.0"
             ),
             (
-                f"Gecko/{self.generator.date_time_between(datetime(2010, 1, 1))} "
+                f"Gecko/{self.generator.date_time_between(datetime(2010, 1, 1), _DT_ALMOST_MAX)} "
                 f"Firefox/3.6.{self.generator.random.randint(1, 20)}"
             ),
-            f"Gecko/{self.generator.date_time_between(datetime(2010, 1, 1))} Firefox/3.8",
+            f"Gecko/{self.generator.date_time_between(datetime(2010, 1, 1), _DT_ALMOST_MAX)} Firefox/3.8",
         )
         tmplt_win: str = "({0}; {1}; rv:1.9.{2}.20) {3}"
         tmplt_lin: str = "({0}; rv:1.9.{1}.20) {2}"

--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 
 from .. import BaseProvider, ElementsType
 
-
 _DT_ALMOST_MAX = datetime.max - timedelta(1.0)
 
 

--- a/tests/providers/test_user_agent.py
+++ b/tests/providers/test_user_agent.py
@@ -3,8 +3,6 @@ import re
 
 from typing import Pattern
 
-import pytest
-
 from freezegun import freeze_time
 
 from faker import Faker

--- a/tests/providers/test_user_agent.py
+++ b/tests/providers/test_user_agent.py
@@ -38,7 +38,6 @@ class TestUserAgentProvider:
             match = self.mac_token_pattern.fullmatch(faker.mac_platform_token())
             assert match.group("mac_processor") in UaProvider.mac_processors
 
-    @pytest.mark.xfail(reason="https://github.com/joke2k/faker/issues/1618", strict=True)
     def test_firefox_deterministic_output(self, faker: Faker, num_samples: int) -> None:
         """Check whether ``faker.firefox()`` is deterministic, given the same seed."""
 


### PR DESCRIPTION
### What does this change

Make Firefox UA output deterministic when the same seed is used.

### What was wrong

The range from which the random dates were generated were dependent on the current date and therefore nondeterministic.

### How this fixes it

Random dates are now called with a fixed end of range, far in the future (`datetime.datetime.max`).

Fixes #1618

This PR was kindly supported by [Ordina Pythoneers](https://www.ordina.nl/vakgebieden/python/).