### PR TITLE
Fixed uk_UA 5 digit postcode generation issue

### DIFF
--- a/faker/providers/address/uk_UA/__init__.py
+++ b/faker/providers/address/uk_UA/__init__.py
@@ -2235,7 +2235,7 @@ class Provider(AddressProvider):
 
     def postcode(self) -> str:
         """The code consists of five digits (01000-99999)"""
-        return f"{self.generator.random.randint(0, 10)}{self.generator.random.randint(1000, 10000)}"
+        return f"{self.generator.random.randrange(1000, 99999):05}"
 
     def street_prefix(self, min_length: Optional[int] = None, max_length: Optional[int] = None) -> str:
         return self.random_element(self.street_prefixes, min_length, max_length)


### PR DESCRIPTION
### What does this change
Changed the random no generation logic in postcode generation for uk_UA.

### What was wrong

- postcode() does not work properly for uk_UA
- The postcode consists of five digits (01000-99999)
- Actual behaviour was generating 6 digit postcodes sometimes.

### How this fixes it
- Postcode is generated between (01000-99999).

Fixes https://github.com/joke2k/faker/issues/1705
