### PR TITLE
fix: pyfloat type error on none max value

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -161,11 +161,21 @@ class Provider(BaseProvider):
             raise ValueError("Max value must fit within left digits")
         if left_digits is not None and min_value and math.ceil(math.log10(abs(min_value))) > left_digits:
             raise ValueError("Min value must fit within left digits")
+        if max_value is not None and max_value < -(10**sys.float_info.dig + 1):
+            raise ValueError(f"Max value must be greater than {-10**sys.float_info.dig - 1}")
+        if min_value is not None and min_value > 10**sys.float_info.dig - 1:
+            raise ValueError(f"Min value must be less than {10**sys.float_info.dig - 1}")
 
+        left_digits_requested = left_digits is not None
+        right_digits_requested = right_digits is not None
         # Make sure at least either left or right is set
         if left_digits is None and right_digits is None:
             needed_left_digits = max(1, math.ceil(math.log10(max(abs(max_value or 1), abs(min_value or 1)))))
-            right_digits = self.random_int(1, sys.float_info.dig - needed_left_digits)
+            if (sys.float_info.dig - needed_left_digits) < 1:
+                right_digits = 0
+            else:
+                right_digits = self.random_int(1, sys.float_info.dig - needed_left_digits)
+
 
         # If only one side is set, choose #digits for other side
         if (left_digits is None) ^ (right_digits is None):
@@ -181,32 +191,67 @@ class Provider(BaseProvider):
                 f"{sys.float_info.dig})",
             )
 
-        sign = ""
         if (min_value is not None) or (max_value is not None):
             # Copy values to ensure we're not modifying the original values and thus going out of bounds
-            left_min_value = min_value
-            left_max_value = max_value
+            temp_min_value = min_value
+            temp_max_value = max_value
             # Make sure left_digits still respected
-            if left_digits is not None:
-                if max_value is None:
-                    left_max_value = 10**left_digits  # minus smallest representable, adjusted later
-                if min_value is None:
-                    left_min_value = -(10**left_digits)  # plus smallest representable, adjusted later
+            if max_value is None:
+                temp_max_value = 10 ** (left_digits + right_digits)
+                if min_value is not None:
+                    temp_min_value = min_value * 10 ** right_digits
+            if min_value is None:
+                temp_min_value = -(10 ** (left_digits + right_digits))
+                if max_value is not None:
+                    if max_value < temp_min_value:
+                        temp_min_value = max_value - 1
+                    temp_max_value = max_value * 10 ** right_digits
 
             if max_value is not None and max_value < 0:
-                left_max_value += 1  # as the random_int will be generated up to max_value - 1
+                temp_max_value += 1  # as the random_int will be generated up to max_value - 1
             if min_value is not None and min_value < 0:
