### PR TITLE
Remove duplicate assigned HTTP Status codes

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -134,8 +134,6 @@ class Provider(BaseProvider):
     http_assigned_codes: ElementsType[int] = (
         100,
         101,
-        100,
-        101,
         102,
         103,
         200,


### PR DESCRIPTION
### What does this change

Remove duplicate entries from `http_assigned_codes`.

### What was wrong

Two values appeared twice in the list skewing the probabilities and making the list harder to maintain.

### How this fixes it

Removed duplicate entries.

### Remark

Would it be acceptable to replace this hard coded list by values from the `http.HTTPStatus` enum included in the Python standard library? (I understand if this repo prefers hard coded lists)
Also; that enum has changed in recent Python version, Python 3.9 added 3 additional status codes, including `418 – IM A TEAPOT` which is not part of the current list because it is considered [Unused](https://www.rfc-editor.org/rfc/rfc9110.html#name-418-unused) by the RFC.