### PR TITLE
use DE base for AddressProvider (#1916)

### DIFF
--- a/faker/providers/address/de_CH/__init__.py
+++ b/faker/providers/address/de_CH/__init__.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from .. import Provider as AddressProvider
+from ..de import Provider as AddressProvider
 
 
 class Provider(AddressProvider):


### PR DESCRIPTION
### What does this change
Partial fix for #1916 

The original base (via `providers/date_time/__init__.py`) still loads strings with the wrong encoding.