### PR TITLE
feat: Enable generation of windows file paths

### DIFF
--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -259,26 +259,35 @@ class Provider(BaseProvider):
         category: Optional[str] = None,
         extension: Optional[str] = None,
         absolute: Optional[bool] = True,
+        windows: Optional[bool] = False,
     ) -> str:
         """Generate an pathname to a file.
 
         This method uses |file_name| under the hood to generate the file name
         itself, and ``depth`` controls the depth of the directory path, and
         |word| is used under the hood to generate the different directory names.
+        When |windows| is set, the generate path will be a windows one.
 
         If ``absolute`` is ``True`` (default), the generated path starts with
-        ``/`` and is absolute. Otherwise, the generated path is relative.
+        ``/`` by default and ``C:\\`` for windows.
+        Otherwise, the generated path is relative.
 
         :sample: size=10
         :sample: depth=3
         :sample: depth=5, category='video'
         :sample: depth=5, category='video', extension='abcdef'
         """
-        file: str = self.file_name(category, extension)
-        path: str = f"/{file}"
+        path: str = self.file_name(category, extension)
+        separator: str = "/"
+        absolute_prefix: str = separator
+        if windows:
+            separator = "\\"
+            absolute_prefix = "C:\\"
+
         for _ in range(0, depth):
-            path = f"/{self.generator.word()}{path}"
-        return path if absolute else path[1:]
+            path = f"{self.generator.word()}{separator}{path}"
+
+        return f"{absolute_prefix}{path}" if absolute else path
 
     def unix_device(self, prefix: Optional[str] = None) -> str:
         """Generate a Unix device file name.

--- a/tests/providers/test_file.py
+++ b/tests/providers/test_file.py
@@ -23,6 +23,17 @@ class TestFile(unittest.TestCase):
             assert re.search(r"\/\w+\/\w+\.pdf", file_path)
             file_path = self.fake.file_path(category="image")
             assert re.search(r"\/\w+\/\w+\.(bmp|gif|jpeg|jpg|png|tiff)", file_path)
+            # Windows filepaths
+            file_path = self.fake.file_path(windows=True)
+            assert re.search(r"C:\\\w+\\\w+\.\w+", file_path)
+            file_path = self.fake.file_path(windows=True, absolute=False)
+            assert re.search(r"\w+\\\w+\.\w+", file_path)
+            file_path = self.fake.file_path(windows=True, depth=3)
+            assert re.search(r"C:\\\w+\\\w+\\\w+\\\w+\.\w+", file_path)
+            file_path = self.fake.file_path(windows=True, extension="pdf")
+            assert re.search(r"C:\\\w+\\\w+\.pdf", file_path)
+            file_path = self.fake.file_path(windows=True, category="image")
+            assert re.search(r"C:\\\w+\\\w+\.(bmp|gif|jpeg|jpg|png|tiff)", file_path)
 
     def test_unix_device(self):
         reg_device = re.compile(r"^/dev/(vd|sd|xvd)[a-z]$")


### PR DESCRIPTION
### What does this change

`fake.file_path()` now has a `window: Optional[bool]` that allows generating windows file paths.

### What was wrong

It was not possible to fake windows paths.

### How this fixes it

Windows paths (both relative and absolute) can be faked.

Fixes #1961
