### PR TITLE
Area code, add 830000 and parameterized

### DIFF
--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -9,6 +9,7 @@ from .. import Provider as SsnProvider
 class Provider(SsnProvider):
     # Extracted from
     # http://www.stats.gov.cn/tjsj/tjbz/xzqhdm/201504/t20150415_712722.html
+    # 《港澳台居民居住证申领发放办法》https://www.gov.cn/zhengce/content/2018-08/19/content_5314865.htm
     area_codes: List[str] = [
         "110000",
         "110100",
@@ -3522,9 +3523,11 @@ class Provider(SsnProvider):
         "710000",
         "810000",
         "820000",
+        "830000",
     ]
 
-    def ssn(self, min_age: int = 18, max_age: int = 90, gender: Optional[SexLiteral] = None) -> str:
+    def ssn(self, min_age: int = 18, max_age: int = 90, gender: Optional[SexLiteral] = None,
+            area_code: str = None) -> str:
         """
         Return 18 character chinese personal identity code
 
@@ -3538,7 +3541,9 @@ class Provider(SsnProvider):
         birthday = datetime.date.today() - age
         birthday_str = birthday.strftime("%Y%m%d")
 
-        area_code: str = self.random_element(self.area_codes)
+        if (area_code is None) or (area_code not in self.area_codes):
+            area_code: str = self.random_element(self.area_codes)
+
         ssn_without_checksum = self.numerify(area_code + birthday_str + "##")
 
         _number = ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")

--- a/faker/providers/ssn/zh_CN/__init__.py
+++ b/faker/providers/ssn/zh_CN/__init__.py
@@ -3526,12 +3526,14 @@ class Provider(SsnProvider):
         "830000",
     ]
 
-    def ssn(self, min_age: int = 18, max_age: int = 90, gender: Optional[SexLiteral] = None,
-            area_code: str = None) -> str:
+    def ssn(
+        self, min_age: int = 18, max_age: int = 90, gender: Optional[SexLiteral] = None, area_code: str = ""
+    ) -> str:
         """
         Return 18 character chinese personal identity code
 
         :param gender: F for female  M for male  None for default
