### PR TITLE
Added de_DE swift_location_codes

### DIFF
--- a/faker/providers/bank/de_DE/__init__.py
+++ b/faker/providers/bank/de_DE/__init__.py
@@ -2,7 +2,20 @@ from .. import Provider as BankProvider
 
 
 class Provider(BankProvider):
-    """Implement bank provider for ``de_DE`` locale."""
+    """Implement bank provider for ``de_DE`` locale.
+
+    Source for rules for swift location codes:
+
+    - https://www.ebics.de/de/datenformate
+    """
 
     bban_format = "##################"
     country_code = "DE"
+
+    first_place = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "23456789"
+    second_place = "ABCDEFGHIJKLMNPQRSTUVWXYZ" + "0123456789"
+    swift_location_codes = []
+    for i in first_place:
+        for j in second_place:
+            swift_location_codes.append(str(i) + str(j))
+    swift_location_codes = tuple(swift_location_codes)

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -271,6 +271,16 @@ class TestFrFr:
             assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
 
 
+class TestDeDe:
+    """Test de_DE bank provider"""
+
+    def test_swift_use_dataset(self, faker, num_samples):
+        regex = re.compile("[A-Z]{6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3})?")
+        for _ in range(num_samples):
+            code = faker.swift(use_dataset=True)
+            assert regex.fullmatch(code) is not None
+
+
 class TestEnPh:
     """Test en_PH bank provider"""
 


### PR DESCRIPTION
### What does this change

This fixes the issue found in #1823 and adds a test to verify this.

### What was wrong

Faker did not follow the norms for EBICS/SWIFT in de_De locale, specifically the regular expression [A-Z]{6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3})? . In other words, there must not be a 0 or 1 in the 1st place and no O in the 2nd place of the swift location code.

### How this fixes it

This adds the allowed list of swift location codes. Now if swift is called with "use_dataset=True" for "de_De" locale, it follows the rules. I am unsure if this the best way, since the rules should be followed even without "use_dataset=True" argument, but I see that this is how it has been implemented for other locales.
