### PR TITLE
feature: HTTP status codes

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -131,6 +131,71 @@ class Provider(BaseProvider):
         "TRACE",
         "PATCH",
     )
+    http_assigned_codes: ElementsType[int] = (
+        100,
+        101,
+        100,
+        101,
+        102,
+        103,
+        200,
+        201,
+        202,
+        203,
+        204,
+        205,
+        206,
+        207,
+        208,
+        226,
+        300,
+        301,
+        302,
+        303,
+        304,
+        305,
+        307,
+        308,
+        400,
+        401,
+        402,
+        403,
+        404,
+        405,
+        406,
+        407,
+        408,
+        409,
+        410,
+        411,
+        412,
+        413,
+        414,
+        415,
+        416,
+        417,
+        421,
+        422,
+        423,
+        424,
+        425,
+        426,
+        428,
+        429,
+        431,
+        451,
+        500,
+        501,
+        502,
+        503,
+        504,
+        505,
+        506,
+        507,
+        508,
+        510,
+        511,
+    )
 
     user_name_formats: ElementsType[str] = (
         "{{last_name}}.{{first_name}}",
@@ -307,6 +372,23 @@ class Provider(BaseProvider):
         """
 
         return self.random_element(self.http_methods)
+
+    def http_status_code(self, include_unassigned=True) -> int:
+        """Returns random HTTP status code
+        https://www.rfc-editor.org/rfc/rfc9110#name-status-codes
+        :param include_unassigned: Whether to include status codes which have
+            not yet been assigned or are unused
+
+        :return: a random three digit status code
+        :rtype: int
+
+        :example: 404
+
+        """
+        if include_unassigned:
+            return self.random_int(min=100, max=599)
+        else:
+            return self.random_element(self.http_assigned_codes)
 
     def url(self, schemes: Optional[List[str]] = None) -> str:
         """

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -345,6 +345,9 @@ class TestInternetProvider:
         status_code = provider.http_status_code()
         assert isinstance(status_code, int)
         assert 100 <= status_code <= 599
+        status_code = provider.http_status_code(include_unassigned=False)
+        assert isinstance(status_code, int)
+        assert 100 <= status_code <= 599
 
     def test_dga(self, faker):
         assert faker.dga() != faker.dga()

--- a/tests/providers/test_internet.py
+++ b/tests/providers/test_internet.py
@@ -10,6 +10,7 @@ import pytest
 from validators import domain as validate_domain
 from validators import email as validate_email
 
+from faker import Generator
 from faker.providers.internet import Provider as InternetProvider
 from faker.providers.internet.az_AZ import Provider as AzAzInternetProvider
 from faker.providers.internet.en_GB import Provider as EnGbInternetProvider
@@ -338,6 +339,12 @@ class TestInternetProvider:
             got_methods.add(faker.http_method())
 
         assert expected_methods == sorted(got_methods)
+
+    def test_http_status_code(self, faker, num_samples):
+        provider = InternetProvider(faker)
+        status_code = provider.http_status_code()
+        assert isinstance(status_code, int)
+        assert 100 <= status_code <= 599
 
     def test_dga(self, faker):
         assert faker.dga() != faker.dga()


### PR DESCRIPTION
### What does this change

Adds HTTP status codes - closes #1977 

### What was wrong

All Http status codes must be in the range 100 to 599, with a subset of these values being currently assigned by RFCs

### How this fixes it

Selects by default a random value in the full valid range or optionally a random selection from only the assigned values

Fixes #1977 
