### PR TITLE
Added faker_pyspark reference

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -90,7 +90,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/
 .. _mdgen: https://pypi.org/project/mdgen/
-.. _faker_pyspark: https://pypi.org/project/faker_pyspark/
+.. _faker_pyspark: https://pypi.org/project/faker-pyspark/
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -45,7 +45,7 @@ Here's a list of Providers written by the community:
 |               | format                    |                                  |
 +---------------+---------------------------+----------------------------------+
 | PySpark       | Fake PySpark DataFrane    | `faker_pyspark`_                 |
-|               | and Schema generator      |
+|               | and Schema generator      |                                  |
 +---------------+---------------------------+----------------------------------+
 | Vehicle       | Fake vehicle information  | `faker_vehicle`_                 |
 |               | includes Year Make Model  |                                  |

--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -44,6 +44,9 @@ Here's a list of Providers written by the community:
 | Posts         | Fake posts in markdown    | `mdgen`_                         |
 |               | format                    |                                  |
 +---------------+---------------------------+----------------------------------+
+| PySpark       | Fake PySpark DataFrane    | `faker_pyspark`_                 |
+|               | and Schema generator      |
++---------------+---------------------------+----------------------------------+
 | Vehicle       | Fake vehicle information  | `faker_vehicle`_                 |
 |               | includes Year Make Model  |                                  |
 +---------------+---------------------------+----------------------------------+
@@ -87,6 +90,7 @@ In order to be included, your provider must satisfy these requirement:
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/
 .. _mdgen: https://pypi.org/project/mdgen/
+.. _faker_pyspark: https://pypi.org/project/faker_pyspark/
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/
 .. _faker_web: https://pypi.org/project/faker_web/
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/


### PR DESCRIPTION
Added faker_pyspark reference

### What does this change

faker_pyspark is a PySpark provider for the Faker python package

### What was wrong

Nothing was wrong, adding new community package to documentation