### PR TITLE
Fix type variable inside the ElementsType

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -405,7 +405,7 @@ class BaseProvider:
 
     def random_elements(
         self,
-        elements: ElementsType[T] = ("a", "b", "c"),
+        elements: ElementsType[T] = ("a", "b", "c"),  # type: ignore[assignment]
         length: Optional[int] = None,
         unique: bool = False,
         use_weighting: Optional[bool] = None,
@@ -498,7 +498,11 @@ class BaseProvider:
             length=length,
         )
 
-    def random_choices(self, elements: ElementsType[T] = ("a", "b", "c"), length: Optional[int] = None) -> Sequence[T]:
+    def random_choices(
+        self,
+        elements: ElementsType[T] = ("a", "b", "c"),  # type: ignore[assignment]
+        length: Optional[int] = None,
+    ) -> Sequence[T]:
         """Generate a list of objects randomly sampled from ``elements`` with replacement.
 
         For information on the ``elements`` and ``length`` arguments, please refer to
@@ -541,7 +545,11 @@ class BaseProvider:
 
         return self.random_elements(elements, length=1)[0]
 
-    def random_sample(self, elements: ElementsType[T] = ("a", "b", "c"), length: Optional[int] = None) -> Sequence[T]:
+    def random_sample(
+        self,
+        elements: ElementsType[T] = ("a", "b", "c"),  # type: ignore[assignment]
+        length: Optional[int] = None
+    ) -> Sequence[T]:
         """Generate a list of objects randomly sampled from ``elements`` without replacement.
 
         For information on the ``elements`` and ``length`` arguments, please refer to

--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -4,21 +4,21 @@ localized = True
 
 
 class Provider(BaseProvider):
-    city_suffixes: ElementsType = ["Ville"]
-    street_suffixes: ElementsType = ["Street"]
-    city_formats: ElementsType = ("{{first_name}} {{city_suffix}}",)
-    street_name_formats: ElementsType = ("{{last_name}} {{street_suffix}}",)
-    street_address_formats: ElementsType = ("{{building_number}} {{street_name}}",)
-    address_formats: ElementsType = ("{{street_address}} {{postcode}} {{city}}",)
-    building_number_formats: ElementsType = ("##",)
-    postcode_formats: ElementsType = ("#####",)
-    countries: ElementsType = [tz["name"] for tz in date_time.Provider.countries]
+    city_suffixes: ElementsType[str] = ["Ville"]
+    street_suffixes: ElementsType[str] = ["Street"]
+    city_formats: ElementsType[str] = ("{{first_name}} {{city_suffix}}",)
+    street_name_formats: ElementsType[str] = ("{{last_name}} {{street_suffix}}",)
+    street_address_formats: ElementsType[str] = ("{{building_number}} {{street_name}}",)
+    address_formats: ElementsType[str] = ("{{street_address}} {{postcode}} {{city}}",)
+    building_number_formats: ElementsType[str] = ("##",)
+    postcode_formats: ElementsType[str] = ("#####",)
+    countries: ElementsType[str] = [tz["name"] for tz in date_time.Provider.countries]
 
     ALPHA_2 = "alpha-2"
     ALPHA_3 = "alpha-3"
 
