### PR TITLE
Fix for #1993: Locale et_EE (Estoniana) with seed_instance returns random values instead of fixed upon restart

### DIFF
--- a/faker/providers/person/et_EE/__init__.py
+++ b/faker/providers/person/et_EE/__init__.py
@@ -33,7 +33,7 @@ class Provider(PersonProvider):
     prefixes_neutral = ("doktor", "dr", "prof")
     prefixes_male = ("härra", "hr") + prefixes_neutral
     prefixes_female = ("proua", "pr") + prefixes_neutral
-    prefixes = list(set(prefixes_male + prefixes_female))
+    prefixes = sorted(set(prefixes_male + prefixes_female))
 
     suffixes = ("PhD", "MSc", "BSc")
 
@@ -162,9 +162,9 @@ class Provider(PersonProvider):
 
     first_names_rus = first_names_male_rus + first_names_female_rus
 
-    first_names_male = list(set(first_names_male_est + first_names_male_rus))
-    first_names_female = list(set(first_names_female_est + first_names_female_rus))
-    first_names = list(set(first_names_male) | set(first_names_female))
+    first_names_male = sorted(set(first_names_male_est + first_names_male_rus))
+    first_names_female = sorted(set(first_names_female_est + first_names_female_rus))
+    first_names = sorted(set(first_names_male + first_names_female))
 
     # http://ekspress.delfi.ee/kuum/\
     # top-500-eesti-koige-levinumad-perekonnanimed?id=27677149
@@ -681,7 +681,7 @@ class Provider(PersonProvider):
         "Žukov",
         "Žuravljov",
     )
-    last_names = list(set(last_names_est + last_names_rus))
+    last_names = sorted(set(last_names_est + last_names_rus))
 
     def first_name_male_est(self) -> str:
         return self.random_element(self.first_names_male_est)

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -15,6 +15,7 @@ from faker.providers.person.en_IN import Provider as EnINProvider
 from faker.providers.person.en_US import Provider as EnUSProvider
 from faker.providers.person.es import Provider as EsProvider
 from faker.providers.person.es_CO import Provider as EsCOProvider
+from faker.providers.person.et_EE import Provider as EtEEProvider
 from faker.providers.person.fi_FI import Provider as FiProvider
 from faker.providers.person.fr_BE import Provider as FrBEProvider
 from faker.providers.person.ga_IE import Provider as GaIEProvider
@@ -417,6 +418,101 @@ class TestFrBE(unittest.TestCase):
         assert name
         self.assertIsInstance(name, str)
         assert name in self.provider.last_names
+
+
+class TestEtEE(unittest.TestCase):
+    def setUp(self):
+        self.fake = Faker("et_EE")
+        self.provider = EtEEProvider
+        Faker.seed(0)
+
+    def test_first_name(self):
+        # General first name
+        name = self.fake.first_name()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+
+        # Est first name
+        name = self.fake.first_name_est()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_est
+
+        # Rus first name
+        name = self.fake.first_name_rus()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_rus
+
+        # Females first name
+        name = self.fake.first_name_female()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_female
+
+        # Est females first name
+        name = self.fake.first_name_female_est()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_female
+        assert name in self.provider.first_names_female_est
+
+        # Rus females first name
+        name = self.fake.first_name_female_rus()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_female
+        assert name in self.provider.first_names_female_rus
+
+        # Male first name
+        name = self.fake.first_name_male()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_male
+
+        # Est male first name
+        name = self.fake.first_name_male_est()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_male
+        assert name in self.provider.first_names_male_est
+
+        # Rus male first name
+        name = self.fake.first_name_male_rus()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.first_names
+        assert name in self.provider.first_names_male
+        assert name in self.provider.first_names_male_rus
+
+    def test_last_name(self):
+        # General last name.
+        name = self.fake.last_name()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.last_names
+
+        # Est last name.
+        name = self.fake.last_name_est()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.last_names
+        assert name in self.provider.last_names_est
+
+        # Rus last name.
+        name = self.fake.last_name_rus()
+        assert name
+        self.assertIsInstance(name, str)
+        assert name in self.provider.last_names
+        assert name in self.provider.last_names_rus
 
 
 class TestFiFI(unittest.TestCase):


### PR DESCRIPTION
### What does this change

Fix makes Faker return data repeatedly the same when seed is set to the same value on several runs.
Lists for first_name_female, first_name_male, first_name, prefix, last_name for et_EE locale are made from tuples by converting them to sets, uniting them and converting them to list.
Conversion to sets are required because some initial tuples contains common elements (like "Anna" are in both first_names_female_est and first_names_female_rus tuples).
But when sets union converted to list (like `first_names_female = list(set(first_names_female_est + first_names_female_rus))`) there's no guarantee of order elements in list (try to run several times `list({'a', 'b', 'c'})` resulting list will be different).
That's why with every new run, even seed was set to the same value, initial lists were different and that's why different values were produced.
To fix this issue changed `list` to `sorted` to guarantee that lists will have the same elements in the same order on every run.

On current master the code below returns different values when re-run script though seed set to 0. On fix branch it returns the same values:
```
from faker import Faker
fake = Faker("et_EE")
fake.seed_instance(0)
print(fake.first_name_female())
print(fake.first_name_male())
print(fake.first_name())
print(fake.prefix())
print(fake.last_name())
```

Also changed line `first_names = list(set(first_names_male) | set(first_names_female))` to `first_names = sorted(set(first_names_male + first_names_female))` to be consistent with other list creation.

### What was wrong

For locale et_EE, when seed_instance(0) was called, with each rerun, Faker returns different data for first_name_female, first_name_male, first_name, prefix, last_name (described in [#1993](https://github.com/joke2k/faker/issues/1993))

### How this fixes it

Fixes #1993 by preserving order in lists: prefixes, first_names_male, first_names_female, first_names, last_names.
Checked that it was the only locale where set to list conversion was used.
