### PR TITLE
Add support for prefix and suffix to `pystr` provider

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -51,20 +51,22 @@ class Provider(BaseProvider):
     def pybool(self) -> bool:
         return self.random_int(0, 1) == 1
 
-    def pystr(self, min_chars: Optional[int] = None, max_chars: int = 20) -> str:
+    def pystr(self, min_chars: Optional[int] = None, max_chars: int = 20, prefix: str = "", suffix: str = "") -> str:
         """
         Generates a random string of upper and lowercase letters.
         :return: Random of random length between min and max characters.
         """
         if min_chars is None:
-            return "".join(self.random_letters(length=max_chars))
+            chars = "".join(self.random_letters(length=max_chars))
         else:
             assert max_chars >= min_chars, "Maximum length must be greater than or equal to minimum length"
-            return "".join(
+            chars = "".join(
                 self.random_letters(
                     length=self.generator.random.randint(min_chars, max_chars),
                 ),
             )
+
+        return prefix + chars + suffix
 
     def pystr_format(
         self,

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -397,6 +397,56 @@ class TestPydecimal(unittest.TestCase):
         self.assertGreater(result, 10**1000)
 
 
+class TestPystr(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker(includes=["tests.mymodule.en_US"])
+        Faker.seed(0)
+
+    def test_no_parameters(self):
+        some_string = self.fake.pystr()
+        assert isinstance(some_string, str)
+        assert len(some_string) <= 20
+
+    def test_lower_length_limit(self):
+        some_string = self.fake.pystr(min_chars=3)
+        assert isinstance(some_string, str)
+        assert len(some_string) >= 3
+        assert len(some_string) <= 20
+
+    def test_upper_length_limit(self):
+        some_string = self.fake.pystr(max_chars=5)
+        assert isinstance(some_string, str)
+        assert len(some_string) <= 5
+
+    def test_invalid_length_limits(self):
+        with self.assertRaises(AssertionError):
+            self.fake.pystr(min_chars=6, max_chars=5)
+
+    def test_exact_length(self):
+        some_string = self.fake.pystr(min_chars=5, max_chars=5)
+        assert isinstance(some_string, str)
+        assert len(some_string) == 5
+
+    def test_prefix(self):
+        some_string = self.fake.pystr(prefix="START_")
+        assert isinstance(some_string, str)
+        assert some_string.startswith("START_")
+        assert len(some_string) == 26
+
+    def test_suffix(self):
+        some_string = self.fake.pystr(suffix="_END")
+        assert isinstance(some_string, str)
+        assert some_string.endswith("_END")
+        assert len(some_string) == 24
+
+    def test_prefix_and_suffix(self):
+        some_string = self.fake.pystr(min_chars=9, max_chars=20, prefix="START_", suffix="_END")
+        assert isinstance(some_string, str)
+        assert some_string.startswith("START_")
+        assert some_string.endswith("_END")
+        assert len(some_string) >= 19
+
+
 class TestPystrFormat(unittest.TestCase):
     def setUp(self):
         self.fake = Faker(includes=["tests.mymodule.en_US"])
@@ -421,26 +471,6 @@ class TestPython(unittest.TestCase):
     def test_pybool(self):
         some_bool = self.factory.pybool()
         assert isinstance(some_bool, bool)
-
-    def py_str(self):
-        some_string = self.factory.pystr()
-        assert isinstance(some_string, str)
-        assert len(some_string) <= 20
-
-        some_string = self.factory.pystr(min_chars=3)
-        assert isinstance(some_string, str)
-        assert len(some_string) >= 3
-        assert len(some_string) <= 20
-
-        some_string = self.factory.pystr(max_chars=5)
-        assert isinstance(some_string, str)
-        assert len(some_string) <= 5
-
-        with self.assertRaises(AssertionError):
-            self.factory.pystr(min_chars=6, max_chars=5)
-
-        with self.assertRaises(AssertionError):
-            self.factory.pystr(min_chars=5, max_chars=5)
 
     def test_pytuple(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
### What does this change

Adds support for providing a prefix and a suffix for the `pystr` provider.

### What was wrong

The `pystr` provider did not allow to use prefixes and suffixes, which is required for migrating from `factory_boy.fuzzy.FuzzyText`.

### How this fixes it

Adds two new parameters for it.

Additionally, the `pystr` tests have been fixed itself, as they have not been running lately (missing `test_` prefix for the method) and the assertion for `min_chars == max_chars` was broken as well.

Fixes #1707.
