### PR TITLE
Fix pydecimal crash on float min_value or max_value

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -258,21 +258,21 @@ class Provider(BaseProvider):
 
     def pydecimal(
         self,
-        left_digits=None,
-        right_digits=None,
-        positive=False,
-        min_value=None,
-        max_value=None,
-    ):
+        left_digits: Optional[int] = None,
+        right_digits: Optional[int] = None,
+        positive: bool = False,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+    ) -> Decimal:
         if left_digits is not None and left_digits < 0:
             raise ValueError("A decimal number cannot have less than 0 digits in its " "integer part")
         if right_digits is not None and right_digits < 0:
             raise ValueError("A decimal number cannot have less than 0 digits in its " "fractional part")
         if (left_digits is not None and left_digits == 0) and (right_digits is not None and right_digits == 0):
             raise ValueError("A decimal number cannot have 0 digits in total")
-        if None not in (min_value, max_value) and min_value > max_value:
+        if min_value is not None and max_value is not None and min_value > max_value:
             raise ValueError("Min value cannot be greater than max value")
-        if None not in (min_value, max_value) and min_value == max_value:
+        if min_value is not None and max_value is not None and min_value == max_value:
             raise ValueError("Min and max value cannot be the same")
         if positive and min_value is not None and min_value <= 0:
             raise ValueError("Cannot combine positive=True with negative or zero min_value")
@@ -299,7 +299,7 @@ class Provider(BaseProvider):
 
         if sign == "+":
             if max_value is not None:
-                left_number = str(self.random_int(max(min_value or 0, 0), max_value))
+                left_number = str(self.random_int(int(max(min_value or 0, 0)), int(max_value)))
             else:
                 min_left_digits = math.ceil(math.log10(max(min_value or 1, 1)))
                 if left_digits is None:
@@ -307,7 +307,7 @@ class Provider(BaseProvider):
                 left_number = "".join([str(self.random_digit()) for i in range(0, left_digits)]) or "0"
         else:
             if min_value is not None:
-                left_number = str(self.random_int(max(max_value or 0, 0), abs(min_value)))
+                left_number = str(self.random_int(int(max(max_value or 0, 0)), int(abs(min_value))))
             else:
                 min_left_digits = math.ceil(math.log10(abs(min(max_value or 1, 1))))
                 if left_digits is None:

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -84,6 +84,36 @@ def test_pyfloat_right_or_left_digit_overflow():
             assert str(abs(result)) == "1.12345678901234"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Only relevant for Python 3.10 and later.")
+@pytest.mark.parametrize(
+    ("min_value", "max_value"),
+    [
+        (1.5, None),
+        (-1.5, None),
+        (None, -1.5),
+        (None, 1.5),
+        (-1.5, 1.5),
+    ],
+)
+@pytest.mark.parametrize(("left_digits"), [None, 5])
+@pytest.mark.parametrize(("right_digits"), [None, 5])
+@pytest.mark.filterwarnings(
+    # Convert the warning to an error for this test
+    r"error:non-integer arguments to randrange\(\):DeprecationWarning"
+)
+def test_float_min_and_max_value_does_not_crash(
+    left_digits: Optional[int],
+    right_digits: Optional[int],
+    min_value: Optional[float],
+    max_value: Optional[float],
+):
+    """
+    Float arguments to randrange are deprecated from Python 3.10. This is a regression
+    test to check that `pydecimal` does not cause a crash on any code path.
+    """
+    Faker().pydecimal(left_digits, right_digits, min_value=min_value, max_value=max_value)
+
+
 class TestPyint(unittest.TestCase):
     def setUp(self):
         self.fake = Faker()


### PR DESCRIPTION
### What does this change

This fixes crashes of `Faker().pydecimal` when used with `float` `min_value` and/or `max_value` on python >= 3.10.

```py
>>> From faker import Faker

>>> Faker().pydecimal(min_value=0.2, max_value=1.5)

ValueError: non-integer arg 1 for randrange()
```

### What was wrong

An internal change of `random.randrange` introduced in Python 3.10 prohibits float values (see #1824) 

### How this fixes it

Casting values to `int` before passing them to `random_int` ensures that `random.randrange` gets integers.