-    alpha_2_country_codes: ElementsType = [tz["alpha-2-code"] for tz in date_time.Provider.countries]
-    alpha_3_country_codes: ElementsType = [tz["alpha-3-code"] for tz in date_time.Provider.countries]
+    alpha_2_country_codes: ElementsType[str] = [tz["alpha-2-code"] for tz in date_time.Provider.countries]
+    alpha_3_country_codes: ElementsType[str] = [tz["alpha-3-code"] for tz in date_time.Provider.countries]
 
     def city_suffix(self) -> str:
         """

--- a/faker/providers/address/es_CL/__init__.py
+++ b/faker/providers/address/es_CL/__init__.py
@@ -557,7 +557,7 @@ class Provider(AddressProvider):
     )
 
     # Some streets are named by plants
-    plant_street_names: ElementsType = (
+    plant_street_names: ElementsType[str] = (
         "Los Cactus",
         "Los Laureles",
         "Los Piñones",

--- a/faker/providers/color/__init__.py
+++ b/faker/providers/color/__init__.py
@@ -156,7 +156,7 @@ class Provider(BaseProvider):
         )
     )
 
-    safe_colors: ElementsType = (
+    safe_colors: ElementsType[str] = (
         "black",
         "maroon",
         "green",

--- a/faker/providers/company/__init__.py
+++ b/faker/providers/company/__init__.py
@@ -6,15 +6,15 @@ localized = True
 
 
 class Provider(BaseProvider):
-    formats: ElementsType = (
+    formats: ElementsType[str] = (
         "{{last_name}} {{company_suffix}}",
         "{{last_name}}-{{last_name}}",
         "{{last_name}}, {{last_name}} and {{last_name}}",
     )
 
-    company_suffixes: ElementsType = ("Inc", "and Sons", "LLC", "Group", "PLC", "Ltd")
+    company_suffixes: ElementsType[str] = ("Inc", "and Sons", "LLC", "Group", "PLC", "Ltd")
 
-    catch_phrase_words: Tuple[ElementsType, ...] = (
+    catch_phrase_words: Tuple[ElementsType[str], ...] = (
         (
             "Adaptive",
             "Advanced",
@@ -328,7 +328,7 @@ class Provider(BaseProvider):
         ),
     )
 
-    bsWords: Tuple[ElementsType, ...] = (
+    bsWords: Tuple[ElementsType[str], ...] = (
         (
             "implement",
             "utilize",

--- a/faker/providers/company/es_CL/__init__.py
+++ b/faker/providers/company/es_CL/__init__.py
@@ -413,7 +413,7 @@ class Provider(CompanyProvider):
         ),
     )
 
-    company_prefixes: ElementsType = (
+    company_prefixes: ElementsType[str] = (
         "Corporación",
         "Compañía",
         "Comercial",
@@ -426,7 +426,7 @@ class Provider(CompanyProvider):
         "Proyectos",
     )
 
-    company_suffixes: ElementsType = (
+    company_suffixes: ElementsType[str] = (
         "Sociedad Anónima",
         "Limitada",
         "S.A.",

--- a/faker/providers/currency/__init__.py
+++ b/faker/providers/currency/__init__.py
@@ -306,7 +306,7 @@ class Provider(BaseProvider):
         "ZWD": "\u0024",
     }
 
-    price_formats: ElementsType = ["#.##", "%#.##", "%##.##", "%,###.##", "%#,###.##"]
+    price_formats: ElementsType[str] = ["#.##", "%#.##", "%##.##", "%,###.##", "%#,###.##"]
 
     def currency(self) -> Tuple[str, str]:
         return self.random_element(self.currencies)

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -72,7 +72,7 @@ for name, sym in [
 
 
 class Provider(BaseProvider):
-    centuries: ElementsType = [
+    centuries: ElementsType[str] = [
         "I",
         "II",
         "III",

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -9,7 +9,7 @@ from .. import BaseProvider, ElementsType
 class Provider(BaseProvider):
     """Implement default file provider for Faker."""
 
-    application_mime_types: ElementsType = (
+    application_mime_types: ElementsType[str] = (
         "application/atom+xml",  # Atom feeds
         "application/ecmascript",
         # ECMAScript/JavaScript; Defined in RFC 4329 (equivalent to
@@ -49,7 +49,7 @@ class Provider(BaseProvider):
         "application/gzip",  # Gzip, Defined in RFC 6713
     )
 
-    audio_mime_types: ElementsType = (
+    audio_mime_types: ElementsType[str] = (
         "audio/basic",  # mulaw audio at 8 kHz, 1 channel; Defined in RFC 2046
         "audio/L24",  # 24bit Linear PCM audio at 8-48 kHz, 1-N channels; Defined in RFC 3190
         "audio/mp4",  # MP4 audio
@@ -62,7 +62,7 @@ class Provider(BaseProvider):
         "audio/webm",  # WebM open media format
     )
 
-    image_mime_types: ElementsType = (
+    image_mime_types: ElementsType[str] = (
         "image/gif",  # GIF image; Defined in RFC 2045 and RFC 2046
         "image/jpeg",  # JPEG JFIF image; Defined in RFC 2045 and RFC 2046
         "image/pjpeg",
@@ -76,7 +76,7 @@ class Provider(BaseProvider):
         "image/vnd.microsoft.icon",  # ICO image; Registered[11]
     )
 
-    message_mime_types: ElementsType = (
+    message_mime_types: ElementsType[str] = (
         "message/http",  # Defined in RFC 2616
         "message/imdn+xml",  # IMDN Instant Message Disposition Notification; Defined in RFC 5438
         "message/partial",  # Email; Defined in RFC 2045 and RFC 2046
@@ -85,7 +85,7 @@ class Provider(BaseProvider):
         "message/rfc822",
     )
 
-    model_mime_types: ElementsType = (
+    model_mime_types: ElementsType[str] = (
         "model/example",  # Defined in RFC 4735
         "model/iges",  # IGS files, IGES files; Defined in RFC 2077
         "model/mesh",  # MSH files, MESH files; Defined in RFC 2077, SILO files
@@ -97,7 +97,7 @@ class Provider(BaseProvider):
         "model/x3d+xml",  # X3D ISO standard for representing 3D computer graphics, X3D XML files
     )
 
-    multipart_mime_types: ElementsType = (
+    multipart_mime_types: ElementsType[str] = (
         "multipart/mixed",  # MIME Email; Defined in RFC 2045 and RFC 2046
         "multipart/alternative",  # MIME Email; Defined in RFC 2045 and RFC 2046
         # MIME Email; Defined in RFC 2387 and used by MHTML (HTML mail)
@@ -107,7 +107,7 @@ class Provider(BaseProvider):
         "multipart/encrypted",  # Defined in RFC 1847
     )
 
-    text_mime_types: ElementsType = (
+    text_mime_types: ElementsType[str] = (
         "text/cmd",  # commands; subtype resident in Gecko browsers like Firefox 3.5
         "text/css",  # Cascading Style Sheets; Defined in RFC 2318
         "text/csv",  # Comma-separated values; Defined in RFC 4180
@@ -123,7 +123,7 @@ class Provider(BaseProvider):
         "text/xml",  # Extensible Markup Language; Defined in RFC 3023
     )
 
-    video_mime_types: ElementsType = (
+    video_mime_types: ElementsType[str] = (
         "video/mpeg",  # MPEG-1 video with multiplexed audio; Defined in RFC 2045 and RFC 2046
         "video/mp4",  # MP4 video; Defined in RFC 4337
         # Ogg Theora or other video (with audio); Defined in RFC 5334
@@ -135,7 +135,7 @@ class Provider(BaseProvider):
         "video/x-flv",  # Flash video (FLV files)
     )
 
-    mime_types: Dict[str, ElementsType] = OrderedDict(
+    mime_types: Dict[str, ElementsType[str]] = OrderedDict(
         (
             ("application", application_mime_types),
             ("audio", audio_mime_types),
@@ -148,13 +148,13 @@ class Provider(BaseProvider):
         )
     )
 
-    audio_file_extensions: ElementsType = (
+    audio_file_extensions: ElementsType[str] = (
         "flac",
         "mp3",
         "wav",
     )
 
-    image_file_extensions: ElementsType = (
+    image_file_extensions: ElementsType[str] = (
         "bmp",
         "gif",
         "jpeg",
@@ -163,7 +163,7 @@ class Provider(BaseProvider):
         "tiff",
     )
 
-    text_file_extensions: ElementsType = (
+    text_file_extensions: ElementsType[str] = (
         "css",
         "csv",
         "html",
@@ -172,14 +172,14 @@ class Provider(BaseProvider):
         "txt",
     )
 
-    video_file_extensions: ElementsType = (
+    video_file_extensions: ElementsType[str] = (
         "mp4",
         "avi",
         "mov",
         "webm",
     )
 
-    office_file_extensions: ElementsType = (
+    office_file_extensions: ElementsType[str] = (
         "doc",  # legacy MS Word
         "docx",  # MS Word
         "xls",  # legacy MS Excel
@@ -195,7 +195,7 @@ class Provider(BaseProvider):
         "pdf",  # Portable Document Format
     )
 
-    file_extensions: Dict[str, ElementsType] = OrderedDict(
+    file_extensions: Dict[str, ElementsType[str]] = OrderedDict(
         (
             ("audio", audio_file_extensions),
             ("image", image_file_extensions),
@@ -204,7 +204,7 @@ class Provider(BaseProvider):
             ("video", video_file_extensions),
         )
     )
-    unix_device_prefixes: ElementsType = ("sd", "vd", "xvd")
+    unix_device_prefixes: ElementsType[str] = ("sd", "vd", "xvd")
 
     def mime_type(self, category: Optional[str] = None) -> str:
         """Generate a mime type under the specified ``category``.

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -56,9 +56,9 @@ class _IPv4Constants:
 
 
 class Provider(BaseProvider):
