### PR TITLE
Added PresidioSentenceFaker to community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -57,7 +57,7 @@ Here's a list of Providers written by the community:
 |               | faker, to make values     |                                  |
 |               | optional!                 |                                  |
 +---------------+---------------------------+----------------------------------+
-| Presidio      | Create synthetic datasets | `presidio-sentence-faker`        |
+| Presidio      | Create synthetic datasets | `presidio-sentence-faker`_       |
 |               | for training Named Entity |                                  |
 |               | Recognition models        |                                  |
 |               | using Faker.              |                                  |

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -57,9 +57,9 @@ Here's a list of Providers written by the community:
 |               | faker, to make values     |                                  |
 |               | optional!                 |                                  |
 +---------------+---------------------------+----------------------------------+
-| Presidio      | Create synthetic datasets | `presidio-sentence-faker`_       |
-|               | for training Named Entity |                                  |
-|               | Recognition models        |                                  |
+| Presidio      | Create synthetic datasets | `presidio-evaluator`_            |
+| Sentence      | for training Named Entity |                                  |
+| Faker         | Recognition models        |                                  |
 |               | using Faker.              |                                  |
 +---------------+---------------------------+----------------------------------+
 
@@ -91,4 +91,4 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/
 .. _optional_faker: https://pypi.org/project/optional_faker
-.. _presidio-sentence-faker: https://pypi.org/project/presidio-evaluator
+.. _presidio-evaluator: https://pypi.org/project/presidio-evaluator

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -57,6 +57,11 @@ Here's a list of Providers written by the community:
 |               | faker, to make values     |                                  |
 |               | optional!                 |                                  |
 +---------------+---------------------------+----------------------------------+
+| Presidio      | Create synthetic datasets | `presidio-sentence-faker`        |
+|               | for training Named Entity |                                  |
+|               | Recognition models        |                                  |
+|               | using Faker.              |                                  |
++---------------+---------------------------+----------------------------------+
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -86,3 +91,4 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/
 .. _optional_faker: https://pypi.org/project/optional_faker
+.. _presidio-sentence-faker: https://pypi.org/project/presidio-evaluator


### PR DESCRIPTION
### What does this change

Added a link to the `presidio-evaluator` python package, which contains a fake data generator for creating synthetic/augmented Named Entity Recognition datasets. It extends `Faker` by returning the start and end of each fake value, as a mechanism to auto-label datasets for NER training.

Presidio Evaluator: https://github.com/microsoft/presidio-research
Data generator module: https://github.com/microsoft/presidio-research/blob/master/presidio_evaluator/data_generator/README.md

