### PR TITLE
docs: update `pystr` docstring to include param descriptions, fix docstring formats

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1809,6 +1809,7 @@ class Provider(BaseProvider):
         """
         Get a timestamp between January 1, 1970 and now, unless passed
         explicit start_datetime or end_datetime values.
+
         :example: 1061306726
         """
         start_datetime = self._parse_start_datetime(start_datetime)
@@ -1833,6 +1834,7 @@ class Provider(BaseProvider):
     ) -> datetime:
         """
         Get a datetime object for a date between January 1, 1970 and now
+
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example: datetime('2005-08-16 20:39:21')
         :return: datetime
@@ -1850,6 +1852,7 @@ class Provider(BaseProvider):
     ) -> datetime:
         """
         Get a datetime object for a date between January 1, 001 and now
+
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :example: datetime('1265-03-22 21:15:52')
         :return: datetime
@@ -1883,6 +1886,7 @@ class Provider(BaseProvider):
     ) -> str:
         """
         Get a timestamp in ISO 8601 format (or one of its profiles).
+
         :param tzinfo: timezone, instance of datetime.tzinfo subclass
         :param sep: separator between date and time, defaults to 'T'
         :param timespec: format specifier for the time part, defaults to 'auto' - see datetime.isoformat() documentation
@@ -1903,6 +1907,7 @@ class Provider(BaseProvider):
     def date_object(self, end_datetime: Optional[datetime] = None) -> dtdate:
         """
         Get a date object between January 1, 1970 and now
+
         :example: datetime.date(2016, 9, 20)
         """
         return self.date_time(end_datetime=end_datetime).date()
@@ -1910,6 +1915,7 @@ class Provider(BaseProvider):
     def time(self, pattern: str = "%H:%M:%S", end_datetime: Optional[DateParseType] = None) -> str:
         """
         Get a time string (24h format by default)
+
         :param pattern: format
         :example: '15:02:34'
         """
@@ -1918,6 +1924,7 @@ class Provider(BaseProvider):
     def time_object(self, end_datetime: Optional[DateParseType] = None) -> dttime:
         """
         Get a time object
+
         :example: datetime.time(15, 56, 56, 772876)
         """
         return self.date_time(end_datetime=end_datetime).time()

--- a/faker/providers/person/__init__.py
+++ b/faker/providers/person/__init__.py
@@ -200,7 +200,7 @@ class Provider(BaseProvider):
 
     def name(self) -> str:
         """
-        :example 'John Doe'
+        :example: 'John Doe'
         """
         pattern: str = self.random_element(self.formats)
         return self.generator.parse(pattern)

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -111,6 +111,11 @@ class Provider(BaseProvider):
     ) -> str:
         """
         Generates a random string of upper and lowercase letters.
+
+        :param min_chars: minimum length of the random part.
+        :param max_chars: maximum length of the random part.
+        :param prefix: an optional prefix to prepend to the random string.
+        :param suffix: an optional suffix to append to the random string.
         :return: Random of random length between min and max characters.
         """
         if min_chars is None:


### PR DESCRIPTION
### What does this change

* Adds description of parameters to `pystr`.
* Adds newline to some docstrings that weren't rendering properly in docs.  Example:
![image](https://github.com/joke2k/faker/assets/16111337/9b71ee00-3215-41b7-8706-4b969f4bd4b8)


### What was wrong

See #1877 

### How this fixes it

Should remove confusion around `max_chars` and `prefix`/`suffix` usage.  Docs should render appropriately when built with sphinx.

closes #1877 
