### PR TITLE
Add enum provider

### DIFF
--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
-from enum import Enum, auto
 
+from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from .generator import Generator

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -3,12 +3,12 @@ import string
 import sys
 import warnings
 
-from enum import Enum
 from decimal import Decimal
+from enum import Enum
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union, cast, no_type_check
 
-from .. import BaseProvider, ElementsType
 from ...exceptions import BaseFakerException
+from .. import BaseProvider, ElementsType
 
 TypesNames = List[str]
 TypesSpec = Union[List[Type], Tuple[Type, ...]]
@@ -437,13 +437,11 @@ class Provider(BaseProvider):
             raise ValueError("'enum_cls' cannot be None")
 
         if not issubclass(enum_cls, Enum):
-            raise TypeError(f"'enum_cls' must be an Enum type")
+            raise TypeError("'enum_cls' must be an Enum type")
 
         members: List[TEnum] = list(cast(Iterable[TEnum], enum_cls))
 
         if len(members) < 1:
-            raise EmptyEnumException(
-                f"The provided Enum: '{enum_cls.__name__}' has no members."
-            )
+            raise EmptyEnumException(f"The provided Enum: '{enum_cls.__name__}' has no members.")
 
         return self.random_element(members)

--- a/tests/providers/test_enum.py
+++ b/tests/providers/test_enum.py
@@ -1,6 +1,6 @@
-import pytest
-
 from enum import Enum, auto
+
+import pytest
 
 from faker.providers.python import EmptyEnumException
 
@@ -49,4 +49,3 @@ class TestEnumProvider:
         not_an_enum_type = type("NotAnEnumType")
         with pytest.raises(TypeError):
             faker.enum(not_an_enum_type)
-


### PR DESCRIPTION
### What does this change

Adds an enum provider to allow users to generate values based on enums. 

#### Usage:
```python
from enum import Enum

from faker import Faker


class Color(Enum):
    RED = 1
    GREEN = 2
    BLUE = 3


fake = Faker()
fake.enum(Color)
# One of [Color.RED, Color.GREEN, Color.BLUE]
```

