### PR TITLE
Ensure unix_time provider returns an integer

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1830,7 +1830,7 @@ class Provider(BaseProvider):
         """
         start_datetime = self._parse_start_datetime(start_datetime)
         end_datetime = self._parse_end_datetime(end_datetime)
-        return self._rand_seconds(start_datetime, end_datetime)
+        return int(self._rand_seconds(start_datetime, end_datetime))
 
     def time_delta(self, end_datetime: Optional[DateParseType] = None) -> timedelta:
         """


### PR DESCRIPTION
Based on the common understanding that a UNIX timestamp is the number of seconds since **00:00:00 UTC on 1 January 1970**, and also the typing information provided in the function signature, this change forces the returned timestamp to integer precision.

### What does this change

This casts the result of **unix_time** into an **integer**.

### What was wrong

unix_time provider was returning **float** values, which is in conflict with the specified return type of **int**. For reference, [here is the Wikipedia page for UNIX time](https://en.wikipedia.org/wiki/Unix_time).

### How this fixes it

This casts the result of **unix_time** into an **integer**.
