### PR TITLE
fix: update `pydecimal` algorithm to ensure left part is not generated with a leading 0

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -262,6 +262,21 @@ class Provider(BaseProvider):
     def pyint(self, min_value: int = 0, max_value: int = 9999, step: int = 1) -> int:
         return self.generator.random_int(min_value, max_value, step=step)
 
+    def _random_int_of_length(self, length: int) -> int:
+        """Generate a random integer of a given length
+
+        If length is 0, so is the number. Otherwise the first digit must not be 0.
+        """
+
+        if length < 0:
+            raise ValueError("Length must be a non-negative integer.")
+        elif length == 0:
+            return 0
+        else:
+            min_value = 10 ** (length - 1)
+            max_value = (10**length) - 1
+            return self.pyint(min_value=min_value, max_value=max_value)
+
     def pydecimal(
         self,
         left_digits: Optional[int] = None,
@@ -310,7 +325,7 @@ class Provider(BaseProvider):
                 min_left_digits = math.ceil(math.log10(max(min_value or 1, 1)))
                 if left_digits is None:
                     left_digits = self.random_int(min_left_digits, max_left_random_digits)
-                left_number = "".join([str(self.random_digit()) for i in range(0, left_digits)]) or "0"
+                left_number = str(self._random_int_of_length(left_digits))
         else:
             if min_value is not None:
                 left_number = str(self.random_int(int(max(max_value or 0, 0)), int(abs(min_value))))
@@ -318,7 +333,7 @@ class Provider(BaseProvider):
                 min_left_digits = math.ceil(math.log10(abs(min(max_value or 1, 1))))
                 if left_digits is None:
                     left_digits = self.random_int(min_left_digits, max_left_random_digits)
-                left_number = "".join([str(self.random_digit()) for i in range(0, left_digits)]) or "0"
+                left_number = str(self._random_int_of_length(left_digits))
 
         if right_digits is None:
             right_digits = self.random_int(0, max_random_digits)

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -325,30 +325,6 @@ class TestPydecimal(unittest.TestCase):
         left_digits = int(result)
         self.assertEqual(expected_left_digits, left_digits)
 
-    def test_positive_integer_part_matches_length(self) -> None:
-        """The integer part of a positive decimal number must match the expected length"""
-
-        expected_left_digits = 8
-
-        Faker.seed(2)
-
-        result = self.fake.pydecimal(left_digits=expected_left_digits, positive=True)
-
-        left_number = abs(int(result))
-        self.assertEqual(len(str(left_number)), expected_left_digits)
-
-    def test_negative_integer_part_matches_length(self) -> None:
-        """The integer part of a negative decimal number must match the expected length"""
-
-        expected_left_digits = 8
-
-        Faker.seed(2)
-
-        result = self.fake.pydecimal(left_digits=expected_left_digits, max_value=0)
-
-        left_number = abs(int(result))
-        self.assertEqual(len(str(left_number)), expected_left_digits)
-
     def test_right_digits(self):
         expected_right_digits = 10
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -325,6 +325,30 @@ class TestPydecimal(unittest.TestCase):
         left_digits = int(result)
         self.assertEqual(expected_left_digits, left_digits)
 
+    def test_positive_integer_part_matches_length(self) -> None:
+        """The integer part of a positive decimal number must match the expected length"""
+
+        expected_left_digits = 8
+
+        Faker.seed(2)
+
+        result = self.fake.pydecimal(left_digits=expected_left_digits, positive=True)
+
+        left_number = abs(int(result))
+        self.assertEqual(len(str(left_number)), expected_left_digits)
+
+    def test_negative_integer_part_matches_length(self) -> None:
+        """The integer part of a negative decimal number must match the expected length"""
+
+        expected_left_digits = 8
+
+        Faker.seed(2)
+
+        result = self.fake.pydecimal(left_digits=expected_left_digits, max_value=0)
+
+        left_number = abs(int(result))
+        self.assertEqual(len(str(left_number)), expected_left_digits)
+
     def test_right_digits(self):
         expected_right_digits = 10
 


### PR DESCRIPTION
### What does this change

This changes the algorithm of `pydecimal` to ensure the integer part if of the specified length.

### What was wrong

As suggested in https://github.com/joke2k/faker/issues/1992, it is possible for `pydecimal` to generate a value with an integer part that's shorter than the specified length.

### How this fixes it

The original algorithm generated a list of digits and joined it into an integer. However, with that approach it is possible that one or more leading digits are 0, thus ending up with a shorter value.

For example,

```python
from faker import Faker
fake = Faker()
fake.seed_instance(15)
fake.pydecimal(left_digits=8, right_digits=3)
```

Generates `08023002` for left number, thus resulting in `Decimal("8023002.531")`. Since `8023002` is only 7 digits, it does not satisfy the requirement that the resulting value has 8 left digits.

Fixes #1992
