### PR TITLE
Typing-only Mixin Class for Type Checking

### DIFF
--- a/faker/providers/address/__init__.py
+++ b/faker/providers/address/__init__.py
@@ -12,13 +12,17 @@ class Provider(BaseProvider):
     address_formats: ElementsType[str] = ("{{street_address}} {{postcode}} {{city}}",)
     building_number_formats: ElementsType[str] = ("##",)
     postcode_formats: ElementsType[str] = ("#####",)
-    countries: ElementsType[str] = [country.name for country in date_time.Provider.countries]
+    countries: ElementsType[str] = [country.name for country in date_time.Provider.country_timezones]
 
     ALPHA_2 = "alpha-2"
     ALPHA_3 = "alpha-3"
 
-    alpha_2_country_codes: ElementsType[str] = [country.alpha_2_code for country in date_time.Provider.countries]
-    alpha_3_country_codes: ElementsType[str] = [country.alpha_3_code for country in date_time.Provider.countries]
+    alpha_2_country_codes: ElementsType[str] = [
+        country.alpha_2_code for country in date_time.Provider.country_timezones
+    ]
+    alpha_3_country_codes: ElementsType[str] = [
+        country.alpha_3_code for country in date_time.Provider.country_timezones
+    ]
 
     def city_suffix(self) -> str:
         """
@@ -92,7 +96,9 @@ class Provider(BaseProvider):
     def current_country(self) -> str:
         current_country_code = self.current_country_code()
         current_country = [
-            country.name for country in date_time.Provider.countries if country.alpha_2_code == current_country_code
+            country.name
+            for country in date_time.Provider.country_timezones
+            if country.alpha_2_code == current_country_code
         ]
         if len(current_country) == 1:
             return current_country[0]  # type: ignore

--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -29,7 +29,7 @@ class Provider(BaseProvider):
 
     ALPHA: Dict[str, str] = {c: str(ord(c) % 55) for c in string.ascii_uppercase}
     bban_format: str = "????#############"
-    country_code: str = "GB"
+    bank_country_code: str = "GB"
 
     def aba(self) -> str:
         """Generate an ABA routing transit number."""
@@ -46,7 +46,7 @@ class Provider(BaseProvider):
 
     def bank_country(self) -> str:
         """Generate the bank provider's ISO 3166-1 alpha-2 country code."""
-        return self.country_code
+        return self.bank_country_code
 
     def bban(self) -> str:
         """Generate a Basic Bank Account Number (BBAN)."""
@@ -57,12 +57,12 @@ class Provider(BaseProvider):
         """Generate an International Bank Account Number (IBAN)."""
         bban = self.bban()
 
-        check = bban + self.country_code + "00"
+        check = bban + self.bank_country_code + "00"
         check_ = int("".join(self.ALPHA.get(c, c) for c in check))
         check_ = 98 - (check_ % 97)
         check = str(check_).zfill(2)
 
-        return self.country_code + check + bban
+        return self.bank_country_code + check + bban
 
     def swift8(self, use_dataset: bool = False) -> str:
         """Generate an 8-digit SWIFT code.
@@ -143,7 +143,7 @@ class Provider(BaseProvider):
             location_code = self.lexify("??", letters=string.ascii_uppercase + string.digits)
 
         if length == 8:
-            return bank_code + self.country_code + location_code
+            return bank_code + self.bank_country_code + location_code
 
         if primary:
             branch_code = "XXX"
@@ -152,4 +152,4 @@ class Provider(BaseProvider):
         else:
             branch_code = self.lexify("???", letters=string.ascii_uppercase + string.digits)
 
-        return bank_code + self.country_code + location_code + branch_code
+        return bank_code + self.bank_country_code + location_code + branch_code

--- a/faker/providers/bank/az_AZ/__init__.py
+++ b/faker/providers/bank/az_AZ/__init__.py
@@ -5,7 +5,7 @@ class Provider(BankProvider):
     """Implement bank provider for ``az_AZ`` locale."""
 
     bban_format = "????####################"
-    country_code = "AZ"
+    bank_country_code = "AZ"
 
     banks = (
         "AccessBank",

--- a/faker/providers/bank/bn_BD/__init__.py
+++ b/faker/providers/bank/bn_BD/__init__.py
@@ -12,7 +12,7 @@ class Provider(BankProvider):
     """
 
     bban_format: str = "????#########"
