### PR TITLE
Mention ``faker-file`` package

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -21,6 +21,9 @@ Here's a list of Providers written by the community:
 | Education     | Public school name and    | `faker_education`_               |
 |               | info for testing purposes |                                  |
 +---------------+---------------------------+----------------------------------+
+| Faker File    | Generate files with fake  | `faker-file`_                    |                          
+|               | content                   |                                  |
++---------------+---------------------------+----------------------------------+
 | Geoscience    | Earth sciences-related    | `faker_geoscience`_              |
 |               | fake-random data          |                                  |
 |               | generators.               |                                  |
@@ -64,6 +67,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_biology: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_education: https://pypi.org/project/faker_education/
+.. _faker-file: https://pypi.org/project/faker-file/
 .. _faker_geoscience: https://pypi.org/project/faker-geoscience/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -21,7 +21,7 @@ Here's a list of Providers written by the community:
 | Education     | Public school name and    | `faker_education`_               |
 |               | info for testing purposes |                                  |
 +---------------+---------------------------+----------------------------------+
-| Faker File    | Generate files with fake  | `faker-file`_                    |                          
+| Faker File    | Generate files with fake  | `faker-file`_                    |
 |               | content                   |                                  |
 +---------------+---------------------------+----------------------------------+
 | Geoscience    | Earth sciences-related    | `faker_geoscience`_              |


### PR DESCRIPTION
Mention [faker-file](https://pypi.org/project/faker-file/) package.

- [PyPI](https://pypi.org/project/faker-file/)
- [GitHub](https://github.com/barseghyanartur/faker-file/)
- [Documentation](https://faker-file.readthedocs.io/en/latest/?badge=latest)
- [Tests](https://github.com/barseghyanartur/faker-file/actions/workflows/test.yml)
- [License](https://github.com/barseghyanartur/faker-file#license)

### What does this change

Mention [faker-file](https://pypi.org/project/faker-file/) package.

### What was wrong

Nothing. Just adding a reference to a new ``faker`` based package to the docs.

### How this fixes it

Mentions reference to ``faker-file`` in the ``faker`` documentation.
