### PR TITLE
Add a new Education Provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -18,6 +18,9 @@ Here's a list of Providers written by the community:
 | Credit Score  | Fake credit score data   | `faker_credit_score`_            |
 |               | for testing purposes     |                                  |
 +---------------+--------------------------+----------------------------------+
+| Education     | Public school name and   | `faker_education`_               |
+|               | info for testing purposes|                                  |
++---------------+--------------------------+----------------------------------+
 | Geoscience    | Earth sciences-related   | `faker_geoscience`_              |
 |               | fake-random data         |                                  |
 |               | generators.              |                                  |
@@ -60,6 +63,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
 .. _faker_biology: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
+.. _faker_education: https://pypi.org/project/faker_education/ 
 .. _faker_geoscience: https://pypi.org/project/faker-geoscience/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/


### PR DESCRIPTION
I created a new education provider to populate public school information from schools in the United States. I may add additional information later but for now I needed this so I figured I'd publish so other's could use it too.

### What does this change

Links to a new community provider I built.

### What was wrong

I needed to generate school information such as school names and districts but couldn't find an easy way to do this without populating my own faker choice list.

### How this fixes it

I built my own provider using publicly available public school data.

Fixes #...
