### PR TITLE
Feature/allow passing optional json encoder

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -9,7 +9,7 @@ import tarfile
 import uuid
 import zipfile
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 
 from faker.exceptions import UnsupportedFeature
 
@@ -488,7 +488,13 @@ class Provider(BaseProvider):
             delimiter="|",
         )
 
-    def json(self, data_columns: Optional[List] = None, num_rows: int = 10, indent: Optional[int] = None) -> str:
+    def json(
+        self,
+        data_columns: Optional[List] = None,
+        num_rows: int = 10,
+        indent: Optional[int] = None,
+        cls: Optional[Type[json.JSONEncoder]] = None,
+    ) -> str:
         """
         Generate random JSON structure values.
 
@@ -521,6 +527,8 @@ class Provider(BaseProvider):
         :type num_rows: int
         :param indent: number of spaces to indent the fields
         :type indent: int
+        :param cls: optional json encoder to use for non-standard objects such as datetimes
+        :type cls: json.JSONEncoder
         :return: Serialized JSON data
         :rtype: str
 
@@ -585,10 +593,10 @@ class Provider(BaseProvider):
             raise TypeError("Invalid data_columns type. Must be a dictionary or list")
 
         if num_rows == 1:
-            return json.dumps(create_json_structure(data_columns), indent=indent)
+            return json.dumps(create_json_structure(data_columns), indent=indent, cls=cls)
 
         data = [create_json_structure(data_columns) for _ in range(num_rows)]
-        return json.dumps(data, indent=indent)
+        return json.dumps(data, indent=indent, cls=cls)
 
     def fixed_width(self, data_columns: Optional[list] = None, num_rows: int = 10, align: str = "left") -> str:
         """


### PR DESCRIPTION
### What does this change

Allowing callers to misc.json provider pass a json encoder subclass so they can later be converted to json objects

### What was wrong

```
kwargs = {"data_columns": {"item1": "date_time"}, "num_rows": 1}
faker.json(**kwargs)
```
would raise an error as datetime objects can be serialized into json.

### How this fixes it

caller can pass a class which serializes any desired object into something which json compliant. 
