### PR TITLE
Suggest `faker --help` if CLI arguments are missing

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -267,6 +267,10 @@ examples:
             "first argument)",
         )
 
+        if not self.argv[1:]:
+            parser.print_usage(sys.stderr)
+            parser.exit(2, f"Try '{self.prog_name} --help' for more information.\n")
+
         arguments = parser.parse_args(self.argv[1:])
 
         if arguments.verbose:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -110,6 +110,19 @@ class FactoryTestCase(unittest.TestCase):
         finally:
             sys.stdout = orig_stdout
 
+    def test_cli_no_args(self):
+        from faker.cli import Command
+
+        orig_stderr = sys.stderr
+        try:
+            sys.stderr = io.StringIO()
+            command = Command(["faker"])
+            with pytest.raises(SystemExit):
+                command.execute()
+            assert "Try 'faker --help'" in sys.stderr.getvalue()
+        finally:
+            sys.stderr = orig_stderr
+
     def test_unknown_provider(self):
         with pytest.raises(ModuleNotFoundError) as excinfo:
             Factory.create(providers=["dummy_provider"])


### PR DESCRIPTION
### What does this change

Attempt to make the command-line output of `faker` (invoked without arguments) more user friendly.

### What was wrong

Running `faker` prints several megabytes of sample data to stdout, which is confusing.

### How this fixes it

Running `faker` displays command's usage with an additional message `Try 'faker --help' for more information.`.

Fixes #1187