+        :param area_code: None for default
         """
 
         def checksum(s):
@@ -3541,8 +3543,8 @@ class Provider(SsnProvider):
         birthday = datetime.date.today() - age
         birthday_str = birthday.strftime("%Y%m%d")
 
-        if (area_code is None) or (area_code not in self.area_codes):
-            area_code: str = self.random_element(self.area_codes)
+        if area_code not in self.area_codes:
+            area_code = self.random_element(self.area_codes)
 
         ssn_without_checksum = self.numerify(area_code + birthday_str + "##")
 

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -584,16 +584,16 @@ class TestEsCO(unittest.TestCase):
         # NITs and check digits of some Colombian state entities.
         # Source: <https://www.funcionpublica.gov.co/web/sigep/entidades>
         for nit, check_digit in (
-                ("830040256", "0"),
-                ("899999003", "1"),
-                ("892301483", "2"),
-                ("800194600", "3"),
-                ("899999403", "4"),
-                ("860042945", "5"),
-                ("830114475", "6"),
-                ("811000231", "7"),
-                ("899999027", "8"),
-                ("900639630", "9"),
+            ("830040256", "0"),
+            ("899999003", "1"),
+            ("892301483", "2"),
+            ("800194600", "3"),
+            ("899999403", "4"),
+            ("860042945", "5"),
+            ("830114475", "6"),
+            ("811000231", "7"),
+            ("899999027", "8"),
+            ("900639630", "9"),
         ):
             with self.subTest(nit=nit, check_digit=check_digit):
                 assert nit_check_digit(nit) == check_digit
@@ -855,9 +855,9 @@ class TestFrCH:
         Faker.seed(0)
 
         with mock.patch(
-                "faker.providers.ssn.fr_CH.Provider.numerify",
-                return_value=digits,
-                autospec=True,
+            "faker.providers.ssn.fr_CH.Provider.numerify",
+            return_value=digits,
+            autospec=True,
         ):
             result = fake.vat_id()
             assert result == expected
@@ -1230,23 +1230,31 @@ class TestZhCN(unittest.TestCase):
         assert int(ssn[16]) % 2 == 1
 
     def test_zh_CN_ssn_invalid_area_code_passed(self):
-        with pytest.raises(ValueError):
-            self.fake.ssn(area_code=1)
-        with pytest.raises(ValueError):
-            self.fake.ssn(area_code={})
-        with pytest.raises(ValueError):
-            self.fake.ssn(area_code=[])
+        ssn = self.fake.ssn(area_code=12)
+        assert int(ssn[0:6]) > 0
+
+        ssn = self.fake.ssn(area_code={})
+        assert int(ssn[0:6]) > 0
+
+        ssn = self.fake.ssn(area_code=[])
+        assert int(ssn[0:6]) > 0
+
+        ssn = self.fake.ssn(area_code=None)
+        assert int(ssn[0:6]) > 0
+
+        ssn = self.fake.ssn()
+        assert int(ssn[0:6]) > 0
 
     def test_zh_CN_ssn_area_code_passed(self):
         #
         ssn = self.fake.ssn(area_code="654225")
-        assert int(ssn[0:6]) == "654225"
+        assert int(ssn[0:6]) == 654225
 
         ssn = self.fake.ssn(area_code="820000")
-        assert int(ssn[0:6]) == "820000"
+        assert int(ssn[0:6]) == 820000
 
         ssn = self.fake.ssn(area_code="830000")
-        assert int(ssn[0:6]) == "830000"
+        assert int(ssn[0:6]) == 830000
 
 
 class TestRoRO(unittest.TestCase):

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -584,16 +584,16 @@ class TestEsCO(unittest.TestCase):
         # NITs and check digits of some Colombian state entities.
         # Source: <https://www.funcionpublica.gov.co/web/sigep/entidades>
         for nit, check_digit in (
-            ("830040256", "0"),
-            ("899999003", "1"),
-            ("892301483", "2"),
-            ("800194600", "3"),
-            ("899999403", "4"),
-            ("860042945", "5"),
-            ("830114475", "6"),
-            ("811000231", "7"),
-            ("899999027", "8"),
-            ("900639630", "9"),
+                ("830040256", "0"),
+                ("899999003", "1"),
+                ("892301483", "2"),
+                ("800194600", "3"),
+                ("899999403", "4"),
+                ("860042945", "5"),
+                ("830114475", "6"),
+                ("811000231", "7"),
+                ("899999027", "8"),
+                ("900639630", "9"),
         ):
             with self.subTest(nit=nit, check_digit=check_digit):
                 assert nit_check_digit(nit) == check_digit
@@ -855,9 +855,9 @@ class TestFrCH:
         Faker.seed(0)
 
         with mock.patch(
-            "faker.providers.ssn.fr_CH.Provider.numerify",
-            return_value=digits,
-            autospec=True,
+                "faker.providers.ssn.fr_CH.Provider.numerify",
+                return_value=digits,
+                autospec=True,
         ):
             result = fake.vat_id()
             assert result == expected
@@ -1228,6 +1228,25 @@ class TestZhCN(unittest.TestCase):
         # Males have odd number at index 17
         ssn = self.fake.ssn(gender="M")
         assert int(ssn[16]) % 2 == 1
+
+    def test_zh_CN_ssn_invalid_area_code_passed(self):
+        with pytest.raises(ValueError):
+            self.fake.ssn(area_code=1)
+        with pytest.raises(ValueError):
+            self.fake.ssn(area_code={})
+        with pytest.raises(ValueError):
+            self.fake.ssn(area_code=[])
+
+    def test_zh_CN_ssn_area_code_passed(self):
+        #
+        ssn = self.fake.ssn(area_code="654225")
+        assert int(ssn[0:6]) == "654225"
+
+        ssn = self.fake.ssn(area_code="820000")
+        assert int(ssn[0:6]) == "820000"
+
+        ssn = self.fake.ssn(area_code="830000")
+        assert int(ssn[0:6]) == "830000"
 
 
 class TestRoRO(unittest.TestCase):


### PR DESCRIPTION

### What does this change

In the `zh_CN` provider for SSN , the area code is enhanced by adding `830000` and making it parameterized.

### What was wrong

The area code `830000` has been officially released by www.gov.cn. During actual testing, it is necessary to generate SSN in the specified region.

### How this fixes it

Firstly, `830000` is added to the `area_codes` list.
Then, in the `ssn()` method, a new parameter `area_code` is added, with the default value being `None`. 
If the passed `area_code` value exists in the `area_codes` list, it will be used to generate an SSN that meets the requirements. Otherwise, one of the codes from `area_codes` will be randomly selected to generate the SSN.