### PR TITLE
Fix ImportError on python <3.7.2

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -1,7 +1,12 @@
 import re
 import string
 
-from typing import Any, Collection, List, Optional, OrderedDict, Sequence, TypeVar, Union
+from typing import Any, Collection, List, Optional, Sequence, TypeVar, Union
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    from typing_extensions import OrderedDict
 
 from ..generator import Generator
 from ..utils.distribution import choices_distribution, choices_distribution_unique

--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -1,14 +1,11 @@
 import re
 import string
 
+from collections import OrderedDict
 from typing import Any, Collection, List, Optional, Sequence, TypeVar, Union
 
-try:
-    from typing import OrderedDict
-except ImportError:
-    from typing_extensions import OrderedDict
-
 from ..generator import Generator
+from ..typing import OrderedDictType
 from ..utils.distribution import choices_distribution, choices_distribution_unique
 
 _re_hash = re.compile(r"#")
@@ -20,7 +17,7 @@ _re_cir = re.compile(r"\^")
 
 S = TypeVar("S")
 T = TypeVar("T")
-ElementsType = Union[Collection[T], OrderedDict[T, float]]
+ElementsType = Union[Collection[T], OrderedDictType[T, float]]
 
 
 class BaseProvider:

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 9):
 elif sys.version_info >= (3, 7, 2):
     from typing import OrderedDict as OrderedDictType
 else:
-    from typing_extensions import OrderedDict as OrderedDictType
+    from typing_extensions import OrderedDict as OrderedDictType  # NOQA
 
 DateParseType = Union[date, datetime, timedelta, str, int]
 HueType = TypeVar("HueType", str, float, Sequence[int])

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -1,3 +1,5 @@
+import sys
+
 from datetime import date, datetime, timedelta
 from typing import Sequence, TypeVar, Union
 
@@ -5,6 +7,13 @@ try:
     from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal  # type: ignore
+
+if sys.version_info >= (3, 9):
+    from collections import OrderedDict as OrderedDictType
+elif sys.version_info >= (3, 7, 2):
+    from typing import OrderedDict as OrderedDictType
+else:
+    from typing_extensions import OrderedDict as OrderedDictType
 
 DateParseType = Union[date, datetime, timedelta, str, int]
 HueType = TypeVar("HueType", str, float, Sequence[int])


### PR DESCRIPTION
788350230154b6e2c151850f9e9c0b7f1abccbca added an import of `typing.OrderedDict` but this was added in Python 3.7.2[1] resulting in an import failure for python versions before this.

[1] https://docs.python.org/3/library/typing.html#typing.OrderedDict

### What does this change

Fix ImportError on python <3.7.2

### What was wrong

There is an `ImporError` in python versions before this, see #1732

### How this fixes it

Import from `typing_extensions` if not available in `typing`

Fixes #1732
