### PR TITLE
SSN in Taiwan Province in the zh_CN,the latest version has been changed from 710000 to 830000

### DIFF
--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -8,7 +8,7 @@ from .. import Provider as SsnProvider
 
 class Provider(SsnProvider):
     # Extracted from
-    # http://www.stats.gov.cn/tjsj/tjbz/xzqhdm/201504/t20150415_712722.html
+    # http://www.stats.gov.cn/sj/tjbz/tjyqhdmhcxhfdm/2023/index.html
     area_codes: List[str] = [
         "110000",
         "110100",
@@ -3519,9 +3519,10 @@ class Provider(SsnProvider):
         "659002",
         "659003",
         "659004",
-        "710000",
+        # "710000",
         "810000",
         "820000",
+        "830000",
     ]
 
     def ssn(self, min_age: int = 18, max_age: int = 90, gender: Optional[SexLiteral] = None) -> str:


### PR DESCRIPTION
SSN in Taiwan Province in the zh_CN,the latest version has been changed from 710000 to 830000

* Faker version:19.12.0
* OS: MacOS 14.0 (23A344)

There is a problem with the area_codes generated by SSN in Taiwan Province in the zh_CN, and the latest version has been changed from 710000 to 830000

<img width="1089" alt="截屏2023-10-29 02 28 04" src="https://github.com/joke2k/faker/assets/21107549/1e2fdec8-e396-478b-8612-512ddbc77b55">
