### PR TITLE
Fix siret and siren generation for fr_FR locale company information

### DIFF
--- a/faker/providers/company/fr_FR/__init__.py
+++ b/faker/providers/company/fr_FR/__init__.py
@@ -1,5 +1,7 @@
 from typing import Tuple
 
+from faker.utils.checksums import calculate_luhn
+
 from .. import Provider as CompanyProvider
 
 
@@ -121,9 +123,11 @@ class Provider(CompanyProvider):
 
     def siren(self) -> str:
         """
-        Generates a siren number (9 digits).
+        Generates a siren number (9 digits). Formatted as '### ### ###'.
         """
-        return self.numerify(self.siren_format)
+        code = self.numerify("########")
+        luhn_checksum = str(calculate_luhn(float(code)))
+        return f"{code[:3]} {code[3:6]} {code[6:]}{luhn_checksum}"
 
     def siret(self, max_sequential_digits: int = 2) -> str:
         """
@@ -131,10 +135,15 @@ class Provider(CompanyProvider):
         It is in fact the result of the concatenation of a siren number (9 digits),
         a sequential number (4 digits) and a control number (1 digit) concatenation.
         If $max_sequential_digits is invalid, it is set to 2.
-        :param max_sequential_digits: The maximum number of digits for the sequential number (> 0 && <= 4).
+
+        The siret number is formatted as '### ### ### #####'.
+        :param max_sequential_digits The maximum number of digits for the sequential number (> 0 && <= 4).
         """
         if max_sequential_digits > 4 or max_sequential_digits <= 0:
             max_sequential_digits = 2
 
         sequential_number = str(self.random_number(max_sequential_digits)).zfill(4)
-        return self.numerify(self.siren() + " " + sequential_number + "#")
+
+        code = self.siren().replace(" ", "") + sequential_number
+        luhn_checksum = str(calculate_luhn(float(code)))
+        return f"{code[:3]} {code[3:6]} {code[6:9]} {code[9:]}{luhn_checksum}"

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -23,6 +23,7 @@ from faker.providers.company.ru_RU import Provider as RuRuCompanyProvider
 from faker.providers.company.ru_RU import calculate_checksum
 from faker.providers.company.th_TH import Provider as ThThCompanyProvider
 from faker.providers.company.tr_TR import Provider as TrTrCompanyProvider
+from faker.utils.checksums import luhn_checksum
 
 
 class TestAzAz:
@@ -58,6 +59,22 @@ class TestFiFi:
             company_id = faker.company_business_id()
             assert len(company_id) == 9
             assert self._has_valid_checksum(company_id)
+
+
+class TestFrFr:
+    """Test fr_FR company provider methods"""
+
+    def test_siren(self, faker, num_samples):
+        for _ in range(num_samples):
+            siren = faker.siren()
+            assert len(siren) == 11
+            assert luhn_checksum(siren.replace(" ", "")) == 0
+
+    def test_siret(self, faker, num_samples):
+        for _ in range(num_samples):
+            siret = faker.siret()
+            assert len(siret) == 17
+            assert luhn_checksum(siret.replace(" ", "")) == 0
 
 
 class TestHyAm:


### PR DESCRIPTION
Hi !

This is a new attempt to fix the French SIRET/SIREN generation.

The correction was first submitted in MR #1465 in 2021 but never merged

I simply did a rebase from the master branch and I added basic tests

