### PR TITLE
adding state_code and state API

### DIFF
--- a/faker/providers/address/en_IN/__init__.py
+++ b/faker/providers/address/en_IN/__init__.py
@@ -393,6 +393,9 @@ class Provider(AddressProvider):
 
     def city_name(self) -> str:
         return self.random_element(self.cities)
+    
+    def state_name(self) -> str:
+        return self.random_element(self.states)
 
     def administrative_unit(self) -> str:
         return self.random_element(self.states)

--- a/faker/providers/address/en_IN/__init__.py
+++ b/faker/providers/address/en_IN/__init__.py
@@ -393,7 +393,7 @@ class Provider(AddressProvider):
 
     def city_name(self) -> str:
         return self.random_element(self.cities)
-    
+
     def state_name(self) -> str:
         return self.random_element(self.states)
 

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -497,6 +497,12 @@ class Provider(AddressProvider):
 
     def administrative_unit(self) -> str:
         return self.random_element(self.states)
+    
+    def state_code(self) -> str:
+        """
+        :example: 'IA'
+        """
+        return self.random_element(self.states_abbr)
 
     state = administrative_unit
 

--- a/faker/providers/address/en_US/__init__.py
+++ b/faker/providers/address/en_US/__init__.py
@@ -497,7 +497,7 @@ class Provider(AddressProvider):
 
     def administrative_unit(self) -> str:
         return self.random_element(self.states)
-    
+
     def state_code(self) -> str:
         """
         :example: 'IA'

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -631,6 +631,12 @@ class TestEnUS:
         first = faker.state_abbr()
         faker.seed_instance(0)
         assert faker.state_abbr() == first
+    
+    def test_state_code(self, faker, num_samples):
+        for _ in range(num_samples):
+            state_code = faker.state_code()
+            assert not isinstance(state_code, str)
+            assert state_code in EnUsAddressProvider.states_abbr
 
 
 class TestEsCo:
@@ -1812,6 +1818,12 @@ class TestEnIn:
             assert city_name in EnInAddressProvider.cities
 
     def test_state(self, faker, num_samples):
+        for _ in range(num_samples):
+            state = faker.state()
+            assert isinstance(state, str)
+            assert state in EnInAddressProvider.states
+
+    def test_state_name(self, faker, num_samples):
         for _ in range(num_samples):
             state = faker.state()
             assert isinstance(state, str)

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -631,7 +631,7 @@ class TestEnUS:
         first = faker.state_abbr()
         faker.seed_instance(0)
         assert faker.state_abbr() == first
-    
+
     def test_state_code(self, faker, num_samples):
         for _ in range(num_samples):
             state_code = faker.state_code()


### PR DESCRIPTION
### What does this change

Adds state_code() API to address provider in en_US and state_name() in en_IN

### What was wrong

Address provider did not have state() and state_code() APIs

### How this fixes it
Adds the above API and corresponding test cases

Fixes #1845 
