### PR TITLE
Fix determinism in `state_abbr()`

### DIFF
--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Optional, Set
+from typing import Optional, Tuple
 
 from ..en import Provider as AddressProvider
 
@@ -516,11 +516,11 @@ class Provider(AddressProvider):
         :param include_freely_associated_states: If True, freely-associated states will be included.
             If False, sovereign states in free association with the US will be excluded.
         """
-        abbreviations: Set[str] = set(self.states_abbr)
+        abbreviations: Tuple[str, ...] = self.states_abbr
         if include_territories:
-            abbreviations.update(self.territories_abbr)
+            abbreviations += self.territories_abbr
         if include_freely_associated_states:
-            abbreviations.update(self.freely_associated_states_abbr)
+            abbreviations += self.freely_associated_states_abbr
         return self.random_element(abbreviations)
 
     def postcode(self) -> str:

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -626,6 +626,12 @@ class TestEnUS:
         with pytest.raises(Exception):
             faker.postalcode_in_state("XX")
 
+    def test_state_abbr_determinism(self, faker):
+        faker.seed_instance(0)
+        first = faker.state_abbr()
+        faker.seed_instance(0)
+        assert faker.state_abbr() == first
+
 
 class TestEsCo:
     """Test es_CO address provider methods"""


### PR DESCRIPTION
Unfortunately, by changing the code to use sets (unordered by definition) from simple tuples, I broke the determinism of `state_abbr()`. Apologies! Changing it back to use a simple ordered collection fixes the problem.

(This probably makes sense to ship as 18.3.1, since there's no change in the API)