### PR TITLE
Fix value error formatting

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -87,7 +87,7 @@ class Provider(BaseProvider):
         elif object_type == dict:
             return self.pydict()
         else:
-            raise ValueError("Object type `{object_type}` is not supported by `pyobject` function")
+            raise ValueError(f"Object type `{object_type}` is not supported by `pyobject` function")
 
     def pybool(self, truth_probability: int = 50) -> bool:
         """


### PR DESCRIPTION
### What does this change

Fix the `ValueError` formatting

### What was wrong

The error was not printed 

### How this fixes it

I literally add just a char to format the message error (my mistake, I forgot it in #1822)