### PR TITLE
Improve fr_FR provider postcode

### DIFF
--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -46,7 +46,6 @@ class Provider(AddressProvider):
     address_formats = ("{{street_address}}\n{{postcode}} {{city}}",)
 
     building_number_formats = ("%", "%#", "%#", "%#", "%##")
-    postcode_formats = ("#####",)
     countries = (
         "Afghanistan",
         "Afrique du sud",
@@ -467,3 +466,13 @@ class Provider(AddressProvider):
         :example: '59'
         """
         return self.department()[0]
+
+    def postcode(self) -> str:
+        """
+        Randomly returns a postcode generated from existing french depertment number.
+        exemple: '33260'
+        """
+        department = self.department_number()
+        if department in ["2A", "2B"]:
+            department = "20"
+        return f"{department}{self.random_number(digits=5 - len(department))}"

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -865,6 +865,17 @@ class TestFrFr:
             assert isinstance(department_number, str)
             assert department_number in department_numbers
 
+    def test_postcode(self, faker, num_samples):
+        department_numbers = [dept_num for dept_num, dept_name in FrFrAddressProvider.departments]
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            assert (
+                postcode[:3] in department_numbers  # for 3 digits deparments number
+                or postcode[:2] == "20"  # for Corsica : "2A" or "2B"
+                or postcode[:2] in department_numbers  # any other
+            )
+
 
 class TestHeIl:
     """Test he_IL address provider methods"""


### PR DESCRIPTION
### What does this change

Improve postcode for fr_FR address provider

### What was wrong

The current provider may generate postcodes for invalid departments (any number starting with 96 is invalid)

### How this fixes it

Generate postcode from department codes


NB: I'm not sure how to test this commit : I could check that the generated postcode always match a department, but the test would be flaky before the fix... 