### PR TITLE
Fix Provider._parse_date_time to support timestamps (#1668)

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1983,7 +1983,7 @@ class Provider(BaseProvider):
             time_params = cls._parse_date_string(value)
             return datetime_to_timestamp(now + timedelta(**time_params))  # type: ignore
         if isinstance(value, int):
-            return datetime_to_timestamp(now + timedelta(value))
+            return value
         raise ParseError(f"Invalid format for date {value!r}")
 
     @classmethod

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -125,7 +125,7 @@ class TestDateTime(unittest.TestCase):
         assert timestamp > now
         delta = timedelta(days=30)
         from_delta = DatetimeProvider._parse_date_time(delta)
-        from_int = DatetimeProvider._parse_date_time(30)
+        from_int = DatetimeProvider._parse_date_time(timestamp)
 
         assert datetime.fromtimestamp(from_delta).date() == (datetime.fromtimestamp(timestamp).date())
 


### PR DESCRIPTION
### What does this change

Change `Provider._parse_date_time` to treat integer values as UNIX timestamps.

### What was wrong

`Provider._parse_date_time` when taking an integer as a parameter treats it as a timedelta in days where as `unix_time()` returns the POSIX timestamp in seconds. Either the creation of the timedelta object or its addition to `datetime.now()` would cause an
OverflowError.

### How this fixes it

Value is directly returned rather than being treated as a timedelta.

Fixes #1668
