### PR TITLE
Add Vietnamese Names and Surnames

### DIFF
--- a/faker/providers/person/vn_VN/__init__.py
+++ b/faker/providers/person/vn_VN/__init__.py
@@ -1,0 +1,23 @@
+from .. import Provider as PersonProvider
+
+
+class Provider(PersonProvider):
+    formats_male = ("{{first_name_male}} {{last_name}}",)
+    formats_female = ("{{first_name_female}} {{last_name}}",)
+    formats = formats_male + formats_female
+
+    first_names_male = (
+        "An", "Binh", "Chinh", "Duc", "Hai", "Hoang", "Khanh", "Lam", "Minh", "Nam",
+        "Nhan", "Phat", "Quan", "Son", "Tuan", "Van", "Viet", "Xuan", "Huu", "Trung",
+    )
+
+    first_names_female = (
+        "Anh", "Bao", "Cam", "Diep", "Hoa", "Lan", "Mai", "Nga", "Phuong", "Quynh",
+        "Thu", "Huong", "Linh", "Thao", "Ngoc", "Yen", "Trang", "Kieu", "My", "Hien",
+    )
+
+    last_names = (
+        "Nguyen", "Tran", "Le", "Pham", "Hoang", "Vu", "Do", "Truong", "Ngoc", "Bui",
+        "Dang", "Huynh", "Ngo", "Vo", "Luong", "Duong", "Ly", "Ha", "Nguyen", "Ho",
+    )
+

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -32,6 +32,7 @@ from faker.providers.person.ru_RU import translit
 from faker.providers.person.sv_SE import Provider as SvSEProvider
 from faker.providers.person.ta_IN import Provider as TaINProvider
 from faker.providers.person.th_TH import Provider as ThThProvider
+from faker.providers.person.vn_VN import Provider as VnProvider
 from faker.providers.person.zh_CN import Provider as ZhCNProvider
 from faker.providers.person.zh_TW import Provider as ZhTWProvider
 from faker.providers.person.zu_ZA import Provider as ZuZAProvider
@@ -1329,6 +1330,43 @@ class TestZuZa(unittest.TestCase):
             self.assertIn(last_name, ZuZAProvider.last_names)
         else:
             raise AssertionError("Invalid number of name parts. Expected 2 or 3.")
+
+
+class TestVnPersonProvider(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker()
+        self.fake.add_provider(VnProvider)
+
+    def test_generate_male_name(self):
+        name = self.fake.format("{{first_name_male}} {{last_name}}")
+        first_name = name.split()[0]
+        last_name = name.split()[1]
+
+        self.assertIn(first_name, VnProvider.first_names_male)
+        self.assertIn(last_name, VnProvider.last_names)
+
+    def test_generate_female_name(self):
+        name = self.fake.format("{{first_name_female}} {{last_name}}")
+        first_name = name.split()[0]
+        last_name = name.split()[1]
+
+        self.assertIn(first_name, VnProvider.first_names_female)
+        self.assertIn(last_name, VnProvider.last_names)
+
+    def test_generate_any_name(self):
+        name = self.fake.format("{{first_name}} {{last_name}}")
+        first_name = name.split()[0]
+        last_name = name.split()[1]
+
+        self.assertTrue(
+            (first_name in VnProvider.first_names_male) or
+            (first_name in VnProvider.first_names_female)
+        )
+        self.assertIn(last_name, VnProvider.last_names)
+
+    def test_generate_invalid_format(self):
+        with self.assertRaises(ValueError):
+            self.fake.format("Invalid {{format}}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Daniele Faraglia,

I trust this message finds you well. I've made a contribution to enhance the Faker Python library by adding a collection of Vietnamese names and surnames. This will provide users with more diverse and realistic data for testing purposes.

**Details:**

- Update the file: `faker/providers/person/vn_VN/__init__.py`
- Includes formats for male and female names, along with a list of first names and last names.

**Example Usage:**


```
from faker import Faker

fake = Faker('vn_VN')

print(fake.name())
```
