### PR TITLE
Add method to generate JSON as bytes

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -488,6 +488,21 @@ class Provider(BaseProvider):
             delimiter="|",
         )
 
+    def json_bytes(
+        self,
+        data_columns: Optional[List] = None,
+        num_rows: int = 10,
+        indent: Optional[int] = None,
+        cls: Optional[Type[json.JSONEncoder]] = None,
+    ) -> bytes:
+        """
+        Generate random JSON structure and return as bytes.
+
+        For more information on the different arguments of this method, refer to
+        :meth:`json() <faker.providers.misc.Provider.json>` which is used under the hood.
+        """
+        return self.json(data_columns=data_columns, num_rows=num_rows, indent=indent, cls=cls).encode()
+
     def json(
         self,
         data_columns: Optional[List] = None,

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -697,6 +697,13 @@ class TestMiscProvider:
         with pytest.raises(TypeError):
             faker_with_foobar.json(**kwargs)
 
+    def test_json_bytes(self, faker_with_foobar):
+        kwargs = {"data_columns": {"item1": "foo_bar"}, "num_rows": 1}
+        json_data_bytes = faker_with_foobar.json_bytes(**kwargs)
+        assert isinstance(json_data_bytes, bytes)
+        json_data = json.loads(json_data_bytes.decode())
+        assert json_data["item1"] == "FooBar"
+
     def test_fixed_width_with_arguments(self, faker_with_foobar):
         kwargs = {
             "data_columns": [


### PR DESCRIPTION
### What does this change

Add wrapper method around the JSON provider to generate JSON as bytes.

### What was wrong

I use Faker through factory boy and couldn't find a convenient way to achieve that. The change is quite small so I thought it could be a nice addition to the library.

### How this fixes it

Wraps the existing JSON provider and encode its output to bytes.
