### PR TITLE
Refactor mapping of lambda functions

### DIFF
--- a/faker/providers/geo/el_GR/__init__.py
+++ b/faker/providers/geo/el_GR/__init__.py
@@ -17,13 +17,13 @@ class Provider(GeoProvider):
         return str(self.local_latitude()), str(self.local_longitude())
 
     def local_latitude(self) -> Decimal:
-        latitudes = list(map(lambda t: int(Decimal(t[0]) * 10000000), self.poly))
+        latitudes = [int(Decimal(t[0]) * 10000000) for t in self.poly]
         return Decimal(str(self.generator.random.randint(min(latitudes), max(latitudes)) / 10000000)).quantize(
             Decimal(".000001")
         )
 
     def local_longitude(self) -> Decimal:
-        longitudes = list(map(lambda t: int(Decimal(t[1]) * 10000000), self.poly))
+        longitudes = [int(Decimal(t[1]) * 10000000) for t in self.poly]
         return Decimal(str(self.generator.random.randint(min(longitudes), max(longitudes)) / 10000000)).quantize(
             Decimal(".000001")
         )

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -592,7 +592,7 @@ class Provider(BaseProvider):
 
     def mac_address(self) -> str:
         mac = [self.generator.random.randint(0x00, 0xFF) for _ in range(0, 6)]
-        return ":".join(map(lambda x: "%02x" % x, mac))
+        return ":".join("%02x" % x for x in mac)
 
     def port_number(self, is_system: bool = False, is_user: bool = False, is_dynamic: bool = False) -> int:
         """Returns a network port number

--- a/faker/providers/internet/el_GR/__init__.py
+++ b/faker/providers/internet/el_GR/__init__.py
@@ -68,7 +68,7 @@ def latinize(value: str) -> str:
 
     def replace_greek_character(match):
         matched = list(match.group(0))
-        value = map(lambda l: replace[search.find(l)], matched)
+        value = (replace[search.find(char)] for char in matched)
         return "".join(value)
 
     return re.sub(

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -211,22 +211,22 @@ class TestJaJP(unittest.TestCase):
         first_name_pair = self.fake.first_name_pair()
         assert first_name_pair
         assert len(first_name_pair) == 3
-        assert all(map(lambda s: isinstance(s, str), first_name_pair))
+        assert all(isinstance(s, str) for s in first_name_pair)
 
         first_name_male_pair = self.fake.first_name_male_pair()
         assert first_name_male_pair
         assert len(first_name_male_pair) == 3
-        assert all(map(lambda s: isinstance(s, str), first_name_male_pair))
+        assert all(isinstance(s, str) for s in first_name_male_pair)
 
         first_name_female_pair = self.fake.first_name_female_pair()
         assert first_name_female_pair
         assert len(first_name_female_pair) == 3
-        assert all(map(lambda s: isinstance(s, str), first_name_female_pair))
+        assert all(isinstance(s, str) for s in first_name_female_pair)
 
         last_name_pair = self.fake.last_name_pair()
         assert last_name_pair
         assert len(last_name_pair) == 3
-        assert all(map(lambda s: isinstance(s, str), last_name_pair))
+        assert all(isinstance(s, str) for s in last_name_pair)
 
 
 class TestNeNP(unittest.TestCase):


### PR DESCRIPTION
### What does this change

Usages of `map(lambda...)` refactored to list comprehensions or generator expressions.

### What was wrong

When running checks locally with `tox`, the `flake8` job failed with "C417 Unnecessary use of map".

### How this fixes it

All tox jobs run successfully.

Fixes #1755
