### PR TITLE
docs(docs/communityproviders.rst): Add faker-geoscience

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -18,6 +18,10 @@ Here's a list of Providers written by the community:
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |
 |               | for testing purposes     |                                  |
 +---------------+--------------------------+----------------------------------+
+| Geoscience    | Earth sciences-related   | `faker_geoscience`_              |
+|               | fake-random data         |                                  |
+|               | generators.              |                                  |
++---------------+--------------------------+----------------------------------+
 | Microservice  | Fake microservice names  | `faker_microservice`_            |
 +---------------+--------------------------+----------------------------------+
 | Music         | Music genres, subgenres, | `faker_music`_                   |
@@ -56,6 +60,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
 .. _faker_biology: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
+.. _faker_geoscience: https://pypi.org/project/faker-geoscience/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/
 .. _mdgen: https://pypi.org/project/mdgen/


### PR DESCRIPTION
### What does this change

* Add faker-geoscience to the community provider list

### Description

Me and @e-panourgia are collaborating on a new Faker community provider for data related to the Earth sciences - we used those collected for the purposes of #1665 to jump start the effort.

We'd be really glad if our project could be included in the list of community providers - it does fulfill all the basic requirements listed and we could use the visibility to invite contributions too.
