### PR TITLE
Add market-data identifiers provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -25,6 +25,11 @@ Here's a list of Providers written by the community:
 |               | fake-random data          |                                  |
 |               | generators.               |                                  |
 +---------------+---------------------------+----------------------------------+
+| Market Data   | Fake market data          |                                  |
+|               | identifiers (SEDOL, CUSIP,| `faker_marketdata`_              |
+|               | ISIN, etc.)               |                                  |
+|               |                           |                                  |
++---------------+---------------------------+----------------------------------+
 | Microservice  | Fake microservice names   | `faker_microservice`_            |
 +---------------+---------------------------+----------------------------------+
 | Music         | Music genres, subgenres,  | `faker_music`_                   |
@@ -65,6 +70,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/
 .. _faker_education: https://pypi.org/project/faker_education/
 .. _faker_geoscience: https://pypi.org/project/faker-geoscience/
+.. _faker_marketdata: https://pypi.org/project/faker-marketdata/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/
 .. _mdgen: https://pypi.org/project/mdgen/


### PR DESCRIPTION
### What does this change

Adds a new provider (faker-marketdata) to generate fake market data widely used in financial services (ISIN, SEDOL, CUSIP, etc.). List of supported IDs is in the [documentation](https://github.com/rubenafo/faker_marketdata).

### What was wrong

No bugs fixed with this PR

