### PR TITLE
Minor docstring changes and RUT range corrections

### DIFF
--- a/faker/providers/ssn/es_CL/__init__.py
+++ b/faker/providers/ssn/es_CL/__init__.py
@@ -29,33 +29,39 @@ class Provider(BaseProvider):
     A Faker provider for the Chilean VAT IDs, also known as RUTs.
 
     Sources:
-    https://es.wikipedia.org/wiki/Rol_%C3%9Anico_Tributario
-    https://presslatam.cl/2018/04/el-problema-de-la-escasez-y-stock-disponible-de-los-ruts-en-chile/
+
+    - https://es.wikipedia.org/wiki/Rol_%C3%9Anico_Tributario - Definition and check digit calculation
+    - https://presslatam.cl/2018/04/el-problema-de-la-escasez-y-stock-disponible-de-los-ruts-en-chile/
+      paragraph 4, where known ranges are described.
     """
 
+    minimum_rut_person = 10
+    maximum_rut_person = 31999999
+    minimum_rut_company = 60000000
+    maximum_rut_company = 99999999
     rut_format = "{:,d}-{:s}"
 
     def person_rut(self) -> str:
         """
         :return: a random Chilean RUT between a 10 and 31.999.999 range
         """
-        return self.rut(10, 31999999)
+        return self.rut(self.minimum_rut_person, self.maximum_rut_person)
 
     def company_rut(self) -> str:
         """
-        :return: a random Chilean RUT between 32.000.000 and 99.999.999
+        :return: a random Chilean RUT between 60.000.000 and 99.999.999
         """
-        return self.rut(32000000, 99999999)
+        return self.rut(self.minimum_rut_company, self.maximum_rut_company)
 
-    def rut(self, min: int = 10, max: int = 99999999) -> str:
+    def rut(self, min_value: int = minimum_rut_person, max_value: int = maximum_rut_company) -> str:
         """
         Generates a RUT within the specified ranges, inclusive.
 
-        :param min: Minimum RUT to generate.
-        :param max: Maximum RUT to generate.
+        :param min_value: Minimum RUT to generate.
+        :param max_value: Maximum RUT to generate.
         :return: a random Chilean RUT between 35.000.000 and 99.999.999
         """
 
-        digits = self.random_int(min, max)
+        digits = self.random_int(min_value, max_value)
         check = rut_check_digit(digits)
         return self.rut_format.format(digits, check).replace(",", ".")


### PR DESCRIPTION
### What does this change
- Redefine `faker.providers.ssn.es_CL.Provider.company_rut()` to return values starting from 60,000,000.
- Extract bounds to class definition.
- Reformat and improve `faker.providers.ssn.es_CL.Provider` docstring.

### What was wrong
Docstring was formatted improperly, and ranges did not match with cited sources.

### How this fixes it
See first section.