### PR TITLE
add a separate basic number format for US

### DIFF
--- a/faker/providers/phone_number/en_US/__init__.py
+++ b/faker/providers/phone_number/en_US/__init__.py
@@ -37,3 +37,14 @@ class Provider(PhoneNumberProvider):
         "001-###-###-####x####",
         "001-###-###-####x#####",
     )
+
+    basic_formats = (
+        # basic 10-digit phone number format with no extensions
+        "##########",
+        "###-###-####",
+        "(###)###-####",
+    )
+
+    def basic_phone_number(self) -> str:
+        pattern: str = self.random_element(self.basic_formats)
+        return self.numerify(self.generator.parse(pattern))

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -373,17 +373,9 @@ class TestEnUs:
         pattern_no_whitespaces: Pattern = re.compile(
             r"\d{9}",
         )
-        pattern_dashes: Pattern = re.compile(
-            r"\d{3}-\d{3}-\d{4}"
-        )
-        pattern_parens: Pattern = re.compile(
-            r"\(\d{3}\)\d{3}-\d{4}"
-        )
-        patterns = [
-            pattern_no_whitespaces,
-            pattern_dashes,
-            pattern_parens
-        ]
+        pattern_dashes: Pattern = re.compile(r"\d{3}-\d{3}-\d{4}")
+        pattern_parens: Pattern = re.compile(r"\(\d{3}\)\d{3}-\d{4}")
+        patterns = [pattern_no_whitespaces, pattern_dashes, pattern_parens]
         for _ in range(num_samples):
             phone_number = faker.basic_phone_number()
             assert any([re.match(pattern, phone_number) for pattern in patterns])

--- a/tests/providers/test_phone_number.py
+++ b/tests/providers/test_phone_number.py
@@ -364,3 +364,26 @@ class TestFrFr:
         for _ in range(num_samples):
             phone_number = faker.phone_number()
             assert any([re.match(pattern, phone_number) for pattern in patterns])
+
+
+class TestEnUs:
+    """Test En_US phone provider methods"""
+
+    def test_basic_phone_number(self, faker, num_samples):
+        pattern_no_whitespaces: Pattern = re.compile(
+            r"\d{9}",
+        )
+        pattern_dashes: Pattern = re.compile(
+            r"\d{3}-\d{3}-\d{4}"
+        )
+        pattern_parens: Pattern = re.compile(
+            r"\(\d{3}\)\d{3}-\d{4}"
+        )
+        patterns = [
+            pattern_no_whitespaces,
+            pattern_dashes,
+            pattern_parens
+        ]
+        for _ in range(num_samples):
+            phone_number = faker.basic_phone_number()
+            assert any([re.match(pattern, phone_number) for pattern in patterns])


### PR DESCRIPTION
issue ticket: https://github.com/joke2k/faker/issues/1847

### What does this change

Adds a 'basic phone number' type to en_US to comply with some form requirements, as well as a unit test.

### What was wrong

Some forms do not allow for phone formats with extensions or country codes. As a result, the faker get_phone function for en_US doesn't work for all cases. 

### How this fixes it

Adds a function that allows the user to only use 'basic' ten-digit phone numbers and standard formatting. 
