### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
     needs: [flake8, isort, black, doc8, checkmanifest, typing]
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "pypy-3.9"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v3
@@ -210,7 +210,7 @@ jobs:
     needs: [flake8, isort, black, doc8, checkmanifest, typing]
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         arch: ["x86", "x64"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{37,38,39,310,py3},32bit,alpine,flake8,checkmanifest,isort,mypy,doc8
+envlist=py{37,38,39,310,311,py3},32bit,alpine,flake8,checkmanifest,isort,mypy,doc8
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
### What does this change

- add Python 3.11 to tox test environments
- add Python 3.11 to GitHub Actions test matrices
- add Python 3.11 to classifiers in setup.py
