### PR TITLE
Rfc3339

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1877,8 +1877,8 @@ class Provider(BaseProvider):
         self,
         tzinfo: Optional[TzInfo] = None,
         end_datetime: Optional[DateParseType] = None,
-        sep: Optional[str] = 'T',
-        timespec: Optional[str] = 'auto'
+        sep: Optional[str] = "T",
+        timespec: Optional[str] = "auto",
     ) -> str:
         """
         Get a timestamp in ISO 8601 format (or one of its profiles).

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1877,12 +1877,17 @@ class Provider(BaseProvider):
         self,
         tzinfo: Optional[TzInfo] = None,
         end_datetime: Optional[DateParseType] = None,
+        sep: Optional[str] = 'T',
+        timespec: Optional[str] = 'auto'
     ) -> str:
         """
+        Get a timestamp in ISO 8601 format (or one of its profiles).
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
+        :param sep: separator between date and time, defaults to 'T'
+        :param timespec: format specifier for the time part, defaults to 'auto' - see datetime.isoformat() documentation
         :example: '2003-10-21T16:05:52+0000'
         """
-        return self.date_time(tzinfo, end_datetime=end_datetime).isoformat()
+        return self.date_time(tzinfo, end_datetime=end_datetime).isoformat(sep, timespec)
 
     def date(self, pattern: str = "%Y-%m-%d", end_datetime: Optional[DateParseType] = None) -> str:
         """

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -179,6 +179,18 @@ class TestDateTime(unittest.TestCase):
 
         assert not self.fake.iso8601().endswith("+00:00")
         assert self.fake.iso8601(utc).endswith("+00:00")
+        assert self.fake.iso8601()[10] == 'T'
+        assert len(self.fake.iso8601()) == 19
+        assert len(self.fake.iso8601(timespec = 'hours')) == 13
+        assert len(self.fake.iso8601(timespec = 'minutes')) == 16
+        assert len(self.fake.iso8601(timespec = 'seconds')) == 19
+        assert len(self.fake.iso8601(timespec = 'milliseconds')) == 23
+        assert len(self.fake.iso8601(timespec = 'microseconds')) == 26
+        # frequently used RFC 3339 separators
+        assert self.fake.iso8601(tzinfo = utc, sep = 't')[10] == 't'
+        assert self.fake.iso8601(tzinfo = utc, sep = ' ')[10] == ' '
+        assert self.fake.iso8601(tzinfo = utc, sep = '_')[10] == '_'
+        
 
     def test_date_object(self):
         assert isinstance(self.fake.date_object(), date)


### PR DESCRIPTION
### What does this change

* Expose `sep` and `timespec` parameters for isoformat()
* Update documentation
* Update tests

### What was wrong

Inspiration for this PR was gotten from #1628 - the RFC 3999 [1] format for date-time representation is universal in computing, therefore allowing for its full support in `faker` is a worthwhile effort.

Most of the various valid date and time representations [2] are already well-supported by `faker` through pattern-passing to the relevant producing functions. Combined date-time representations are, however, currently limited to the default `isoformat()` output.

### How this fixes it

The easiest and most maintainable way to add support for RFC 3999 (as well as all ISO 8601 timestamp profiles) would be to expose the `sep` and `timespec` parameters in `isoformat()`. This way users can just pass the specifics of the profile configuration they would like the result to be returned in. Changes are non-breaking and fully tested.

[1] https://datatracker.ietf.org/doc/html/rfc3339
[2] https://ijmacd.github.io/rfc3339-iso8601/