-    safe_domain_names: ElementsType = ("example.org", "example.com", "example.net")
-    free_email_domains: ElementsType = ("gmail.com", "yahoo.com", "hotmail.com")
-    tlds: ElementsType = (
+    safe_domain_names: ElementsType[str] = ("example.org", "example.com", "example.net")
+    free_email_domains: ElementsType[str] = ("gmail.com", "yahoo.com", "hotmail.com")
+    tlds: ElementsType[str] = (
         "com",
         "com",
         "com",
@@ -70,7 +70,7 @@ class Provider(BaseProvider):
         "net",
         "org",
     )
-    hostname_prefixes: ElementsType = (
+    hostname_prefixes: ElementsType[str] = (
         "db",
         "srv",
         "desktop",
@@ -79,7 +79,7 @@ class Provider(BaseProvider):
         "email",
         "web",
     )
-    uri_pages: ElementsType = (
+    uri_pages: ElementsType[str] = (
         "index",
         "home",
         "search",
@@ -95,7 +95,7 @@ class Provider(BaseProvider):
         "privacy",
         "author",
     )
-    uri_paths: ElementsType = (
+    uri_paths: ElementsType[str] = (
         "app",
         "main",
         "wp-content",
@@ -109,7 +109,7 @@ class Provider(BaseProvider):
         "list",
         "explore",
     )
-    uri_extensions: ElementsType = (
+    uri_extensions: ElementsType[str] = (
         ".html",
         ".html",
         ".html",
@@ -120,7 +120,7 @@ class Provider(BaseProvider):
         ".jsp",
         ".asp",
     )
-    http_methods: ElementsType = (
+    http_methods: ElementsType[str] = (
         "GET",
         "HEAD",
         "POST",
@@ -132,28 +132,28 @@ class Provider(BaseProvider):
         "PATCH",
     )
 
-    user_name_formats: ElementsType = (
+    user_name_formats: ElementsType[str] = (
         "{{last_name}}.{{first_name}}",
         "{{first_name}}.{{last_name}}",
         "{{first_name}}##",
         "?{{last_name}}",
     )
-    email_formats: ElementsType = (
+    email_formats: ElementsType[str] = (
         "{{user_name}}@{{domain_name}}",
         "{{user_name}}@{{free_email_domain}}",
     )
-    url_formats: ElementsType = (
+    url_formats: ElementsType[str] = (
         "www.{{domain_name}}/",
         "{{domain_name}}/",
     )
-    uri_formats: ElementsType = (
+    uri_formats: ElementsType[str] = (
         "{{url}}",
         "{{url}}{{uri_page}}/",
         "{{url}}{{uri_page}}{{uri_extension}}",
         "{{url}}{{uri_path}}/{{uri_page}}/",
         "{{url}}{{uri_path}}/{{uri_page}}{{uri_extension}}",
     )
-    image_placeholder_services: ElementsType = (
+    image_placeholder_services: ElementsType[str] = (
         "https://picsum.photos/{width}/{height}",
         "https://dummyimage.com/{width}x{height}",
         "https://placekitten.com/{width}/{height}",

--- a/faker/providers/job/__init__.py
+++ b/faker/providers/job/__init__.py
@@ -4,7 +4,7 @@ localized = True
 
 
 class Provider(BaseProvider):
-    jobs: ElementsType = (
+    jobs: ElementsType[str] = (
         "Academic librarian",
         "Accommodation manager",
         "Accountant, chartered",

--- a/faker/providers/job/es/__init__.py
+++ b/faker/providers/job/es/__init__.py
@@ -5,7 +5,7 @@ from .. import Provider as BaseProvider
 class Provider(BaseProvider):
     # Source:
     # https://www.ilo.org/public/spanish/bureau/stat/isco/docs/struct08.xls
-    jobs: ElementsType = (
+    jobs: ElementsType[str] = (
         "Abogado",
         "Acarreador de agua",
         "Recolector de leña",

--- a/faker/providers/person/__init__.py
+++ b/faker/providers/person/__init__.py
@@ -6,14 +6,14 @@ localized = True
 
 
 class Provider(BaseProvider):
-    formats: ElementsType = ["{{first_name}} {{last_name}}"]
+    formats: ElementsType[str] = ["{{first_name}} {{last_name}}"]
 
-    first_names: ElementsType = ["John", "Jane"]
+    first_names: ElementsType[str] = ["John", "Jane"]
 
-    last_names: ElementsType = ["Doe"]
+    last_names: ElementsType[str] = ["Doe"]
 
     # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-    language_names: ElementsType = [
+    language_names: ElementsType[str] = [
         "Afar",
         "Abkhazian",
         "Avestan",

--- a/faker/providers/phone_number/__init__.py
+++ b/faker/providers/phone_number/__init__.py
@@ -13,7 +13,7 @@ localized = True
 
 class Provider(BaseProvider):
 
-    country_calling_codes: ElementsType = (
+    country_calling_codes: ElementsType[str] = (
         "+93",
         "+358 18",
         "+355",
@@ -317,9 +317,9 @@ class Provider(BaseProvider):
         "+263",
     )
 
-    formats: ElementsType = ("###-###-###",)
+    formats: ElementsType[str] = ("###-###-###",)
 
-    msisdn_formats: ElementsType = ("#############",)
+    msisdn_formats: ElementsType[str] = ("#############",)
 
     def phone_number(self) -> str:
         return self.numerify(self.random_element(self.formats))

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -20,7 +20,7 @@ class EmptyEnumException(BaseFakerException):
 
 
 class Provider(BaseProvider):
-    default_value_types: ElementsType = (
+    default_value_types: ElementsType[str] = (
         "str",
         "str",
         "str",

--- a/faker/providers/ssn/__init__.py
+++ b/faker/providers/ssn/__init__.py
@@ -4,7 +4,7 @@ localized = True
 
 
 class Provider(BaseProvider):
-    ssn_formats: ElementsType = ("###-##-####",)
+    ssn_formats: ElementsType[str] = ("###-##-####",)
 
     def ssn(self) -> str:
         return self.bothify(self.random_element(self.ssn_formats))

--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -10,7 +10,7 @@ _DT_ALMOST_MAX = datetime.max - timedelta(1.0)
 class Provider(BaseProvider):
     """Implement default user agent provider for Faker."""
 
-    user_agents: ElementsType = (
+    user_agents: ElementsType[str] = (
         "chrome",
         "firefox",
         "internet_explorer",
@@ -18,7 +18,7 @@ class Provider(BaseProvider):
         "safari",
     )
 
-    windows_platform_tokens: ElementsType = (
+    windows_platform_tokens: ElementsType[str] = (
         "Windows 95",
         "Windows 98",
         "Windows 98; Win 9x 4.90",
@@ -34,11 +34,11 @@ class Provider(BaseProvider):
         "Windows NT 10.0",
     )
 
-    linux_processors: ElementsType = ("i686", "x86_64")
+    linux_processors: ElementsType[str] = ("i686", "x86_64")
 
-    mac_processors: ElementsType = ("Intel", "PPC", "U; Intel", "U; PPC")
+    mac_processors: ElementsType[str] = ("Intel", "PPC", "U; Intel", "U; PPC")
 
-    android_versions: ElementsType = (
+    android_versions: ElementsType[str] = (
         "1.0",
         "1.1",
         "1.5",
@@ -103,9 +103,9 @@ class Provider(BaseProvider):
         "11",
     )
 
-    apple_devices: ElementsType = ("iPhone", "iPad")
+    apple_devices: ElementsType[str] = ("iPhone", "iPad")
 
-    ios_versions: ElementsType = (
+    ios_versions: ElementsType[str] = (
         "3.1.3",
         "4.2.1",
         "5.1.1",
@@ -145,7 +145,7 @@ class Provider(BaseProvider):
         bld: str = self.lexify(self.numerify("##?###"), string.ascii_uppercase)
         tmplt: str = "({0}) AppleWebKit/{1} (KHTML, like Gecko)" " Chrome/{2}.0.{3}.0 Safari/{4}"
         tmplt_ios: str = "({0}) AppleWebKit/{1} (KHTML, like Gecko)" " CriOS/{2}.0.{3}.0 Mobile/{4} Safari/{1}"
-        platforms: ElementsType = (
+        platforms: ElementsType[str] = (
             tmplt.format(
                 self.linux_platform_token(),
                 saf,
@@ -187,7 +187,7 @@ class Provider(BaseProvider):
 
     def firefox(self) -> str:
         """Generate a Mozilla Firefox web browser user agent string."""
-        ver: ElementsType = (
+        ver: ElementsType[str] = (
             (
                 f"Gecko/{self.generator.date_time_between(datetime(2011, 1, 1), _DT_ALMOST_MAX)} "
                 f"Firefox/{self.generator.random.randint(4, 15)}.0"
@@ -206,7 +206,7 @@ class Provider(BaseProvider):
         saf: str = "{}.{}".format(self.generator.random.randint(531, 536), self.generator.random.randint(0, 2))
         bld: str = self.lexify(self.numerify("##?###"), string.ascii_uppercase)
         bld2: str = self.lexify(self.numerify("#?####"), string.ascii_lowercase)
-        platforms: ElementsType = (
+        platforms: ElementsType[str] = (
             tmplt_win.format(
                 self.windows_platform_token(),
                 self.generator.locale().replace("_", "-"),
@@ -257,7 +257,7 @@ class Provider(BaseProvider):
             " Mobile/8B{5} Safari/6{6}"
         )
         locale: str = self.generator.locale().replace("_", "-")
-        platforms: ElementsType = (
+        platforms: ElementsType[str] = (
             tmplt_win.format(self.windows_platform_token(), saf, ver, saf),
             tmplt_mac.format(
                 self.mac_platform_token(),


### PR DESCRIPTION
### What does this change

Add type variables at every use point of the ElementsType type variable.

### What was wrong

As the inner type variables were not specified, they were assumed to be `<nothing>` in function declarations, and `Any` in variable declarations.

This is a problem in the following example:
```python
class DjangoChoiceProvider(providers.BaseProvider):
    def choice_django(self, choices: Collection[Tuple[str, str]]) -> str:
        """Random choice in django choice element"""
        return self.random_element(choices)[0]
```
Here, mypy complains because `self.random_element(choices)` is assumed to return `<nothing>`, and the subscription is assumed by it to fail.

### How this fixes it

The TypeVar is now bound in the function definition, and takes its value from the passed argument's types.
