### PR TITLE
Relax minimum version of `typing-extensions`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "python-dateutil>=2.4",
-        "typing-extensions>=3.10.0.2;python_version<'3.8'",
+        "typing-extensions>=3.7.4.3;python_version<'3.8'",
     ],
 )


### PR DESCRIPTION
### What does this change

The minimum version of `typing-extensions` is being relaxed, as reported in #1708.

### What was wrong

Version 3.10 is too new for some setups involving multiple packages, while there has been not apparent reason for this requirement.

### How this fixes it

Reduce the required version to 3.7.4.3 which did not cause issues in my tests.

Fixes #1708.
