### PR TITLE
Typo fix - prefix for male BG names

### DIFF
--- a/faker/providers/person/bg_BG/__init__.py
+++ b/faker/providers/person/bg_BG/__init__.py
@@ -1759,7 +1759,7 @@ class Provider(PersonProvider):
 
     formats_male = (
         "{{first_name_male}} {{last_name_male}}",
-        "{{prefix_female}} {{first_name_male}} {{last_name_male}}",
+        "{{prefix_male}} {{first_name_male}} {{last_name_male}}",
     )
 
     formats = formats_male + formats_female


### PR DESCRIPTION
The Bulgarian person provider used `prefix_female` instead of `prefix_male` within `formats_male`.
