### PR TITLE
Add bank provider for zh_CN locale and test function

### DIFF
--- a/faker/providers/bank/zh_CN/__init__.py
+++ b/faker/providers/bank/zh_CN/__init__.py
@@ -1,0 +1,37 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    """Implement bank provider for ``zh_CN`` locale.
+    Source: https://zh.wikipedia.org/wiki/中国大陆银行列表
+    """
+
+    banks = (
+        "中国人民银行",
+        "国家开发银行",
+        "中国进出口银行",
+        "中国农业发展银行",
+        "交通银行",
+        "中国银行",
+        "中国建设银行",
+        "中国农业银行",
+        "中国工商银行",
+        "中国邮政储蓄银行",
+        "中国光大银行",
+        "中国民生银行",
+        "招商银行",
+        "中信银行",
+        "华夏银行",
+        "上海浦东发展银行",
+        "平安银行",
+        "广发银行",
+        "兴业银行",
+        "浙商银行",
+        "渤海银行",
+        "恒丰银行",
+        "西安银行",
+    )
+
+    def bank(self) -> str:
+        """Generate a bank name."""
+        return self.random_element(self.banks)

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -442,3 +442,11 @@ class TestNlBe:
             assert code[4:6] == NlBeBankProvider.country_code
             assert code[6:8] in NlBeBankProvider.swift_location_codes
             assert code[8:11] in NlBeBankProvider.swift_branch_codes
+
+
+class TestZhCn:
+    """Test zh_CN bank provider"""
+
+    def test_bank(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert re.match(r"[\u4e00-\u9fa5]{2,20}", faker.bank())


### PR DESCRIPTION
### What does this change

Add bank provider for zh_CN locale and corresponding test function.

### What was wrong

The functionality was not implemented ever. This pull request creates new functionality.

### How this fixes it

The new functionality will generate the fake bank data in zh_CN locale.
