### PR TITLE
added handling for finnish ssn where min age and max age are the same

### DIFF
--- a/faker/providers/ssn/fi_FI/__init__.py
+++ b/faker/providers/ssn/fi_FI/__init__.py
@@ -26,7 +26,10 @@ class Provider(SsnProvider):
             checksum_characters = "0123456789ABCDEFHJKLMNPRSTUVWXY"
             return checksum_characters[int(hetu) % 31]
 
-        age = datetime.timedelta(days=self.generator.random.randrange(min_age * 365, max_age * 365))
+        if min_age == max_age:
+            age = datetime.timedelta(days=min_age * 365)
+        else:
+            age = datetime.timedelta(days=self.generator.random.randrange(min_age * 365, max_age * 365))
         birthday = datetime.date.today() - age
         hetu_date = "%02d%02d%s" % (
             birthday.day,

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -793,6 +793,18 @@ class TestFiFI(unittest.TestCase):
         for _ in range(100):
             assert re.search(r"^FI\d{8}$", self.fake.vat_id())
 
+    def test_ssn_without_age_range(self):
+        current_year = datetime.now().year
+        age = current_year - 1995
+        ssn = self.fake.ssn(min_age=age, max_age=age, artificial=True)
+        assert "95-" in ssn
+        age = current_year - 2013
+        ssn = self.fake.ssn(min_age=age, max_age=age, artificial=True)
+        assert "13A" in ssn
+        age = current_year - 1898
+        ssn = self.fake.ssn(min_age=age, max_age=age, artificial=True)
+        assert "98+" in ssn
+
 
 class TestFrFR(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this change

Allows the same min_age and max_age parameters for the Finnish ssn provider.
Added ``test_ssn_without_age_range()`` to test scenarios from the 3 supported centuries. 

### What was wrong

See issue #1936  

### How this fixes it

When ``max_age`` and ``min_age`` are the same, the days a person has been alive are calculated according to ``min_age`` instead of picking a random number.

Fixes #1936 
