### PR TITLE
Add support for generating relative file paths

### DIFF
--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -258,12 +258,16 @@ class Provider(BaseProvider):
         depth: int = 1,
         category: Optional[str] = None,
         extension: Optional[str] = None,
+        absolute: Optional[bool] = True,
     ) -> str:
-        """Generate an absolute pathname to a file.
+        """Generate an pathname to a file.
 
         This method uses |file_name| under the hood to generate the file name
         itself, and ``depth`` controls the depth of the directory path, and
         |word| is used under the hood to generate the different directory names.
+
+        If ``absolute`` is ``True`` (default), the generated path starts with
+        ``/`` and is absolute. Otherwise, the generated path is relative.
 
         :sample: size=10
         :sample: depth=3
@@ -274,7 +278,7 @@ class Provider(BaseProvider):
         path: str = f"/{file}"
         for _ in range(0, depth):
             path = f"/{self.generator.word()}{path}"
-        return path
+        return path if absolute else path[1:]
 
     def unix_device(self, prefix: Optional[str] = None) -> str:
         """Generate a Unix device file name.

--- a/tests/providers/test_file.py
+++ b/tests/providers/test_file.py
@@ -15,6 +15,8 @@ class TestFile(unittest.TestCase):
         for _ in range(100):
             file_path = self.fake.file_path()
             assert re.search(r"\/\w+\/\w+\.\w+", file_path)
+            file_path = self.fake.file_path(absolute=False)
+            assert re.search(r"\w+\/\w+\.\w+", file_path)
             file_path = self.fake.file_path(depth=3)
             assert re.search(r"\/\w+\/\w+\/\w+\.\w+", file_path)
             file_path = self.fake.file_path(extension="pdf")


### PR DESCRIPTION
### What does this change

Add support for generating relative file paths to the file provider.

### What was wrong

`file_path()` would always return an absolute file path, i.e., one that starts with `/`.

### How this fixes it

The argument `absolute=True` is added to `file_path()`. It's `True` by default to not change the current behavior but can be set to `False` in case the user wants a relative path.