### PR TITLE
Fix wrong pricetag format in ru_RU locale

### DIFF
--- a/faker/providers/currency/ru_RU/__init__.py
+++ b/faker/providers/currency/ru_RU/__init__.py
@@ -171,7 +171,7 @@ class Provider(CurrencyProvider):
         ("ZWD", "Доллар Зимбабве"),
     )
 
-    price_formats = ["#,##", "%#,##", "%##,##", "%.###,##", "%#.###,##"]
+    price_formats = ["#,##", "%#,##", "%##,##", "% ###,##", "%# ###,##"]
 
     def pricetag(self) -> str:
         return (

--- a/tests/providers/test_currency.py
+++ b/tests/providers/test_currency.py
@@ -1,3 +1,5 @@
+import re
+
 from unittest.mock import patch
 
 import pytest
@@ -131,6 +133,7 @@ class TestRuRu:
         for _ in range(num_samples):
             pricetag = faker.pricetag()
             assert isinstance(pricetag, str)
+            assert re.match(r"\d{1,3}(?:\s\d{3})*,\d{2}\sр\.", pricetag)
 
 
 class TestCsCz:


### PR DESCRIPTION
### What does this change

Correct the pricetag format in `ru_RU` locale

### What was wrong

Related to #2006, the space is used to seperate the hundreds and thousands digit but not a dot.

### How this fixes it

Replace the dot with a space.

Fixes #2006
