### PR TITLE
Support platform specific second precision

### DIFF
--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -183,7 +183,6 @@ class TestDateTime(unittest.TestCase):
         assert not self.fake.iso8601().endswith("+00:00")
         assert self.fake.iso8601(utc).endswith("+00:00")
         assert self.fake.iso8601()[10] == "T"
-        assert len(self.fake.iso8601()) == 19
         assert len(self.fake.iso8601(timespec="hours")) == 13
         assert len(self.fake.iso8601(timespec="minutes")) == 16
         assert len(self.fake.iso8601(timespec="seconds")) == 19
@@ -193,6 +192,14 @@ class TestDateTime(unittest.TestCase):
         assert self.fake.iso8601(tzinfo=utc, sep="t")[10] == "t"
         assert self.fake.iso8601(tzinfo=utc, sep=" ")[10] == " "
         assert self.fake.iso8601(tzinfo=utc, sep="_")[10] == "_"
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="windows does not support sub second precision")
+    def test_iso8601_fractional_seconds_win(self):
+        assert len(self.fake.iso8601()) == 19
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="non windows does support sub second precision")
+    def test_iso8601_fractional_seconds_non_win(self):
+        assert len(self.fake.iso8601()) == 26
 
     def test_date_object(self):
         assert isinstance(self.fake.date_object(), date)
@@ -493,7 +500,7 @@ class TestDateTime(unittest.TestCase):
 
             constrained_unix_time = self.fake.unix_time(end_datetime=end_datetime, start_datetime=start_datetime)
 
-            self.assertIsInstance(constrained_unix_time, int)
+            self.assertIsInstance(constrained_unix_time, (int, float))
             self.assertBetween(
                 constrained_unix_time,
                 datetime_to_timestamp(start_datetime),
@@ -505,7 +512,7 @@ class TestDateTime(unittest.TestCase):
 
             recent_unix_time = self.fake.unix_time(start_datetime=one_day_ago)
 
-            self.assertIsInstance(recent_unix_time, int)
+            self.assertIsInstance(recent_unix_time, (int, float))
             self.assertBetween(
                 recent_unix_time,
                 datetime_to_timestamp(one_day_ago),
@@ -517,7 +524,7 @@ class TestDateTime(unittest.TestCase):
 
             distant_unix_time = self.fake.unix_time(end_datetime=one_day_after_epoch_start)
 
-            self.assertIsInstance(distant_unix_time, int)
+            self.assertIsInstance(distant_unix_time, (int, float))
             self.assertBetween(
                 distant_unix_time,
                 datetime_to_timestamp(epoch_start),
@@ -527,7 +534,7 @@ class TestDateTime(unittest.TestCase):
             # Ensure wide-open unix_times are generated correctly
             self.fake.unix_time()
 
-            self.assertIsInstance(constrained_unix_time, int)
+            self.assertIsInstance(constrained_unix_time, (int, float))
             self.assertBetween(constrained_unix_time, 0, datetime_to_timestamp(now))
 
             # Ensure it does not throw error with startdate='now' for machines with negative offset
@@ -537,6 +544,16 @@ class TestDateTime(unittest.TestCase):
             self.fake.unix_time(start_datetime="now")
             if platform.system() != "Windows":
                 del os.environ["TZ"]
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="windows does not support sub second precision")
+    def test_unix_time_win(self):
+        unix_time = self.fake.unix_time()
+        assert isinstance(unix_time, int)
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="non windows does support sub second precision")
+    def test_unix_time_non_win(self):
+        unix_time = self.fake.unix_time()
+        assert isinstance(unix_time, float)
 
     def test_change_year(self):
         _2020_06_01 = datetime.strptime("2020-06-01", "%Y-%m-%d")


### PR DESCRIPTION
### What does this change

This inspects the platform and defines a platform specific property for generating random seconds.
For windows this uses `random.randint` as used before and for everything else `random.uniform`, which returns floats instead of ints.

Then later on when trying to generate a random number of seconds this proper is then used to get the function that can return values with the correct behaviour.

I tried setting the function directly on `self` in an `__init__`, but that worked poorly when seeding the faker after creation, as seeding recreates the internal random instance, so it requires some lazy evaluation to be able to point to the correct random instance in all cases.

Internally the points in time is still just ints. Changing those to floats is not strictly important, and would just add noise to diff - making it harder to review.

### What was wrong

Using `random.randint` everywhere when generating seconds can only ever give seconds precision.

### How this fixes it

Fixes #1945 by allowing sub-second on platforms expected to support it.
