### PR TITLE
Fix IT SSN generation with latin chars in name or surname

### DIFF
--- a/faker/providers/internet/el_GR/__init__.py
+++ b/faker/providers/internet/el_GR/__init__.py
@@ -68,7 +68,7 @@ def latinize(value: str) -> str:
 
     def replace_greek_character(match):
         matched = list(match.group(0))
-        value = map(lambda l: replace[search.find(l)], matched)
+        value = map(lambda letter: replace[search.find(letter)], matched)
         return "".join(value)
 
     return re.sub(

--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -1,7 +1,8 @@
 """it_IT ssn provider (yields italian fiscal codes)"""
 
-from string import ascii_uppercase, digits
 import unicodedata
+
+from string import ascii_uppercase, digits
 
 from .. import Provider as SsnProvider
 

--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -1,6 +1,7 @@
 """it_IT ssn provider (yields italian fiscal codes)"""
 
 from string import ascii_uppercase, digits
+import unicodedata
 
 from .. import Provider as SsnProvider
 
@@ -8051,6 +8052,8 @@ class Provider(SsnProvider):
         else:
             name = self.generator.first_name_female().upper()
 
+        name = self._transliterate_name(name)
+
         if len(name) < 3:
             return self._pad_shorter(name)
 
@@ -8074,6 +8077,8 @@ class Provider(SsnProvider):
             str
         """
         surname = self.generator.last_name().upper()
+        surname = self._transliterate_name(surname)
+
         if len(surname) < 3:
             return self._pad_shorter(surname)
 
@@ -8085,6 +8090,11 @@ class Provider(SsnProvider):
         else:
             surname_part = "".join(surname_consonants)[:3]
         return surname_part
+
+    @staticmethod
+    def _transliterate_name(name: str) -> str:
+        nfkd_form: str = unicodedata.normalize("NFKD", name)
+        return "".join([c for c in nfkd_form if unicodedata.combining(c) == 0])
 
     @staticmethod
     def _get_vowels(sequence: str) -> list:

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -14,7 +14,8 @@ from validators.i18n.es import es_cif as is_cif
 from validators.i18n.es import es_nie as is_nie
 from validators.i18n.es import es_nif as is_nif
 
-from faker import Faker
+from faker import Factory, Faker
+from faker.providers.person.it_IT import Provider as ItPersonProvider
 from faker.providers.ssn.el_GR import tin_checksum as gr_tin_checksum
 from faker.providers.ssn.en_CA import checksum as ca_checksum
 from faker.providers.ssn.es_CL import rut_check_digit as cl_rut_checksum
@@ -903,6 +904,13 @@ class TestItIT(unittest.TestCase):
 
     def test_checksum(self) -> None:
         assert it_checksum("MDDMRA80L41H501") == "R"
+
+    def test_ssn_with_latin_chars(self):
+        generator = Factory.create("it_IT")
+        generator.last_name = mock.MagicMock(return_value="Foà")
+        ssn = generator.ssn()
+        self.assertEqual(len(ssn), 16)
+        self.assertEqual(ssn[:3], "FOA")
 
 
 class TestPtBR(unittest.TestCase):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -15,7 +15,6 @@ from validators.i18n.es import es_nie as is_nie
 from validators.i18n.es import es_nif as is_nif
 
 from faker import Factory, Faker
-from faker.providers.person.it_IT import Provider as ItPersonProvider
 from faker.providers.ssn.el_GR import tin_checksum as gr_tin_checksum
 from faker.providers.ssn.en_CA import checksum as ca_checksum
 from faker.providers.ssn.es_CL import rut_check_digit as cl_rut_checksum


### PR DESCRIPTION
### What does this change

Fix IT SSN generation when Person provider returns first or last name with latin chars

### What was wrong

Latin chars was considered neither vowel nor consonant. They just got ignored, and the resulting SSN was wrong, or even shorter than expected length (16 chars) in case of short names/surnames.

### How this fixes it

This change applies a transliteration for dyacritic chars, translating them into the equivalents ASCII chars, according to the Italian SSN generation rules.

Fixes #1757 
