### PR TITLE
Add support for latvian ssn generation

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -678,7 +678,7 @@ class Provider(BaseProvider):
 
     def _value_format_selection(self, definition: str, **kwargs: Any) -> Union[int, str]:
         """
-        Formats the string in different ways depending on it's contents.
+        Formats the string in different ways depending on its contents.
 
         The return can be the '@word' itself, a '{{ token }}' passed to PyStr,
         or a 'provider:argument_group' format field that returns potentially
@@ -696,12 +696,12 @@ class Provider(BaseProvider):
         if re.match(r"^@.*", definition):
             return definition.lstrip("@")
 
-        # Check if a argument group has been supplied
+        # Check if an argument group has been supplied
         if re.match(r"^[a-zA-Z0-9_-]*:\w", definition):
             definition, argument_group = definition.split(":")
             arguments = self.generator.get_arguments(argument_group.strip())
 
             return self.generator.format(definition.strip(), **arguments)
 
-        # Assume the string is refering to a provider
+        # Assume the string is referring to a provider
         return self.generator.format(definition, **kwargs)

--- a/faker/providers/ssn/lv_LV/__init__.py
+++ b/faker/providers/ssn/lv_LV/__init__.py
@@ -1,7 +1,57 @@
-from .. import Provider as BaseProvider
+import datetime
+
+from .. import Provider as SsnProvider
 
 
-class Provider(BaseProvider):
+class Provider(SsnProvider):
+    def ssn(self, min_age: int = 0, max_age: int = 105) -> str:
+        """
+        Returns 11 character Latvian personal identity code (Personas kods).
+        This function assigns random age to person.
+
+        Personal code consists of eleven characters of the form DDMMYYCZZZQ, where
+        DDMMYY is the date of birth, C the century sign, ZZZ the individual
+        number and Q the control character (checksum). The number for the
+        century is either 0 (1800–1899), 1 (1900–1999), or 2 (2000–2099).
+        """
+
+        def _checksum(ssn_without_checksum):
+            weights = [1, 6, 3, 7, 9, 10, 5, 8, 4, 2]
+            weighted_sum = sum(int(digit) * weight for digit, weight in zip(ssn_without_checksum, weights))
+            print(weighted_sum)
+            reminder = (1 - weighted_sum) % 11
+            if reminder == 10:
+                return 0
+            elif reminder < -1:
+                return reminder + 11
+            return reminder
+
+        age = datetime.timedelta(days=self.generator.random.randrange(min_age * 365, max_age * 365))
+        birthday = datetime.date.today() - age
+        ssn_date = "%02d%02d%s" % (
+            birthday.day,
+            birthday.month,
+            str(birthday.year)[-2:],
+        )
+        century = self._get_century_code(birthday.year)  # Century
+        suffix = self.generator.random.randrange(111, 999)
+        checksum = _checksum(f"{ssn_date}{century:01d}{suffix:03d}")
+        ssn = f"{ssn_date}-{century:01d}{suffix:03d}{checksum:01d}"
+        return ssn
+
+    @staticmethod
+    def _get_century_code(year: int) -> str:
+        """Returns the century code for a given year"""
+        if 2000 <= year < 3000:
+            code = 2
+        elif 1900 <= year < 2000:
+            code = 1
+        elif 1800 <= year < 1900:
+            code = 0
+        else:
+            raise ValueError("SSN do not support people born before the year 1800 or after the year 2999")
+        return code
+
     """
     A Faker provider for the Latvian VAT IDs
     """

--- a/faker/providers/ssn/lv_LV/__init__.py
+++ b/faker/providers/ssn/lv_LV/__init__.py
@@ -39,7 +39,7 @@ class Provider(SsnProvider):
         return ssn
 
     @staticmethod
-    def _get_century_code(year: int) -> str:
+    def _get_century_code(year: int) -> int:
         """Returns the century code for a given year"""
         if 2000 <= year < 3000:
             code = 2

--- a/faker/providers/ssn/lv_LV/__init__.py
+++ b/faker/providers/ssn/lv_LV/__init__.py
@@ -18,7 +18,6 @@ class Provider(SsnProvider):
         def _checksum(ssn_without_checksum):
             weights = [1, 6, 3, 7, 9, 10, 5, 8, 4, 2]
             weighted_sum = sum(int(digit) * weight for digit, weight in zip(ssn_without_checksum, weights))
-            print(weighted_sum)
             reminder = (1 - weighted_sum) % 11
             if reminder == 10:
                 return 0

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -23,10 +23,10 @@ from faker.providers.ssn.es_MX import curp_checksum as mx_curp_checksum
 from faker.providers.ssn.es_MX import ssn_checksum as mx_ssn_checksum
 from faker.providers.ssn.et_EE import checksum as et_checksum
 from faker.providers.ssn.fi_FI import Provider as fi_Provider
-from faker.providers.ssn.lv_LV import Provider as lv_Provider
 from faker.providers.ssn.fr_FR import calculate_checksum as fr_calculate_checksum
 from faker.providers.ssn.hr_HR import checksum as hr_checksum
 from faker.providers.ssn.it_IT import checksum as it_checksum
+from faker.providers.ssn.lv_LV import Provider as lv_Provider
 from faker.providers.ssn.no_NO import Provider as no_Provider
 from faker.providers.ssn.no_NO import checksum as no_checksum
 from faker.providers.ssn.pl_PL import calculate_month as pl_calculate_mouth

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -23,6 +23,7 @@ from faker.providers.ssn.es_MX import curp_checksum as mx_curp_checksum
 from faker.providers.ssn.es_MX import ssn_checksum as mx_ssn_checksum
 from faker.providers.ssn.et_EE import checksum as et_checksum
 from faker.providers.ssn.fi_FI import Provider as fi_Provider
+from faker.providers.ssn.lv_LV import Provider as lv_Provider
 from faker.providers.ssn.fr_FR import calculate_checksum as fr_calculate_checksum
 from faker.providers.ssn.hr_HR import checksum as hr_checksum
 from faker.providers.ssn.it_IT import checksum as it_checksum
@@ -1236,3 +1237,37 @@ class TestAzAz(unittest.TestCase):
     def check_length(self):
         for sample in self.samples:
             assert len(sample) == 7
+
+
+class TestLvLV(unittest.TestCase):
+    num_sample_runs = 10
+
+    def setUp(self):
+        self.fake = Faker("lv_LV")
+        Faker.seed(0)
+        self.samples = [self.fake.ssn() for _ in range(self.num_sample_runs)]
+        self.provider = lv_Provider
+
+    def test_century_code(self):
+        assert self.provider._get_century_code(1900) == 1
+        assert self.provider._get_century_code(1999) == 1
+        assert self.provider._get_century_code(2000) == 2
+        assert self.provider._get_century_code(2999) == 2
+        assert self.provider._get_century_code(1800) == 0
+        assert self.provider._get_century_code(1899) == 0
+        with pytest.raises(ValueError):
+            self.provider._get_century_code(1799)
+        with pytest.raises(ValueError):
+            self.provider._get_century_code(3000)
+
+    def test_ssn_sanity(self):
+        for age in range(100):
+            self.fake.ssn(min_age=age, max_age=age + 1)
+
+    def check_length(self):
+        for sample in self.samples:
+            assert len(sample) == 12
+
+    def test_vat_id(self):
+        for _ in range(100):
+            assert re.search(r"^LV\d{11}$", self.fake.vat_id())


### PR DESCRIPTION
### What does this change

Add support for correct latvian ssn generation.

### What was wrong

See #1799 

### How this fixes it

Implements ssn and checksum correctly.
I was not able to regenerate docs though, it failed with an error
`UnicodeEncodeError: 'charmap' codec can't encode character '\ufdfc' in position 79: character maps to <undefined>`

Fixes #1799 
