### PR TITLE
Remove obscene word from a poland dictionary

### DIFF
--- a/faker/providers/lorem/pl_PL/__init__.py
+++ b/faker/providers/lorem/pl_PL/__init__.py
@@ -1210,7 +1210,6 @@ class Provider(LoremProvider):
         "lipiec",
         "bohater",
         "prasa",
-        "penis",
         "Czechy",
         "80",
         "fakt",


### PR DESCRIPTION
Remove obscene word from a poland dictionary (lorem provider)

### What does this change

Removed obscene word from a poland dictionary (lorem provider)

### What was wrong

Obscene words are bad and very embracing to show to your clients...

### How this fixes it

* By removing