### PR TITLE
Ensure pyfloat honors min and max values

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -144,20 +144,23 @@ class Provider(BaseProvider):
 
         sign = ""
         if (min_value is not None) or (max_value is not None):
+            # Copy values to ensure we're not modifying the original values and thus going out of bounds
+            left_min_value = min_value
+            left_max_value = max_value
             # Make sure left_digits still respected
             if left_digits is not None:
                 if max_value is None:
-                    max_value = 10**left_digits  # minus smallest representable, adjusted later
+                    left_max_value = 10**left_digits  # minus smallest representable, adjusted later
                 if min_value is None:
-                    min_value = -(10**left_digits)  # plus smallest representable, adjusted later
+                    left_min_value = -(10**left_digits)  # plus smallest representable, adjusted later
 
             if max_value is not None and max_value < 0:
-                max_value += 1  # as the random_int will be generated up to max_value - 1
+                left_max_value += 1  # as the random_int will be generated up to max_value - 1
             if min_value is not None and min_value < 0:
-                min_value += 1  # as we then append digits after the left_number
+                left_min_value += 1  # as we then append digits after the left_number
             left_number = self._safe_random_int(
-                min_value,
-                max_value,
+                left_min_value,
+                left_max_value,
                 positive,
             )
         else:
@@ -178,11 +181,17 @@ class Provider(BaseProvider):
             result = min(result, 10**left_digits - 1)
             result = max(result, -(10**left_digits + 1))
 
-        # It's possible for the result to end up > than max_value
-        # This is a quick hack to ensure result is always smaller.
+        # It's possible for the result to end up > than max_value or < than min_value
+        # When this happens we introduce some variance so we're not always the exactly the min_value or max_value. 
+        # Which can happen a lot depending on the difference of the values.
+        # Ensure the variance is bound by the difference between the max and min
         if max_value is not None:
             if result > max_value:
-                result = result - (result - max_value)
+                result = result - (result - max_value + self.generator.random.uniform(0, max_value - min_value))
+        if min_value is not None:
+            if result < min_value:
+                result = result + (min_value - result + self.generator.random.uniform(0, max_value - min_value))
+
         return result
 
     def _safe_random_int(self, min_value: float, max_value: float, positive: bool) -> int:

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -182,7 +182,7 @@ class Provider(BaseProvider):
             result = max(result, -(10**left_digits + 1))
 
         # It's possible for the result to end up > than max_value or < than min_value
-        # When this happens we introduce some variance so we're not always the exactly the min_value or max_value. 
+        # When this happens we introduce some variance so we're not always the exactly the min_value or max_value.
         # Which can happen a lot depending on the difference of the values.
         # Ensure the variance is bound by the difference between the max and min
         if max_value is not None:

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -181,6 +181,17 @@ class TestPyfloat(unittest.TestCase):
         self.assertLessEqual(result, 100)
         self.assertGreater(result, 0)
 
+    def test_max_and_min_value_positive_with_decimals(self):
+        """
+        Combining the max_value and min_value keyword arguments with
+        positive values for each produces numbers that obey both of
+        those constraints.
+        """
+        for _ in range(1000):
+            result = self.fake.pyfloat(min_value=100.123, max_value=200.321)
+            self.assertLessEqual(result, 200.321)
+            self.assertGreaterEqual(result, 100.123)
+
     def test_max_and_min_value_negative(self):
         """
         Combining the max_value and min_value keyword arguments with
@@ -191,6 +202,17 @@ class TestPyfloat(unittest.TestCase):
         result = self.fake.pyfloat(max_value=-100, min_value=-200)
         self.assertLessEqual(result, -100)
         self.assertGreaterEqual(result, -200)
+
+    def test_max_and_min_value_negative_with_decimals(self):
+        """
+        Combining the max_value and min_value keyword arguments with
+        negative values for each produces numbers that obey both of
+        those constraints.
+        """
+        for _ in range(1000):
+            result = self.fake.pyfloat(max_value=-100.123, min_value=-200.321)
+            self.assertLessEqual(result, -100.123)
+            self.assertGreaterEqual(result, -200.321)
 
     def test_positive_and_min_value_incompatible(self):
         """


### PR DESCRIPTION
### What does this change

Ensure we don't override the user input.
Validate that we're within the allowed range, and if not, ensure we are with some randomness. 

### What was wrong

As shown in #1825, `pyfloat` would reliably produce results that exceeded the provided values.

### How this fixes it

Copy the arguments and modify the copy instead of the original arguments.
Check that we're in the required range, and if not, ensure we are.

Fixes #1825.
