### PR TITLE
Fix passport date of birth documentation typo

### DIFF
--- a/faker/providers/passport/__init__.py
+++ b/faker/providers/passport/__init__.py
@@ -15,7 +15,7 @@ class Provider(BaseProvider):
     passport_number_formats: ElementsType = ()
 
     def passport_dob(self) -> datetime.date:
-        """Generate a datetime date of bisrth."""
+        """Generate a datetime date of birth."""
         birthday = self.generator.date_of_birth()
         return birthday
 


### PR DESCRIPTION
### What does this change

Fix passport date of birth documentation typo.

### What was wrong

In the documentation it was `... a datetime date of birsth.` changed to `... a datetime date of birth.`

### How this fixes it

Description of how the changes fix the issue.

Fixes #...
