### PR TITLE
Allow calls to Faker instance from module (WIP)

### DIFF
--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -5,3 +5,7 @@ from faker.proxy import Faker
 VERSION = "14.2.0"
 
 __all__ = ("Factory", "Generator", "Faker")
+
+_faker = Faker()
+name = _faker.name
+seed = Faker.seed


### PR DESCRIPTION
### What does this change

Allows calls to the faker module using a pre-defined Faker instance.

(This is only a demonstration, as other methods would need to be added... I found more than a hundred!)

### What was wrong

This was required:

```python
from faker import Faker
faker = Faker()

faker.seed(123)
print(faker.name())
```

### How this fixes it

This allows a simpler code:

```python
import faker

faker.seed(123)
print(faker.name())
```

Fixes #1722
