### PR TITLE
refactor(package): move to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "Faker"
+dynamic = ["version", "readme"]
+description = "Faker is a Python package that generates fake data for you."
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development :: Testing",
+  "Topic :: Utilities",
+  "License :: OSI Approved :: MIT License",
+]
+keywords = ["faker", "fixtures", "data", "test", "mock", "generator"]
+authors = [{name = "joke2k", email = "joke2k@gmail.com"}]
+urls = {homepage = "https://github.com/joke2k/faker"}
+license = {text = "MIT License"}
+requires-python = ">=3.6"
+dependencies = [
+  "python-dateutil>=2.4",
+  "typing-extensions>=3.10.0.2;python_version<'3.8'"
+]
+
+[project.scripts]
+faker = "faker.cli:execute_from_command_line"
+
+[project.entry-points]
+pytest11 = {faker = "faker.contrib.pytest.plugin"}
+
+[tool.setuptools.dynamic]
+version = {file = ["VERSION"]}
+readme = {file = ["README.rst"]}
+
+[tool.setuptools.packages.find]
+exclude = ["docs", "tests", "tests.*"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,9 @@ python_files = tests/*.py
 [doc8]
 ignore-path=.tox,docs/_build,*.egg-info
 max-line-length=120
+
+[metadata]
+platforms = any
+
+[options.package_data]
+faker = py.typed

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ try:
     )
 except AttributeError:
     zip_safe = False
-    
+
 setup(zip_safe=zip_safe)

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
 #!/usr/bin/env python
 
-from pathlib import Path
-
 from setuptools import find_packages, setup
-
-here = Path(__file__).resolve().parent
-README = (here / "README.rst").read_text(encoding="utf-8")
-VERSION = (here / "VERSION").read_text(encoding="utf-8").strip()
-
-excluded_packages = ["docs", "tests", "tests.*"]
-
 
 # this module can be zip-safe if the zipimporter implements iter_modules or if
 # pkgutil.iter_importer_modules has registered a dispatch for the zipimporter.
@@ -23,49 +14,5 @@ try:
     )
 except AttributeError:
     zip_safe = False
-
-setup(
-    name="Faker",
-    version=VERSION,
-    description="Faker is a Python package that generates fake data for you.",
-    long_description=README,
-    entry_points={
-        "console_scripts": ["faker=faker.cli:execute_from_command_line"],
-        "pytest11": ["faker = faker.contrib.pytest.plugin"],
-    },
-    classifiers=[
-        # See https://pypi.org/pypi?%3Aaction=list_classifiers
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Software Development :: Testing",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: MIT License",
-    ],
-    keywords="faker fixtures data test mock generator",
-    author="joke2k",
-    author_email="joke2k@gmail.com",
-    url="https://github.com/joke2k/faker",
-    license="MIT License",
-    packages=find_packages(exclude=excluded_packages),
-    package_data={
-        "faker": ["py.typed"],
-    },
-    platforms=["any"],
-    zip_safe=zip_safe,
-    python_requires=">=3.6",
-    install_requires=[
-        "python-dateutil>=2.4",
-        "typing-extensions>=3.10.0.2;python_version<'3.8'",
-    ],
-)
+    
+setup(zip_safe = zip_safe)

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,4 @@ try:
 except AttributeError:
     zip_safe = False
     
-setup(zip_safe = zip_safe)
+setup(zip_safe=zip_safe)


### PR DESCRIPTION
### What does this change

* Move package metadata to pyproject.toml (PEP 621)
* Move build system definition to pyproject.toml (PEP 517, 518)
* Move unsupported options to setup.cfg
* Refactor setup.py to only pass conditional zipsafe flag
* Will close #1636 

### What was wrong

#1636 requests moving the build configuration to `pyproject.toml` in order to ease the burden of switching to a non-`setuptools` build backend in the future.

### How this fixes it

Most metadata and build options that used to be supplied to `setup()` in `setup.py` have been moved to `pyproject.toml`, depending on current `setuptools` support [1] and the PEP 621 specification [2].

The two options whose inclusion in the above file is as of yet unsupported (`metadata`, `package_data`) were moved to `setup.cfg` instead [3]. Again, the reason most metadata lives in `pyproject.toml` is due to the expectation of switching to `poetry` as outlined in #1636.

The `zip_safe` option is generated conditionally and, as such, cannot be included in any of the above files - it remains in `setup.py`.

### Comments

* The new build configuration format was tested against the old by unpacking the wheels generated by `build` and running a [diff](https://github.com/joke2k/faker/files/8747804/diff.txt) (result linked).
* Unlike `setuptools`, `poetry` does not support dynamically loading the version number from a file. Since the `VERSION` file is only used during building as far as I can tell we could just configure `bumpversion` to change the entry in `pyproject.toml` instead.
* No clue what to do about the `zip_safe` flag - is there really any case where `!(zipimport.zipimporter in pkgutil.iter_importer_modules.registry.keys())`? Don't think `poetry` supports it as an option anyway.

[1] https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
[2] https://peps.python.org/pep-0621/
[3] https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
