### PR TITLE
Remove deprecated placeimg image provider

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -157,7 +157,6 @@ class Provider(BaseProvider):
         "https://picsum.photos/{width}/{height}",
         "https://dummyimage.com/{width}x{height}",
         "https://placekitten.com/{width}/{height}",
-        "https://placeimg.com/{width}/{height}/any",
     )
 
     replacements: Tuple[Tuple[str, str], ...] = ()


### PR DESCRIPTION
### What does this change

Image placeholder services

### What was wrong

The service will close down on June 30th 2023. Since this could
create errors in users' code, better get rid of it in due time

### How this fixes it

It's removed from the code

Fixes #1788