-    country_code = "BD"
+    bank_country_code = "BD"
     swift_location_codes = ("DH",)
     swift_branch_codes = (
         "ABBL",

--- a/faker/providers/bank/cs_CZ/__init__.py
+++ b/faker/providers/bank/cs_CZ/__init__.py
@@ -8,4 +8,4 @@ class Provider(BankProvider):
     """
 
     bban_format = "####################"
-    country_code = "CZ"
+    bank_country_code = "CZ"

--- a/faker/providers/bank/da_DK/__init__.py
+++ b/faker/providers/bank/da_DK/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``da_DK`` locale."""
 
     bban_format = "################"
-    country_code = "DK"
+    bank_country_code = "DK"

--- a/faker/providers/bank/de_AT/__init__.py
+++ b/faker/providers/bank/de_AT/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``de_AT`` locale."""
 
     bban_format = "################"
-    country_code = "AT"
+    bank_country_code = "AT"

--- a/faker/providers/bank/de_CH/__init__.py
+++ b/faker/providers/bank/de_CH/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``de_CH`` locale."""
 
     bban_format = "#################"
-    country_code = "CH"
+    bank_country_code = "CH"

--- a/faker/providers/bank/de_DE/__init__.py
+++ b/faker/providers/bank/de_DE/__init__.py
@@ -10,7 +10,7 @@ class Provider(BankProvider):
     """
 
     bban_format = "##################"
-    country_code = "DE"
+    bank_country_code = "DE"
 
     first_place = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "23456789"
     second_place = "ABCDEFGHIJKLMNPQRSTUVWXYZ" + "0123456789"

--- a/faker/providers/bank/el_GR/__init__.py
+++ b/faker/providers/bank/el_GR/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``el_GR`` locale."""
 
     bban_format = "#######################"
-    country_code = "GR"
+    bank_country_code = "GR"

--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``en_GB`` locale."""
 
     bban_format = "????##############"
-    country_code = "GB"
+    bank_country_code = "GB"

--- a/faker/providers/bank/en_IE/__init__.py
+++ b/faker/providers/bank/en_IE/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``en_IE`` locale."""
 
     bban_format = "#######################"
-    country_code = "IE"
+    bank_country_code = "IE"

--- a/faker/providers/bank/en_PH/__init__.py
+++ b/faker/providers/bank/en_PH/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 class Provider(BankProvider):
     """Implement bank provider for ``en_PH`` locale."""
 
-    country_code = "PH"
+    bank_country_code = "PH"
     bban_format = "################"
     swift_bank_codes = (
         "ANZB",

--- a/faker/providers/bank/es_AR/__init__.py
+++ b/faker/providers/bank/es_AR/__init__.py
@@ -6,7 +6,7 @@ class Provider(BankProvider):
     source: https://www.bcra.gob.ar/SistemasFinancierosYdePagos/Activos.asp"""
 
     bban_format = "????####################"
-    country_code = "AR"
+    bank_country_code = "AR"
 
     banks = (
         "Banco de la Nación Argentina",

--- a/faker/providers/bank/es_ES/__init__.py
+++ b/faker/providers/bank/es_ES/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``es_ES`` locale."""
 
     bban_format = "####################"
-    country_code = "ES"
+    bank_country_code = "ES"

--- a/faker/providers/bank/fa_IR/__init__.py
+++ b/faker/providers/bank/fa_IR/__init__.py
@@ -5,7 +5,7 @@ class Provider(BankProvider):
     """Implement bank provider for ``fa_IR`` locale."""
 
     bban_format = "IR########################"
-    country_code = "IR"
+    bank_country_code = "IR"
     swift_bank_codes = (
         "BEGN",
         "KESH",

--- a/faker/providers/bank/fi_FI/__init__.py
+++ b/faker/providers/bank/fi_FI/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``fi_FI`` locale."""
 
     bban_format = "##############"
-    country_code = "FI"
+    bank_country_code = "FI"

--- a/faker/providers/bank/fr_FR/__init__.py
+++ b/faker/providers/bank/fr_FR/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``fr_FR`` locale."""
 
     bban_format = "#######################"
-    country_code = "FR"
+    bank_country_code = "FR"

--- a/faker/providers/bank/it_IT/__init__.py
+++ b/faker/providers/bank/it_IT/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``it_IT`` locale."""
 
     bban_format = "?######################"
-    country_code = "IT"
+    bank_country_code = "IT"

--- a/faker/providers/bank/nl_BE/__init__.py
+++ b/faker/providers/bank/nl_BE/__init__.py
@@ -10,7 +10,7 @@ class Provider(BankProvider):
     """
 
     bban_format = "############"
-    country_code = "BE"
+    bank_country_code = "BE"
 
     banks = (
         "Argenta Spaarbank",

--- a/faker/providers/bank/nl_NL/__init__.py
+++ b/faker/providers/bank/nl_NL/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``nl_NL`` locale."""
 
     bban_format = "????##########"
-    country_code = "NL"
+    bank_country_code = "NL"

--- a/faker/providers/bank/no_NO/__init__.py
+++ b/faker/providers/bank/no_NO/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``no_NO`` locale."""
 
     bban_format = "###########"
-    country_code = "NO"
+    bank_country_code = "NO"

--- a/faker/providers/bank/pl_PL/__init__.py
+++ b/faker/providers/bank/pl_PL/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``pl_PL`` locale."""
 
     bban_format = "#" * 24
-    country_code = "PL"
+    bank_country_code = "PL"

--- a/faker/providers/bank/pt_PT/__init__.py
+++ b/faker/providers/bank/pt_PT/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``pt_PT`` locale."""
 
     bban_format = "#####################"
-    country_code = "PT"
+    bank_country_code = "PT"

--- a/faker/providers/bank/ro_RO/__init__.py
+++ b/faker/providers/bank/ro_RO/__init__.py
@@ -4,7 +4,7 @@ from faker.providers.bank import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``ro_RO`` locale."""
 
-    country_code = "RO"
+    bank_country_code = "RO"
     bban_format = "????################"
     swift_bank_codes = (
         "NBOR",

--- a/faker/providers/bank/ru_RU/__init__.py
+++ b/faker/providers/bank/ru_RU/__init__.py
@@ -11,7 +11,7 @@ class Provider(BankProvider):
     - http://cbr.ru/credit/coreports/ko17012020.zip
     """
 
-    country_code = "RU"
+    bank_country_code = "RU"
 
     region_codes = (
         "01",

--- a/faker/providers/bank/sk_SK/__init__.py
+++ b/faker/providers/bank/sk_SK/__init__.py
@@ -8,4 +8,4 @@ class Provider(BankProvider):
     """
 
     bban_format = "####################"
-    country_code = "SK"
+    bank_country_code = "SK"

--- a/faker/providers/bank/th_TH/__init__.py
+++ b/faker/providers/bank/th_TH/__init__.py
@@ -5,7 +5,7 @@ class Provider(BankProvider):
     """Implement bank provider for ``th_TH`` locale."""
 
     bban_format = "#" * 10
-    country_code = "TH"
+    bank_country_code = "TH"
     swift_bank_codes = (
         "AIAC",
         "ANZB",

--- a/faker/providers/bank/tr_TR/__init__.py
+++ b/faker/providers/bank/tr_TR/__init__.py
@@ -5,4 +5,4 @@ class Provider(BankProvider):
     """Implement bank provider for ``tr_TR`` locale."""
 
     bban_format = "######################"
-    country_code = "TR"
+    bank_country_code = "TR"

--- a/faker/providers/bank/uk_UA/__init__.py
+++ b/faker/providers/bank/uk_UA/__init__.py
@@ -10,7 +10,7 @@ class Provider(BankProvider):
     """
 
     bban_format = "#" * 27
-    country_code = "UA"
+    bank_country_code = "UA"
     banks = (
         "izibank",
         "monobank",

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -113,7 +113,7 @@ class Provider(BaseProvider):
         "XXI",
     ]
 
-    countries = [
+    country_timezones: list[Country] = [
         Country(
             timezones=["Europe/Andorra"],
             alpha_2_code="AD",
@@ -2444,7 +2444,7 @@ class Provider(BaseProvider):
         return self.random_element(self.centuries)
 
     def timezone(self) -> str:
-        return self.generator.random.choice(self.random_element(self.countries).timezones)  # type: ignore
+        return self.generator.random.choice(self.random_element(self.country_timezones).timezones)  # type: ignore
 
     def pytimezone(self, *args: Any, **kwargs: Any) -> Optional[TzInfo]:
         """

--- a/faker/providers/date_time/ar_AA/__init__.py
+++ b/faker/providers/date_time/ar_AA/__init__.py
@@ -53,7 +53,7 @@ class Provider(DateTimeProvider):
         "الثاني والعشرين",
     ]
 
-    countries = [
+    country_timezones = [
         Country(
             timezones=["أوروب/أندورا"],
             alpha_2_code="AD",

--- a/faker/providers/date_time/bn_BD/__init__.py
+++ b/faker/providers/date_time/bn_BD/__init__.py
@@ -29,7 +29,7 @@ class Provider(DateTimeProvider):
         "12": "ডিসেম্বর",
     }
 
-    countries = [
+    country_timezones = [
         Country(
             timezones=["ইউরোপ/অ্যান্ডোরা"],
             alpha_2_code="AD",

--- a/faker/providers/date_time/ru_RU/__init__.py
+++ b/faker/providers/date_time/ru_RU/__init__.py
@@ -30,7 +30,7 @@ class Provider(DateTimeProvider):
     }
 
     # Timezone names are based on Wiki list, source: https://ru.wikipedia.org/wiki/Список_часовых_поясов_по_странам
-    countries = [
+    country_timezones = [
         Country(
             timezones=["Андорра (UTC+01)"],
             alpha_2_code="AD",

--- a/faker/providers/isbn/rules.py
+++ b/faker/providers/isbn/rules.py
@@ -9,10 +9,9 @@ The complete list of prefixes and rules can be found at
 https://www.isbn-international.org/range_file_generation
 """
 
-from collections import namedtuple
 from typing import Dict, List
 
-RegistrantRule = namedtuple("RegistrantRule", ["min", "max", "registrant_length"])
+from ...typing import RegistrantRule
 
 # Structure: RULES[`EAN Prefix`][`Registration Group`] = [Rule1, Rule2, ...]
 RULES: Dict[str, Dict[str, List[RegistrantRule]]] = {

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -9,7 +9,7 @@ import tarfile
 import uuid
 import zipfile
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, overload
 
 from faker.exceptions import UnsupportedFeature
 
@@ -19,6 +19,8 @@ from ..python import TypesSpec
 localized = True
 
 csv.register_dialect("faker-csv", csv.excel, quoting=csv.QUOTE_ALL)
+
+_T = TypeVar("_T")
 
 
 class Provider(BaseProvider):
@@ -98,10 +100,31 @@ class Provider(BaseProvider):
             return res.digest()
         return res.hexdigest()
 
+    @overload
     def uuid4(
         self,
-        cast_to: Optional[Union[Callable[[uuid.UUID], str], Callable[[uuid.UUID], bytes]]] = str,
-    ) -> Union[bytes, str, uuid.UUID]:
+        cast_to: None,
+    ) -> uuid.UUID:
+        ...
+
+    @overload
+    def uuid4(
+        self,
+        cast_to: Callable[[uuid.UUID], _T],
+    ) -> _T:
+        ...
+
+    @overload
+    def uuid4(
+        self,
+        cast_to: Callable[[uuid.UUID], str] = str,
+    ) -> str:
+        ...
+
+    def uuid4(
+        self,
+        cast_to: Optional[Union[Callable[[uuid.UUID], _T], Callable[[uuid.UUID], str]]] = str,
+    ) -> Union[_T, str, uuid.UUID]:
         """Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
 
         By default, ``cast_to`` is set to ``str``.
@@ -643,7 +666,12 @@ class Provider(BaseProvider):
         _dict = {self.generator.word(): _dict}
         return xmltodict.unparse(_dict)
 
-    def fixed_width(self, data_columns: Optional[list] = None, num_rows: int = 10, align: str = "left") -> str:
+    def fixed_width(
+        self,
+        data_columns: Optional[list] = None,
+        num_rows: int = 10,
+        align: str = "left",
+    ) -> str:
         """
         Generate random fixed width values.
 

--- a/faker/providers/sbn/rules.py
+++ b/faker/providers/sbn/rules.py
@@ -4,10 +4,9 @@ number may be within an SBN. It's the same as the ISBN implementation
 for ean 978, reg_group 0.
 """
 
-from collections import namedtuple
 from typing import List
 
-RegistrantRule = namedtuple("RegistrantRule", ["min", "max", "registrant_length"])
+from ...typing import RegistrantRule
 
 # Structure: RULES = [Rule1, Rule2, ...]
 RULES: List[RegistrantRule] = [

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -6,7 +6,7 @@ import re
 
 from collections import OrderedDict
 from random import Random
-from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, TypeVar, Union
 
 from .config import DEFAULT_LOCALE
 from .exceptions import UniquenessException
@@ -15,12 +15,77 @@ from .generator import Generator, random
 from .typing import SeedType
 from .utils.distribution import choices_distribution
 
+if TYPE_CHECKING:
+    from .providers import (
+        address,
+        automotive,
+        bank,
+        barcode,
+        color,
+        company,
+        credit_card,
+        currency,
+        date_time,
+        emoji,
+        file,
+        geo,
+        internet,
+        isbn,
+        job,
+        lorem,
+        misc,
+        passport,
+        person,
+        phone_number,
+        profile,
+        python,
+        sbn,
+        ssn,
+        user_agent,
+    )
+
+    class ProviderMixin(
+        address.Provider,
+        automotive.Provider,
+        bank.Provider,
+        barcode.Provider,
+        color.Provider,
+        company.Provider,
+        credit_card.Provider,
+        currency.Provider,
+        date_time.Provider,
+        emoji.Provider,
+        file.Provider,
+        geo.Provider,
+        internet.Provider,
+        isbn.Provider,
+        job.Provider,
+        lorem.Provider,
+        misc.Provider,
+        passport.Provider,
+        person.Provider,
+        phone_number.Provider,
+        profile.Provider,
+        python.Provider,
+        sbn.Provider,
+        ssn.Provider,
+        user_agent.Provider,
+        Generator,
+    ):
+        pass
+
+else:
+
+    class ProviderMixin:
+        pass
+
+
 _UNIQUE_ATTEMPTS = 1000
 
 RetType = TypeVar("RetType")
 
 
-class Faker:
+class Faker(ProviderMixin):
     """Proxy class capable of supporting multiple locales"""
 
     cache_pattern: Pattern = re.compile(r"^_cached_\w*_mapping$")
@@ -230,7 +295,7 @@ class Faker:
         """
         Generator.seed(seed)
 
-    def seed_instance(self, seed: Optional[SeedType] = None) -> None:
+    def seed_instance(self, seed: Optional[SeedType] = None) -> "Faker":
         """
         Creates and seeds a new `random.Random` object for each factory
 
@@ -238,6 +303,8 @@ class Faker:
         """
         for factory in self._factories:
             factory.seed_instance(seed)
+
+        return self
 
     def seed_locale(self, locale: str, seed: Optional[SeedType] = None) -> None:
         """

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -1,6 +1,7 @@
 import dataclasses
 import sys
 
+from collections import namedtuple
 from datetime import date, datetime, timedelta
 from typing import Sequence, Union
 
@@ -30,3 +31,6 @@ class Country:
     alpha_3_code: str
     continent: str
     capital: str
+
+
+RegistrantRule = namedtuple("RegistrantRule", ["min", "max", "registrant_length"])

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -115,8 +115,13 @@ class TestBaseProvider:
 
     def test_current_country_errors(self):
         dt = providers.date_time
-        countries_duplicated = [*dt.Provider.countries, *dt.Provider.countries]
-        with mock.patch.object(dt.Provider, "countries", countries_duplicated), pytest.raises(ValueError) as e:
+        country_timezones_duplicated = [
+            *dt.Provider.country_timezones,
+            *dt.Provider.country_timezones,
+        ]
+        with mock.patch.object(dt.Provider, "country_timezones", country_timezones_duplicated), pytest.raises(
+            ValueError
+        ) as e:
             Faker("en_US").current_country()
         assert "Ambiguous" in str(e)
         country_code = "faker.providers.address.Provider.current_country_code"
@@ -1148,7 +1153,10 @@ class TestItIt:
         for _ in range(num_samples):
             postcode_city_province = faker.postcode_city_province()
             assert isinstance(postcode_city_province, str)
-            match = re.fullmatch(r"(?P<cap>\d{5}), (?P<city>.*) \((?P<province>[A-Z]{2})\)", postcode_city_province)
+            match = re.fullmatch(
+                r"(?P<cap>\d{5}), (?P<city>.*) \((?P<province>[A-Z]{2})\)",
+                postcode_city_province,
+            )
             assert match
             assert match.group("cap") in ItItAddressProvider.postcode_formats
             assert match.group("city") in ItItAddressProvider.cities
@@ -2113,7 +2121,10 @@ class TestHuHu:
         for _ in range(num_samples):
             street_address_with_county = faker.street_address_with_county()
             assert isinstance(street_address_with_county, str)
-            match = re.fullmatch(r".* \d*.\n.* [A-Za-zÀ-ȕ]*\nH-\d{4} [A-Za-zÀ-ȕ]*", street_address_with_county)
+            match = re.fullmatch(
+                r".* \d*.\n.* [A-Za-zÀ-ȕ]*\nH-\d{4} [A-Za-zÀ-ȕ]*",
+                street_address_with_county,
+            )
             assert match
 
     def test_city_prefix(self, faker, num_samples):

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -51,7 +51,7 @@ class TestAzAz:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == AzAzBankProvider.country_code
+            assert iban[:2] == AzAzBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}[A-Z]{4}\d{20}", iban[2:])
 
     def test_bank(self, faker, num_samples):
@@ -71,7 +71,7 @@ class TestCsCz:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == CsCZBankProvider.country_code
+            assert iban[:2] == CsCZBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
 
 
@@ -86,7 +86,7 @@ class TestSkSk:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == SkSKBankProvider.country_code
+            assert iban[:2] == SkSKBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
 
 
@@ -107,7 +107,7 @@ class TestNoNo:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == NoNoBankProvider.country_code
+            assert iban[:2] == NoNoBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{11}", iban[2:])
 
 
@@ -134,7 +134,7 @@ class TestFiFi:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == FiFiBankProvider.country_code
+            assert iban[:2] == FiFiBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{14}", iban[2:])
 
 
@@ -149,7 +149,7 @@ class TestPlPl:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == PlPlBankProvider.country_code
+            assert iban[:2] == PlPlBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{24}", iban[2:])
 
 
@@ -164,7 +164,7 @@ class TestUkUa:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == UkUaBankProvider.country_code
+            assert iban[:2] == UkUaBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{27}", iban[2:])
 
 
@@ -179,7 +179,7 @@ class TestEnGb:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == EnGbBankProvider.country_code
+            assert iban[:2] == EnGbBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}[A-Z]{4}\d{14}", iban[2:])
 
 
@@ -194,7 +194,7 @@ class TestEnIe:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == EnIeBankProvider.country_code
+            assert iban[:2] == EnIeBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
 
 
@@ -229,7 +229,7 @@ class TestPtPt:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == PtPtBankProvider.country_code
+            assert iban[:2] == PtPtBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{21}", iban[2:])
 
 
@@ -244,7 +244,7 @@ class TestEsEs:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == EsEsBankProvider.country_code
+            assert iban[:2] == EsEsBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
 
 
@@ -300,7 +300,7 @@ class TestEsAr:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == EsArBankProvider.country_code
+            assert iban[:2] == EsArBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}[A-Z]{4}\d{20}", iban[2:])
 
 
@@ -315,7 +315,7 @@ class TestFrFr:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == FrFrBankProvider.country_code
+            assert iban[:2] == FrFrBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
 
 
@@ -349,7 +349,7 @@ class TestEnPh:
             code = faker.swift8(use_dataset=True)
             assert len(code) == 8
             assert code[:4] in EnPhBankProvider.swift_bank_codes
-            assert code[4:6] == EnPhBankProvider.country_code
+            assert code[4:6] == EnPhBankProvider.bank_country_code
             assert code[6:8] in EnPhBankProvider.swift_location_codes
 
     def test_swift11_use_dataset(self, faker, num_samples):
@@ -357,7 +357,7 @@ class TestEnPh:
             code = faker.swift11(use_dataset=True)
             assert len(code) == 11
             assert code[:4] in EnPhBankProvider.swift_bank_codes
-            assert code[4:6] == EnPhBankProvider.country_code
+            assert code[4:6] == EnPhBankProvider.bank_country_code
             assert code[6:8] in EnPhBankProvider.swift_location_codes
             assert code[8:11] in EnPhBankProvider.swift_branch_codes
 
@@ -391,7 +391,7 @@ class TestTrTr:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == TrTrBankProvider.country_code
+            assert iban[:2] == TrTrBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{22}", iban[2:])
 
 
@@ -406,7 +406,7 @@ class TestDeCh:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == DeChBankProvider.country_code
+            assert iban[:2] == DeChBankProvider.bank_country_code
             assert re.fullmatch(r"\d{19}", iban[2:])
 
 
@@ -433,7 +433,7 @@ class TestThTh:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == ThThBankProvider.country_code
+            assert iban[:2] == ThThBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{10}", iban[2:])
 
 
@@ -448,7 +448,7 @@ class TestElGr:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == ElGrBankProvider.country_code
+            assert iban[:2] == ElGrBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
 
 
@@ -471,7 +471,7 @@ class TestNlBe:
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
-            assert iban[:2] == NlBeBankProvider.country_code
+            assert iban[:2] == NlBeBankProvider.bank_country_code
             assert re.fullmatch(r"\d{2}\d{12}", iban[2:])
 
     def test_swift8_use_dataset(self, faker, num_samples):
@@ -479,7 +479,7 @@ class TestNlBe:
             code = faker.swift8(use_dataset=True)
             assert len(code) == 8
             assert code[:4] in NlBeBankProvider.swift_bank_codes
-            assert code[4:6] == NlBeBankProvider.country_code
+            assert code[4:6] == NlBeBankProvider.bank_country_code
             assert code[6:8] in NlBeBankProvider.swift_location_codes
 
     def test_swift11_use_dataset(self, faker, num_samples):
@@ -487,7 +487,7 @@ class TestNlBe:
             code = faker.swift11(use_dataset=True)
             assert len(code) == 11
             assert code[:4] in NlBeBankProvider.swift_bank_codes
-            assert code[4:6] == NlBeBankProvider.country_code
+            assert code[4:6] == NlBeBankProvider.bank_country_code
             assert code[6:8] in NlBeBankProvider.swift_location_codes
             assert code[8:11] in NlBeBankProvider.swift_branch_codes
 


### PR DESCRIPTION
### What does this change

While debugging a typing-related bug in my tests I created a small mixin of some Faker providers for mypy type checking, unfortunately when I added all of them for the future checks I noticed a type/name conflict between address and bank/date_time providers. 

### What was wrong

As Faker proxy is dynamically gathering methods from locals, mypy cannot determine the correct types.

### How this fixes it

This PR adds a typing-only class that is a mixture of all available providers thus giving mypy and IDEs enough information for type checking/completion (potentially fixing https://github.com/joke2k/faker/issues/1604).

### Problems

As some providers have common attributes with different datatypes direct mixing was not possible which makes this change backward incompatible. I would love to hear your thoughts on this approach. Thanks.
