### PR TITLE
PoC: a .optional proxy that may or may not return a fake value

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -356,7 +356,11 @@ class OptionalProxy:
         @functools.wraps(function)
         def wrapper(*args: Any, prob: float = 0.5, **kwargs: Any) -> Optional[RetType]:
             if not 0 < prob <= 1.0:
-                raise ValueError()
-            return function(*args, **kwargs) if self._proxy.pybool() else None
+                raise ValueError("prob must be between 0 and 1")
+            return (
+                function(*args, **kwargs)
+                if self._proxy.boolean(chance_of_getting_true=int(prob * 100))
+                else None
+            )
 
         return wrapper

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -4,7 +4,7 @@ import re
 
 from collections import OrderedDict
 from random import Random
-from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, TypeVar, Union
 
 from .config import DEFAULT_LOCALE
 from .exceptions import UniquenessException
@@ -14,6 +14,8 @@ from .typing import SeedType
 from .utils.distribution import choices_distribution
 
 _UNIQUE_ATTEMPTS = 1000
+
+RetType = TypeVar("RetType")
 
 
 class Faker:
@@ -350,9 +352,9 @@ class OptionalProxy:
     def __setstate__(self, state):
         self.__dict__.update(state)
 
-    def _wrap(self, name: str, function: Callable) -> Callable:
+    def _wrap(self, name: str, function: Callable[..., RetType]) -> Callable[..., Optional[RetType]]:
         @functools.wraps(function)
-        def wrapper(*args, prob: float = 0.5, **kwargs):
+        def wrapper(*args: Any, prob: float = 0.5, **kwargs: Any) -> Optional[RetType]:
             if not 0 < prob <= 1.0:
                 raise ValueError()
             return function(*args, **kwargs) if self._proxy.pybool() else None

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -357,10 +357,6 @@ class OptionalProxy:
         def wrapper(*args: Any, prob: float = 0.5, **kwargs: Any) -> Optional[RetType]:
             if not 0 < prob <= 1.0:
                 raise ValueError("prob must be between 0 and 1")
-            return (
-                function(*args, **kwargs)
-                if self._proxy.boolean(chance_of_getting_true=int(prob * 100))
-                else None
-            )
+            return function(*args, **kwargs) if self._proxy.boolean(chance_of_getting_true=int(prob * 100)) else None
 
         return wrapper

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -332,6 +332,9 @@ class UniqueProxy:
 
 
 class OptionalProxy:
+    """
+    Return either a fake value or None, with a customizable probability.
+    """
     def __init__(self, proxy: Faker):
         self._proxy = proxy
 

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -1,0 +1,44 @@
+import pytest
+
+from faker import Faker
+
+
+class TestOptionalClass:
+    def test_optional(self) -> None:
+        fake = Faker()
+
+        assert {fake.optional.boolean() for _ in range(10)} == {True, False, None}
+
+    def test_optional_probability(self) -> None:
+        """The probability is configurable."""
+        fake = Faker()
+
+        fake.optional.name(prob=0.1)
+
+    def test_optional_arguments(self) -> None:
+        """Other arguments are passed through to the function."""
+        fake = Faker()
+
+        fake.optional.pyint(1, 2, prob=0.4)
+
+    def test_optional_valid_range(self) -> None:
+        """Only probabilities in the range (0, 1]."""
+        fake = Faker()
+
+        with pytest.raises(ValueError, match=""):
+            fake.optional.name(prob=0)
+
+        with pytest.raises(ValueError, match=""):
+            fake.optional.name(prob=1.1)
+
+        with pytest.raises(ValueError, match=""):
+            fake.optional.name(prob=-3)
+
+    def test_functions_only(self):
+        """Accessing non-functions through the `.optional` attribute
+        will throw a TypeError."""
+
+        fake = Faker()
+
+        with pytest.raises(TypeError, match="Accessing non-functions through .optional is not supported."):
+            fake.optional.locales


### PR DESCRIPTION
### What does this change

This adds a `.optional` property, that should make all the usual functions return either a fake value or `None`, with a customisable probability.

This was a quick and dirty lunchtime project which could use some care and attention (in particular I'm not sure about the `prob=n` parameter, and the tests are a bit limited). I thought I'd get some feedback before spending too much time cleaning it up.

### What was wrong

Currently it can be a bit fiddly to create fake optional fake data. There are a few projects out there that extend `faker` to provide this functionality using custom providers, but they're limited in what they can generate. This provides access to everything that would normally be available.
