### PR TITLE
Fix latest days of the month as birth day in italian SSN

### DIFF
--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -8018,8 +8018,10 @@ class Provider(SsnProvider):
         surname: str = self._get_surname_letters()
         name: str = self._get_name_letters(sex)
         year: str = "%02d" % self.random_int(min=0, max=99)
+        is_leap_year: bool = self.is_leap_year(int(year))
         month: str = self.random_element(MONTHS_LIST)
-        day: str = "%02d" % (self.random_int(min=1, max=28) + (40 if sex == 1 else 0))
+        max_day: int = self._get_max_day(is_leap_year=is_leap_year, month=month)
+        day: str = "%02d" % (self.random_int(min=1, max=max_day) + (40 if sex == 1 else 0))
         municipality: str = self.random_element(MUNICIPALITIES_LIST)
         code: str = f"{surname}{name}{year}{month}{day}{municipality}"
         return code + checksum(code)

--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -8125,3 +8125,12 @@ class Provider(SsnProvider):
         Pads shorter string with the allowed char
         """
         return sequence.ljust(3, "X")
+
+    @staticmethod
+    def is_leap_year(year: int) -> bool:
+        """
+        Checks if the one given is a leap year
+        """
+        if (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0):
+            return True
+        return False

--- a/faker/providers/ssn/it_IT/__init__.py
+++ b/faker/providers/ssn/it_IT/__init__.py
@@ -8134,3 +8134,16 @@ class Provider(SsnProvider):
         if (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0):
             return True
         return False
+
+    @staticmethod
+    def _get_max_day(is_leap_year: bool, month: str) -> int:
+        """
+        Returns the maximum day for the current month
+        """
+        if month in ["D", "H", "P", "S"]:
+            max_day = 30
+        elif month == "B":
+            max_day = 29 if is_leap_year else 28
+        else:
+            max_day = 31
+        return max_day


### PR DESCRIPTION
### What does this change

This PR refers to [this issue](https://github.com/joke2k/faker/issues/1940).

### What was wrong

Random interval in Italian SSN generation was not broad enough to consider all possible birth dates.

### How this fixes it

A new method check for leap year and another new method returns the maximum day for the generated month-year couple.
This maximum day is used as upper bound for random_int day generation.