### PR TITLE
Fix amount and layout of sample data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -422,11 +422,17 @@ Run tests:
 
     $ tox
 
-Write documentation for providers:
+Write documentation for the providers of the default locale:
 
 .. code:: bash
 
     $ python -m faker > docs.txt
+
+Write documentation for the providers of a specific locale:
+
+.. code:: bash
+
+    $ python -m faker --lang=de_DE > docs_de.txt
 
 
 Contribute

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -112,23 +112,6 @@ def print_doc(
         for provider, fakers in formatters:
             print_provider(doc, provider, fakers, output=output)
 
-        for language in AVAILABLE_LOCALES:
-            if language == lang:
-                continue
-            print(file=output)
-            print(f"## LANGUAGE {language}", file=output)
-            fake = Faker(locale=language)
-            fake.seed_instance(seed)
-            d = documentor.Documentor(fake)
-
-            for p, fs in d.get_formatters(
-                with_args=True,
-                with_defaults=True,
-                locale=language,
-                excludes=base_provider_formatters + unsupported,
-            ):
-                print_provider(d, p, fs, output=output)
-
 
 class Command:
     def __init__(self, argv: Optional[str] = None) -> None:

--- a/faker/documentor.py
+++ b/faker/documentor.py
@@ -119,7 +119,7 @@ class Documentor:
                 continue
             formatters[signature] = example
 
-            self.max_name_len = max(self.max_name_len, len(signature))
+            self.max_name_len = max(self.max_name_len, *(len(part) for part in signature.split()))
             self.already_generated.append(name)
 
         return formatters


### PR DESCRIPTION
### What does this change

Improve output of faker CLI when invoked without positional arguments.

### What was wrong

Running `faker` prints several megabytes of sample data, in a hard-to-read narrow column.

### How this fixes it

Running `faker` displays sample data for one specific locale only, in a more readable layout.

This is an alternative to #1759.

Fixes #1187
