### PR TITLE
Feat/mac address multicast

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -582,8 +582,18 @@ class Provider(BaseProvider):
             address = str(IPv6Network(address, strict=False))
         return address
 
-    def mac_address(self) -> str:
-        mac = [self.generator.random.randint(0x00, 0xFF) for _ in range(0, 6)]
+    def mac_address(self, multicast: bool = False) -> str:
+        """
+        Returns a random MAC address.
+
+        :param multicast: Multicast address
+        :returns: MAC Address
+        """
+        mac = [self.generator.random.randint(0x00, 0xFF) for _ in range(0, 5)]
+        if multicast is True:
+            mac.insert(0, self.generator.random.randrange(0x01, 0xFF, 2))
+        else:
+            mac.insert(0, self.generator.random.randrange(0x00, 0xFE, 2))
         return ":".join("%02x" % x for x in mac)
 
     def port_number(self, is_system: bool = False, is_user: bool = False, is_dynamic: bool = False) -> int:

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -304,6 +304,15 @@ class TestInternetProvider:
             assert len(address) <= 39 + 4
             assert re.compile(r"^([0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}/\d{1,3}$").search(address)
 
+    def test_mac_address(self, faker):
+        provider = InternetProvider(faker)
+
+        unicast_address = provider.mac_address(multicast=False)
+        assert int(unicast_address[0:2], base=16) % 2 == 0
+
+        multicast_address = provider.mac_address(multicast=True)
+        assert int(multicast_address[0:2], base=16) % 2 == 1
+
     def test_port_number(self, faker, num_samples):
         for _ in range(num_samples):
             assert 0 <= faker.port_number() <= 65535


### PR DESCRIPTION
### What does this change

Add the options to create unicast or multicast MAC address (default: unicast).
As defined in IEEE 802.3, all MAC addresses that have the least significant bit of the most significant byte as "1" are multicast.
This is also mentioned in the RFC7042.

### What was wrong

Previously, the project did not differentiate between unicast and multicast mac addresses. 

### How this fixes it

This PR allows you to choose between unicast and multicast mac addresses. A test set and parameter documentation have also been added.
