### PR TITLE
Fix fr_FR postcode length

### DIFF
--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -469,7 +469,7 @@ class Provider(AddressProvider):
 
     def postcode(self) -> str:
         """
-        Randomly returns a postcode generated from existing french depertment number.
+        Randomly returns a postcode generated from existing french department number.
         exemple: '33260'
         """
         department = self.department_number()

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -475,4 +475,4 @@ class Provider(AddressProvider):
         department = self.department_number()
         if department in ["2A", "2B"]:
             department = "20"
-        return f"{department}{self.random_number(digits=5 - len(department))}"
+        return f"{department}{self.random_number(digits=5 - len(department), fix_len=True)}"

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -870,6 +870,7 @@ class TestFrFr:
         for _ in range(num_samples):
             postcode = faker.postcode()
             assert isinstance(postcode, str)
+            assert len(postcode) == 5
             assert (
                 postcode[:3] in department_numbers  # for 3 digits deparments number
                 or postcode[:2] == "20"  # for Corsica : "2A" or "2B"


### PR DESCRIPTION
### What does this change

Fix the length of the postcode values generated by the fr_FR address provider

### What was wrong

cf #1868 

### How this fixes it

Pass `fix_len` flag to the underlying `BaseProvider.random_number()` call

Fixes #1868 