### PR TITLE
Allow running a subset of the test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
     sphinx>=2.4,<3.0
     Pillow
 commands =
-    coverage run --source=faker -m pytest
-    coverage run --source=faker -a -m pytest --exclusive-faker-session tests/pytest/session_overrides
+    coverage run --source=faker -m pytest {posargs}
+    coverage run --source=faker -a -m pytest --exclusive-faker-session tests/pytest/session_overrides {posargs}
     coverage report
 
 [testenv:flake8]


### PR DESCRIPTION
### What was wrong
Currently, it is impossible to (conveniently) run a subset of the test suite. This renders impossible frequent runs of one test case, TDD, and convenient patch development in general.

### How this fixes it
This patch allows passing positional arguments to `pytest` in order to run a subset of the test suite.
This is a recommended approach with `tox` and is [described in the official documentation](https://tox.wiki/en/2.4.1/example/general.html#interactively-passing-positional-arguments).

### Usage example
```bash
tox -- tests/providers/test_python.py
```
