### PR TITLE
build(setup.py): Add `project_urls`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,12 @@ setup(
     author="joke2k",
     author_email="joke2k@gmail.com",
     url="https://github.com/joke2k/faker",
+    project_urls={
+        "Bug Tracker": "https://github.com/joke2k/faker/issues",
+        "Changes": "https://github.com/joke2k/faker/blob/master/CHANGELOG.md",
+        "Documentation": "http://faker.rtfd.org/",
+        "Source Code": "https://github.com/joke2k/faker",
+    },
     license="MIT License",
     packages=find_packages(exclude=excluded_packages),
     package_data={


### PR DESCRIPTION
### What does this change

Adds [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to _setup.py_

### What was wrong

When on [Faker's PyPI page](https://pypi.org/project/Faker/) it's not possible to get to changelog in a single click

### How this fixes it

Adds links which will be visible on next PyPI release

<details>

<summary>Preview</summary>

![image](https://user-images.githubusercontent.com/26336/179048302-75d5709e-5ccc-4470-9d3f-0cb970645fe8.png)

</details>