### PR TITLE
Add missing number in SHA-256 docstring and add hyphen for SHA hashes

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -70,9 +70,9 @@ class Provider(BaseProvider):
         return res.hexdigest()
 
     def sha1(self, raw_output: bool = False) -> Union[bytes, str]:
-        """Generate a random SHA1 hash.
+        """Generate a random SHA-1 hash.
 
-        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA1 hash
+        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA-1 hash
         will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
 
         :sample: raw_output=False
@@ -84,9 +84,9 @@ class Provider(BaseProvider):
         return res.hexdigest()
 
     def sha256(self, raw_output: bool = False) -> Union[bytes, str]:
-        """Generate a random SHA256 hash.
+        """Generate a random SHA-256 hash.
 
-        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA56 hash
+        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA-256 hash
         will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
 
         :sample: raw_output=False


### PR DESCRIPTION
### What does this change

- Small typo: `SHA56` => `SHA256`
- Rename `SHA<N>` in `SHA-<N>` to match the name used in RFCs and Wikipedia

### What was wrong

See previous

### How this fixes it

See previous