-                left_min_value += 1  # as we then append digits after the left_number
-            left_number = self._safe_random_int(
-                left_min_value,
-                left_max_value,
-                positive,
+                temp_min_value += 1  # as we then append digits after the left_number
+
+            opposite_signs = (temp_min_value * temp_max_value) < 0
+            if opposite_signs and left_digits_requested:
+                positive_number = self._safe_random_int(
+                    10 ** (left_digits + right_digits - 1),
+                    temp_max_value,
+                    positive=True,
+                )
+                negative_number = self._safe_random_int(
+                    temp_min_value,
+                    -(10 ** (left_digits + right_digits - 1)),
+                    positive=False,
+                )
+                number = self.random_element((positive_number, negative_number))
+            else:
+                number = self._safe_random_int(
+                    temp_min_value,
+                    temp_max_value,
+                    positive,
+                )
+
+            params_requested = (
+                    right_digits_requested or left_digits_requested or ((min_value is None) ^ (max_value is None))
             )
+            if params_requested:
+                result = (
+                    float(f"{str(number)[:-right_digits]}.{str(number)[-right_digits:]}")
+                    if right_digits
+                    else float(number)
+                )
+            else:
+                fix_right_digits_len = right_digits > 0
+                result = float(f"{number}.{self.random_number(right_digits, fix_len=fix_right_digits_len)}")
+
         else:
             sign = "+" if positive else self.random_element(("+", "-"))
-            left_number = self.random_number(left_digits)
+            fix_left_digits_len = left_digits > 0
+            left_number = self.random_number(left_digits, fix_len=fix_left_digits_len)
+            fix_right_digits_len = right_digits > 0
+            result = float(f"{sign}{left_number}.{self.random_number(right_digits, fix_len=fix_right_digits_len)}")
 
-        result = float(f"{sign}{left_number}.{self.random_number(right_digits)}")
         if positive and result == 0:
             if right_digits:
                 result = float("0." + "0" * (right_digits - 1) + "1")
@@ -219,17 +264,6 @@ class Provider(BaseProvider):
         else:
             result = min(result, 10**left_digits - 1)
             result = max(result, -(10**left_digits + 1))
-
-        # It's possible for the result to end up > than max_value or < than min_value
-        # When this happens we introduce some variance so we're not always the exactly the min_value or max_value.
-        # Which can happen a lot depending on the difference of the values.
-        # Ensure the variance is bound by the difference between the max and min
-        if max_value is not None:
-            if result > max_value:
-                result = result - (result - max_value + self.generator.random.uniform(0, max_value - min_value))
-        if min_value is not None:
-            if result < min_value:
-                result = result + (min_value - result + self.generator.random.uniform(0, max_value - min_value))
 
         return result
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -162,7 +162,7 @@ class TestPyfloat(unittest.TestCase):
         self.assertGreaterEqual(result, 0)
 
     def test_max_value(self):
-        max_values = (0, 10, -1000, 1000, 999999)
+        max_values = (0, 10, -1000, 1000, 999999, 100000000000001.0, -1000000000000001.0)
 
         for max_value in max_values:
             result = self.fake.pyfloat(max_value=max_value)
@@ -209,6 +209,33 @@ class TestPyfloat(unittest.TestCase):
             result = self.fake.pyfloat(min_value=100.123, max_value=200.321)
             self.assertLessEqual(result, 200.321)
             self.assertGreaterEqual(result, 100.123)
+
+    def test_max_none_and_min_value_with_decimals(self):
+        """
+        Combining the max_value and min_value keyword arguments with
+        positive value for min and None for max produces numbers with
+        left and right digits specified produced numbers greater than
+        the supplied min_value.
+        """
+        for _ in range(1000):
+            result = self.fake.pyfloat(min_value=99884.7, max_value=None, left_digits=5, right_digits=2)
+            self.assertGreaterEqual(result, 99884.7)
+            assert len(str(result).strip("-").split(".")[0]) == 5
+            assert len(str(result).strip("-").split(".")[1]) <= 2
+
+    def test_min_none_and_max_value_with_decimals(self):
+        """
+        Combining the max_value and min_value keyword arguments with
+        positive value for max and None for min produces numbers with
+        left and right digits specified produced numbers greater than
+        the supplied min_value.
+        """
+        for _ in range(1000):
+            result = self.fake.pyfloat(min_value=None, max_value=11000.3, left_digits=5, right_digits=2)
+            self.assertLessEqual(result, 11000.3)
+            assert len(str(result).strip("-").split(".")[0]) == 5
+            assert len(str(result).strip("-").split(".")[1]) <= 2
+
 
     def test_max_and_min_value_negative(self):
         """


### PR DESCRIPTION
### What does this change
Handle the combinations of specified digits and min and max values in a more advanced way for pyfloat.

### What was wrong

There were a few issues that this PR aims to address:
- This line was throwing a TypeError if max_value or min_value was None
```python
self.generator.random.uniform(0, max_value - min_value)
```

- This line would throw an error when `needed_left_digits == sys.float_info.dig` because the range was then invalid
- Giving in `-(10**sys.float_info.dig + 1)` as max value and `10**sys.float_info.dig` as min_value can never succeed because of the following code at the end:
```python
        if right_digits:
            result = min(result, 10**left_digits - float(f'0.{"0" * (right_digits - 1)}1'))
            result = max(result, -(10**left_digits + float(f'0.{"0" * (right_digits - 1)}1')))
        else:
            result = min(result, 10**left_digits - 1)
            result = max(result, -(10**left_digits + 1))
```
- The number of left and right digits were not always respected.

### How this fixes it
- `ValueError` is raised if max_value or min_value is out of bounds
- right digits is set to 0 if the inferred left digits is already equals to sys.float_info.dig
- Rather than choosing only the `left_number` which then caused issues in trying to figure out a "right number" which could then end up being lower/higher than the configured max/min value, an int is chosen randomly between min and max values which are scaled up to have the length of left + right digits so that afterwards a `.` can be inserted in the right place.
- The previous adjustment code containing the TypeError is removed.

Fixes https://github.com/joke2k/faker/issues/1907
