### PR TITLE
fix for #1996: hu-Hu localization gives back non-capitalized city names

### DIFF
--- a/faker/providers/address/hu_HU/__init__.py
+++ b/faker/providers/address/hu_HU/__init__.py
@@ -467,3 +467,13 @@ class Provider(AddressProvider):
     def building_number(self) -> str:
         numeric_part = super().random_int(1, 250)
         return str(numeric_part) + "."
+
+    # method added to fix #1996:
+    # for hu_Hu locale city_part could be first or second component of city,
+    # so city_parts tuple should contain lower-cased strings. Thus city might be lower-cased and should be capitalized
+    def city(self) -> str:
+        """
+        :example: 'Györgyháza'
+        """
+        pattern: str = self.random_element(self.city_formats)
+        return self.generator.parse(pattern).capitalize()

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -2159,6 +2159,20 @@ class TestHuHu:
             match = re.fullmatch(r"\d{0,3}.", building_number)
             assert match
 
+    def test_city(self, faker, num_samples):
+        # generating possible variations for cities for hu_Hu locale
+        real_cities = [city.lower() for city in HuHuAddressProvider.real_city_names]
+        cities_part_suffix = [''.join([part, suffix]) for part in HuHuAddressProvider.city_parts
+                              for suffix in HuHuAddressProvider.city_suffixes]
+        cities_prefix_part_suffix = [''.join([pref, part_suffix]) for pref in HuHuAddressProvider.city_prefs
+                                     for part_suffix in cities_part_suffix]
+        cities = real_cities + cities_part_suffix + cities_prefix_part_suffix
+        for _ in range(num_samples):
+            city = faker.city()
+            assert isinstance(city, str)
+            assert city.lower() in cities
+            assert city[0].isupper()
+
 
 class TestIdId:
     """Test id_ID address provider methods"""


### PR DESCRIPTION
### What does this change

- Added city() method for hu-Hu locale to return city names capitalized.
- Added test for city() method for hu-Hu locale

### What was wrong

hu-Hu locale provides real city names and city names generated as combination of city part and suffix or preffix, city part and suffix. All components of non-real cities specified lower-cased, so such cities returned lower-cased.

### How this fixes it

Added city method to AddressProvider for hu-Hu locale that makes city names capitalized.

Fixes #1996 
