### PR TITLE
fix: change format fake license_plate local_PT

### DIFF
--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -4,4 +4,4 @@ from .. import Provider as AutomotiveProvider
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
 
-    license_formats = ("???-####",)
+    license_formats = ("???-#?##",)

--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -3,5 +3,4 @@ from .. import Provider as AutomotiveProvider
 
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
-    
-    license_formats = ("???-####",)
+    license_formats = ("???-#?##",)

--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -3,4 +3,5 @@ from .. import Provider as AutomotiveProvider
 
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
+    
     license_formats = ("???-#?##",)

--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -3,6 +3,5 @@ from .. import Provider as AutomotiveProvider
 
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
-    # New format since March 2017
-
+    
     license_formats = ("???-####",)

--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -3,5 +3,5 @@ from .. import Provider as AutomotiveProvider
 
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
-    
+
     license_formats = ("???-#?##",)

--- a/faker/providers/automotive/pt_BR/__init__.py
+++ b/faker/providers/automotive/pt_BR/__init__.py
@@ -3,5 +3,6 @@ from .. import Provider as AutomotiveProvider
 
 class Provider(AutomotiveProvider):
     """Implement automotive provider for ``pt_BR`` locale."""
+    # New format since March 2017
 
-    license_formats = ("???-#?##",)
+    license_formats = ("???-####",)

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -48,7 +48,7 @@ class TestSkSk(_SimpleAutomotiveTestMixin):
 class TestPtBr(_SimpleAutomotiveTestMixin):
     """Test pt_BR automotive provider methods"""
 
-    license_plate_pattern: Pattern = re.compile(r"[A-Z]{3}-\d{4}")
+    license_plate_pattern: Pattern = re.compile(r"[A-Z]{3}-\d{1}[A-Z]{1}\d{2}")
 
 
 class TestPtPt(_SimpleAutomotiveTestMixin):


### PR DESCRIPTION
### What does this change

In 2017, Brazil joined Mercosul economic block, where vehicle license plates followed the standard among the bloc's member countries. As a result, a new board reconfiguration was adopted.

### What was wrong

As of old format, it had "LLL - NNNN" configuration plate. With the new change, the fifth element of the plate becomes a number. Ex: "LLL-NLNN".

### How this fixes it

The change basically when creating a new fake plate, the fifth element becomes a letter. Ex: "LLL-NLNN".

Fixes #...
