### PR TITLE
Fix/seeding

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -21,16 +21,12 @@ class Faker:
 
     cache_pattern: Pattern = re.compile(r"^_cached_\w*_mapping$")
     generator_attrs = [
-        attr
-        for attr in dir(Generator)
-        if not attr.startswith("__") and attr not in ["seed", "seed_instance", "random"]
+        attr for attr in dir(Generator) if not attr.startswith("__") and attr not in ["seed", "seed_instance", "random"]
     ]
 
     def __init__(
         self,
-        locale: Optional[
-            Union[str, Sequence[str], Dict[str, Union[int, float]]]
-        ] = None,
+        locale: Optional[Union[str, Sequence[str], Dict[str, Union[int, float]]]] = None,
         providers: Optional[List[str]] = None,
         generator: Optional[Generator] = None,
         includes: Optional[List[str]] = None,
@@ -99,10 +95,7 @@ class Faker:
         :return: the appropriate attribute
         """
         if attr == "seed":
-            msg = (
-                "Calling `.seed()` on instances is deprecated. "
-                "Use the class method `Faker.seed()` instead."
-            )
+            msg = "Calling `.seed()` on instances is deprecated. " "Use the class method `Faker.seed()` instead."
             raise TypeError(msg)
         else:
             return super().__getattribute__(attr)
@@ -117,10 +110,7 @@ class Faker:
         if len(self._factories) == 1:
             return getattr(self._factories[0], attr)
         elif attr in self.generator_attrs:
-            msg = (
-                "Proxying calls to `%s` is not implemented in multiple locale mode."
-                % attr
-            )
+            msg = "Proxying calls to `%s` is not implemented in multiple locale mode." % attr
             raise NotImplementedError(msg)
         elif self.cache_pattern.match(attr):
             msg = "Cached attribute `%s` does not exist" % attr
@@ -137,9 +127,7 @@ class Faker:
         result._factory_map = copy.deepcopy(self._factory_map)
         result._weights = copy.deepcopy(self._weights)
         result._unique_proxy = UniqueProxy(self)
-        result._unique_proxy._seen = {
-            k: {result._unique_proxy._sentinel} for k in self._unique_proxy._seen.keys()
-        }
+        result._unique_proxy._seen = {k: {result._unique_proxy._sentinel} for k in self._unique_proxy._seen.keys()}
         return result
 
     def __setstate__(self, state: Any) -> None:
@@ -177,9 +165,7 @@ class Faker:
     def _select_factory_choice(self, factories):
         return random.choice(factories)
 
-    def _map_provider_method(
-        self, method_name: str
-    ) -> Tuple[List[Factory], Optional[List[float]]]:
+    def _map_provider_method(self, method_name: str) -> Tuple[List[Factory], Optional[List[float]]]:
         """
         Creates a 2-tuple of factories and weights for the given provider method name
 
@@ -329,9 +315,7 @@ class UniqueProxy:
                     break
                 retval = function(*args, **kwargs)
             else:
-                raise UniquenessException(
-                    f"Got duplicated values after {_UNIQUE_ATTEMPTS:,} iterations."
-                )
+                raise UniquenessException(f"Got duplicated values after {_UNIQUE_ATTEMPTS:,} iterations.")
 
             generated.add(retval)
 

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple
 from .config import DEFAULT_LOCALE
 from .exceptions import UniquenessException
 from .factory import Factory
-from .generator import Generator, Sentinel, random
+from .generator import Generator, random
 from .typing import SeedType
 from .utils.distribution import choices_distribution
 
@@ -21,12 +21,16 @@ class Faker:
 
     cache_pattern: Pattern = re.compile(r"^_cached_\w*_mapping$")
     generator_attrs = [
-        attr for attr in dir(Generator) if not attr.startswith("__") and attr not in ["seed", "seed_instance", "random"]
+        attr
+        for attr in dir(Generator)
+        if not attr.startswith("__") and attr not in ["seed", "seed_instance", "random"]
     ]
 
     def __init__(
         self,
-        locale: Optional[Union[str, Sequence[str], Dict[str, Union[int, float]]]] = None,
+        locale: Optional[
+            Union[str, Sequence[str], Dict[str, Union[int, float]]]
+        ] = None,
         providers: Optional[List[str]] = None,
         generator: Optional[Generator] = None,
         includes: Optional[List[str]] = None,
@@ -95,7 +99,10 @@ class Faker:
         :return: the appropriate attribute
         """
         if attr == "seed":
-            msg = "Calling `.seed()` on instances is deprecated. " "Use the class method `Faker.seed()` instead."
+            msg = (
+                "Calling `.seed()` on instances is deprecated. "
+                "Use the class method `Faker.seed()` instead."
+            )
             raise TypeError(msg)
         else:
             return super().__getattribute__(attr)
@@ -110,7 +117,10 @@ class Faker:
         if len(self._factories) == 1:
             return getattr(self._factories[0], attr)
         elif attr in self.generator_attrs:
-            msg = "Proxying calls to `%s` is not implemented in multiple locale mode." % attr
+            msg = (
+                "Proxying calls to `%s` is not implemented in multiple locale mode."
+                % attr
+            )
             raise NotImplementedError(msg)
         elif self.cache_pattern.match(attr):
             msg = "Cached attribute `%s` does not exist" % attr
@@ -127,7 +137,9 @@ class Faker:
         result._factory_map = copy.deepcopy(self._factory_map)
         result._weights = copy.deepcopy(self._weights)
         result._unique_proxy = UniqueProxy(self)
-        result._unique_proxy._seen = {k: {result._unique_proxy._sentinel} for k in self._unique_proxy._seen.keys()}
+        result._unique_proxy._seen = {
+            k: {result._unique_proxy._sentinel} for k in self._unique_proxy._seen.keys()
+        }
         return result
 
     def __setstate__(self, state: Any) -> None:
@@ -165,7 +177,9 @@ class Faker:
     def _select_factory_choice(self, factories):
         return random.choice(factories)
 
-    def _map_provider_method(self, method_name: str) -> Tuple[List[Factory], Optional[List[float]]]:
+    def _map_provider_method(
+        self, method_name: str
+    ) -> Tuple[List[Factory], Optional[List[float]]]:
         """
         Creates a 2-tuple of factories and weights for the given provider method name
 
@@ -315,7 +329,9 @@ class UniqueProxy:
                     break
                 retval = function(*args, **kwargs)
             else:
-                raise UniquenessException(f"Got duplicated values after {_UNIQUE_ATTEMPTS:,} iterations.")
+                raise UniquenessException(
+                    f"Got duplicated values after {_UNIQUE_ATTEMPTS:,} iterations."
+                )
 
             generated.add(retval)
 

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -153,8 +153,6 @@ class Faker:
         elif len(factories) == 1:
             return factories[0]
 
-        if Generator._global_seed is not Sentinel:
-            random.seed(Generator._global_seed)  # type: ignore
         if weights:
             factory = self._select_factory_distribution(factories, weights)
         else:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -141,7 +141,6 @@ class TestFakerProxyClass:
 
         assert first_list == second_list
 
-
     def test_seed_instance(self):
         locale = ["de_DE", "en-US", "en-PH", "ja_JP"]
         fake = Faker(locale)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -133,6 +133,8 @@ class TestFakerProxyClass:
         count = 5
         fake = Faker(["en_GB", "fr_FR", "en_IN"])
         first_list = [fake.name() for _ in range(count)]
+        # We convert the list to a set to remove duplicates and ensure
+        # that we have exactly `count` unique fake values
         assert len(set(first_list)) == count
 
         Faker.seed(2043)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -130,12 +130,14 @@ class TestFakerProxyClass:
 
     def test_seed_class_locales(self):
         Faker.seed(2043)
+        count = 5
         fake = Faker(["en_GB", "fr_FR", "en_IN"])
-        first_list = [fake.name() for _ in range(5)]
+        first_list = [fake.name() for _ in range(count)]
+        assert len(set(first_list)) == count
 
         Faker.seed(2043)
         fake = Faker(["en_GB", "fr_FR", "en_IN"])
-        second_list = [fake.name() for _ in range(5)]
+        second_list = [fake.name() for _ in range(count)]
 
         assert first_list == second_list
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -131,10 +131,14 @@ class TestFakerProxyClass:
     def test_seed_class_locales(self):
         Faker.seed(2043)
         fake = Faker(["en_GB", "fr_FR", "en_IN"])
-        name = fake.name()
+        first_list = [fake.name() for _ in range(5)]
 
-        for _ in range(5):
-            assert fake.name() == name
+        Faker.seed(2043)
+        fake = Faker(["en_GB", "fr_FR", "en_IN"])
+        second_list = [fake.name() for _ in range(5)]
+
+        assert first_list == second_list
+
 
     def test_seed_instance(self):
         locale = ["de_DE", "en-US", "en-PH", "ja_JP"]


### PR DESCRIPTION
fixes #1656 

### What does this change

This removes re-seeding the `Random()` instance on every call to `_select_factory()` which gets called every time a faker method is used. This code was only reached when both conditions are true:

- A seed is set via `Faker.seed()`
- More than one locale is specified

### What was wrong

Basically same as above, it is unnecessary to set the `Random()` instance's seed value every time a faker method is used. The `Random()` instance is seeded when making the call to `Faker.seed()` which is sufficient for making sure that the order of the locales selected is the same between subsequent instances of `Faker`

### How this fixes it

Remove the seeding that isn't needed and modified a test that asserts:

- Generating values when a seed is used and multiple locales are used does not generate the same value over and over
- Calling `Faker.seed()` and using a `Faker` instance in an identical way will produce the same fake output each time

Fixes #...
