### PR TITLE
Improve pydecimal provider with min and max values

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -176,22 +176,23 @@ class Provider(BaseProvider):
 
     def pydecimal(
         self,
-        left_digits=None,
-        right_digits=None,
-        positive=False,
-        min_value=None,
-        max_value=None,
-    ):
+        left_digits: Optional[int] = None,
+        right_digits: Optional[int] = None,
+        positive: bool = False,
+        min_value: Optional[Union[int, float, Decimal]] = None,
+        max_value: Optional[Union[int, float, Decimal]] = None,
+    ) -> Decimal:
         if left_digits is not None and left_digits < 0:
             raise ValueError("A decimal number cannot have less than 0 digits in its " "integer part")
         if right_digits is not None and right_digits < 0:
             raise ValueError("A decimal number cannot have less than 0 digits in its " "fractional part")
         if (left_digits is not None and left_digits == 0) and (right_digits is not None and right_digits == 0):
             raise ValueError("A decimal number cannot have 0 digits in total")
-        if None not in (min_value, max_value) and min_value > max_value:
-            raise ValueError("Min value cannot be greater than max value")
-        if None not in (min_value, max_value) and min_value == max_value:
-            raise ValueError("Min and max value cannot be the same")
+        if min_value is not None and max_value is not None:
+            if min_value > max_value:
+                raise ValueError("Min value cannot be greater than max value")
+            if min_value == max_value:
+                raise ValueError("Min and max value cannot be the same")
         if positive and min_value is not None and min_value <= 0:
             raise ValueError("Cannot combine positive=True with negative or zero min_value")
         if left_digits is not None and max_value and math.ceil(math.log10(abs(max_value))) > left_digits:

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -396,6 +396,117 @@ class TestPydecimal(unittest.TestCase):
         result = self.fake.pydecimal(min_value=10**1000)
         self.assertGreater(result, 10**1000)
 
+    def test_with_min_and_max_values_between_zero_and_one(self):
+        Faker.seed("4")
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("0.02"), max_value=decimal.Decimal("0.6"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("0.02"))
+        self.assertLessEqual(result, decimal.Decimal("0.6"))
+
+    def test_with_min_and_max_values_between_zero_and_minus_one(self):
+        Faker.seed("4")
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-0.6"), max_value=decimal.Decimal("-0.02"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-0.6"))
+        self.assertLessEqual(result, decimal.Decimal("-0.02"))
+
+    def test_with_min_and_max_values_within_a_positive_tiny_interval(self):
+        Faker.seed("2")  # Left is 0, right ∈ [150 ; 970]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("0.15"), max_value=decimal.Decimal("0.97"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("0.15"))
+        self.assertLessEqual(result, decimal.Decimal("0.97"))
+
+        Faker.seed("2")  # Left is 1, right ∈ [380 ; 610]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("1.38"), max_value=decimal.Decimal("1.61"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("1.38"))
+        self.assertLessEqual(result, decimal.Decimal("1.61"))
+
+        Faker.seed("2")  # Left is 3, right ∈ [0 ; 600]
+        result = self.fake.pydecimal(min_value=decimal.Decimal("1.7"), max_value=decimal.Decimal("3.6"), right_digits=3)
+        self.assertGreaterEqual(result, decimal.Decimal("1.7"))
+        self.assertLessEqual(result, decimal.Decimal("3.6"))
+
+        Faker.seed("1")  # Left is 2, right ∈ [0 ; 999]
+        result = self.fake.pydecimal(min_value=decimal.Decimal("1.7"), max_value=decimal.Decimal("3.6"), right_digits=3)
+        self.assertGreaterEqual(result, decimal.Decimal("1.7"))
+        self.assertLessEqual(result, decimal.Decimal("3.6"))
+
+        Faker.seed("4")  # Left is 1, right ∈ [700 ; 999]
+        result = self.fake.pydecimal(min_value=decimal.Decimal("1.7"), max_value=decimal.Decimal("3.6"), right_digits=3)
+        self.assertGreaterEqual(result, decimal.Decimal("1.7"))
+        self.assertLessEqual(result, decimal.Decimal("3.6"))
+
+    def test_with_min_and_max_values_within_a_negative_tiny_interval(self):
+        Faker.seed("2")  # Left is 0, right ∈ [150 ; 970]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-0.97"), max_value=decimal.Decimal("-0.15"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-0.97"))
+        self.assertLessEqual(result, decimal.Decimal("-0.15"))
+
+        Faker.seed("2")  # Left is (-)1, right ∈ [380 ; 610]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-1.61"), max_value=decimal.Decimal("-1.38"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-1.61"))
+        self.assertLessEqual(result, decimal.Decimal("-1.38"))
+
+        Faker.seed("2")  # Left is (-)3, right ∈ [600 ; 999]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-3.6"), max_value=decimal.Decimal("-1.7"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-3.6"))
+        self.assertLessEqual(result, decimal.Decimal("-1.7"))
+
+        Faker.seed("1")  # Left is (-)2, right ∈ [0 ; 999]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-3.6"), max_value=decimal.Decimal("-1.7"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-3.6"))
+        self.assertLessEqual(result, decimal.Decimal("-1.7"))
+
+        Faker.seed("4")  # Left is (-)1, right ∈ [0 ; 700]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-3.6"), max_value=decimal.Decimal("-1.7"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-3.6"))
+        self.assertLessEqual(result, decimal.Decimal("-1.7"))
+
+    def test_with_min_and_max_values_within_a_sign_overlapping_tiny_interval(self):
+        Faker.seed("1")  # Sign is -, left is 1, right ∈ [450 ; 999]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-1.45"), max_value=decimal.Decimal("1.52"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-1.45"))
+        self.assertLessEqual(result, decimal.Decimal("1.52"))
+
+        Faker.seed("0")  # Sign is -, left is 0, right ∈ [0 ; 999]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-1.45"), max_value=decimal.Decimal("1.52"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-1.45"))
+        self.assertLessEqual(result, decimal.Decimal("1.52"))
+
+        Faker.seed("9")  # Sign is +, left is 0, right ∈ [0 ; 999]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-1.45"), max_value=decimal.Decimal("1.52"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-1.45"))
+        self.assertLessEqual(result, decimal.Decimal("1.52"))
+
+        Faker.seed("4")  # Sign is +, left is 1, right ∈ [0 ; 520]
+        result = self.fake.pydecimal(
+            min_value=decimal.Decimal("-1.45"), max_value=decimal.Decimal("1.52"), right_digits=3
+        )
+        self.assertGreaterEqual(result, decimal.Decimal("-1.45"))
+        self.assertLessEqual(result, decimal.Decimal("1.52"))
+
 
 class TestPystrFormat(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this change

Improve numbers generation through the pydecimal provider, especially with `min_value` and `max_value`.

### What was wrong

The pydecimal provider was not accepting floats or decimals for min and max value boundaries.  
Hence it was not possible to cover some cases, like scoped percent values (consider any N-decimal number between 73,5% and 98%, so with `min_value=D("0.735")` and `max_value = D("0.98")`).

### How this fixes it

Support decimals and floats for `min_value` and `max_value`. Improve right number generation accordingly.
