### PR TITLE
fix spelling error for pyspark

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -44,7 +44,7 @@ Here's a list of Providers written by the community:
 | Posts         | Fake posts in markdown    | `mdgen`_                         |
 |               | format                    |                                  |
 +---------------+---------------------------+----------------------------------+
-| PySpark       | Fake PySpark DataFrane    | `faker_pyspark`_                 |
+| PySpark       | Fake PySpark DataFrame    | `faker_pyspark`_                 |
 |               | and Schema generator      |                                  |
 +---------------+---------------------------+----------------------------------+
 | Vehicle       | Fake vehicle information  | `faker_vehicle`_                 |


### PR DESCRIPTION
### What does this change
Changed "datafrane" to "dataframe"

### What was wrong

Dataframe was incorrectly spelled

### How this fixes it

Dataframe is now correctly spelled


