### PR TITLE
drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Faker"
-copyright = "2014-{0}, Daniele Faraglia".format(datetime.now().year)
+copyright = f"2014-{datetime.now().year}, Daniele Faraglia"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/faker/providers/address/es_CL/__init__.py
+++ b/faker/providers/address/es_CL/__init__.py
@@ -631,7 +631,7 @@ class Provider(AddressProvider):
         region_index = int(commune_code[0:2]) - 1
         region_name = tuple(self.regions.values())[region_index]
 
-        return "{:s}, {:s}".format(commune_name, region_name)
+        return f"{commune_name:s}, {region_name:s}"
 
     def road_name(self) -> str:
         self.generator.set_arguments("kilometer", {"min": 1, "max": 35})

--- a/faker/providers/automotive/es_CL/__init__.py
+++ b/faker/providers/automotive/es_CL/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 from collections import OrderedDict

--- a/faker/providers/automotive/es_ES/__init__.py
+++ b/faker/providers/automotive/es_ES/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 from typing import Optional

--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -70,7 +70,7 @@ for name, sym in [
     ("minutes", "m"),
     ("seconds", "s"),
 ]:
-    timedelta_pattern += r"((?P<{}>(?:\+|-)\d+?){})?".format(name, sym)
+    timedelta_pattern += fr"((?P<{name}>(?:\+|-)\d+?){sym})?"
 
 
 class Provider(BaseProvider):

--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -337,7 +337,7 @@ class Provider(BaseProvider):
         if prefix is None:
             prefix = self.random_element(self.unix_device_prefixes)
         suffix: str = self.random_element(string.ascii_lowercase)
-        path = "/dev/%s%s" % (prefix, suffix)
+        path = "/dev/{}{}".format(prefix, suffix)
         return path
 
     def unix_partition(self, prefix: Optional[str] = None) -> str:

--- a/faker/providers/internet/el_GR/__init__.py
+++ b/faker/providers/internet/el_GR/__init__.py
@@ -46,7 +46,7 @@ def remove_accents(value: str) -> str:
             return replace[search.find(matched)]
         return matched
 
-    return re.sub(r"[{}]+".format(search), replace_accented_character, value)
+    return re.sub(fr"[{search}]+", replace_accented_character, value)
 
 
 def latinize(value: str) -> str:
@@ -71,7 +71,7 @@ def latinize(value: str) -> str:
         return "".join(value)
 
     return re.sub(
-        r"[{}]+".format(search),
+        fr"[{search}]+",
         replace_greek_character,
         re.sub(
             r"([ΘΧΨθχψ]+|ΟΥ|ΑΥ|ΕΥ|Ου|Αυ|Ευ|ου|αυ|ευ)",

--- a/faker/providers/user_agent/__init__.py
+++ b/faker/providers/user_agent/__init__.py
@@ -193,7 +193,7 @@ class Provider(BaseProvider):
                 saf,
             ),
             tmplt.format(
-                "Linux; {}".format(self.android_platform_token()),
+                f"Linux; {self.android_platform_token()}",
                 saf,
                 self.generator.random.randint(version_from, version_to),
                 self.generator.random.randint(build_from, build_to),
@@ -228,7 +228,7 @@ class Provider(BaseProvider):
         tmplt_mac: str = "({0}; rv:1.9.{1}.20) {2}"
         tmplt_and: str = "({0}; Mobile; rv:{1}.0) Gecko/{1}.0 Firefox/{1}.0"
         tmplt_ios: str = "({0}) AppleWebKit/{1} (KHTML, like Gecko) FxiOS/{2}.{3}.0 Mobile/{4} Safari/{1}"
-        saf: str = "{}.{}".format(self.generator.random.randint(531, 536), self.generator.random.randint(0, 2))
+        saf: str = f"{self.generator.random.randint(531, 536)}.{self.generator.random.randint(0, 2)}"
         bld: str = self.lexify(self.numerify("##?###"), string.ascii_uppercase)
         bld2: str = self.lexify(self.numerify("#?####"), string.ascii_lowercase)
         platforms: ElementsType[str] = (

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -30,10 +30,10 @@ class Faker:
 
     def __init__(
         self,
-        locale: Optional[Union[str, Sequence[str], Dict[str, Union[int, float]]]] = None,
-        providers: Optional[List[str]] = None,
-        generator: Optional[Generator] = None,
-        includes: Optional[List[str]] = None,
+        locale: str | Sequence[str] | dict[str, int | float] | None = None,
+        providers: list[str] | None = None,
+        generator: Generator | None = None,
+        includes: list[str] | None = None,
         use_weighting: bool = True,
         **config: Any,
     ) -> None:
@@ -92,7 +92,7 @@ class Faker:
         self._factories = list(self._factory_map.values())
 
     def __dir__(self):
-        attributes = set(super(Faker, self).__dir__())
+        attributes = set(super().__dir__())
         for factory in self.factories:
             attributes |= {attr for attr in dir(factory) if not attr.startswith("_")}
         return sorted(attributes)
@@ -153,11 +153,11 @@ class Faker:
         self.__dict__.update(state)
 
     @property
-    def unique(self) -> "UniqueProxy":
+    def unique(self) -> UniqueProxy:
         return self._unique_proxy
 
     @property
-    def optional(self) -> "OptionalProxy":
+    def optional(self) -> OptionalProxy:
         return self._optional_proxy
 
     def _select_factory(self, method_name: str) -> Factory:
@@ -188,7 +188,7 @@ class Faker:
     def _select_factory_choice(self, factories):
         return random.choice(factories)
 
-    def _map_provider_method(self, method_name: str) -> Tuple[List[Factory], Optional[List[float]]]:
+    def _map_provider_method(self, method_name: str) -> tuple[list[Factory], list[float] | None]:
         """
         Creates a 2-tuple of factories and weights for the given provider method name
 
@@ -222,7 +222,7 @@ class Faker:
         return mapping
 
     @classmethod
-    def seed(cls, seed: Optional[SeedType] = None) -> None:
+    def seed(cls, seed: SeedType | None = None) -> None:
         """
         Hashables the shared `random.Random` object across all factories
 
@@ -230,7 +230,7 @@ class Faker:
         """
         Generator.seed(seed)
 
-    def seed_instance(self, seed: Optional[SeedType] = None) -> None:
+    def seed_instance(self, seed: SeedType | None = None) -> None:
         """
         Creates and seeds a new `random.Random` object for each factory
 
@@ -239,7 +239,7 @@ class Faker:
         for factory in self._factories:
             factory.seed_instance(seed)
 
-    def seed_locale(self, locale: str, seed: Optional[SeedType] = None) -> None:
+    def seed_locale(self, locale: str, seed: SeedType | None = None) -> None:
         """
         Creates and seeds a new `random.Random` object for the factory of the specified locale
 
@@ -281,25 +281,25 @@ class Faker:
             raise NotImplementedError(msg)
 
     @property
-    def locales(self) -> List[str]:
+    def locales(self) -> list[str]:
         return list(self._locales)
 
     @property
-    def weights(self) -> Optional[List[Union[int, float]]]:
+    def weights(self) -> list[int | float] | None:
         return self._weights
 
     @property
-    def factories(self) -> List[Generator | Faker]:
+    def factories(self) -> list[Generator | Faker]:
         return self._factories
 
-    def items(self) -> List[Tuple[str, Generator | Faker]]:
+    def items(self) -> list[tuple[str, Generator | Faker]]:
         return list(self._factory_map.items())
 
 
 class UniqueProxy:
     def __init__(self, proxy: Faker):
         self._proxy = proxy
-        self._seen: Dict = {}
+        self._seen: dict = {}
         self._sentinel = object()
 
     def clear(self) -> None:
@@ -372,9 +372,9 @@ class OptionalProxy:
     def __setstate__(self, state):
         self.__dict__.update(state)
 
-    def _wrap(self, name: str, function: Callable[..., RetType]) -> Callable[..., Optional[RetType]]:
+    def _wrap(self, name: str, function: Callable[..., RetType]) -> Callable[..., RetType | None]:
         @functools.wraps(function)
-        def wrapper(*args: Any, prob: float = 0.5, **kwargs: Any) -> Optional[RetType]:
+        def wrapper(*args: Any, prob: float = 0.5, **kwargs: Any) -> RetType | None:
             if not 0 < prob <= 1.0:
                 raise ValueError("prob must be between 0 and 1")
             return function(*args, **kwargs) if self._proxy.boolean(chance_of_getting_true=int(prob * 100)) else None

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -6,7 +6,7 @@ import re
 
 from collections import OrderedDict
 from random import Random
-from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, TypeVar, Union
+from typing import Any, Callable, Pattern, Sequence, TypeVar
 
 from .config import DEFAULT_LOCALE
 from .exceptions import UniquenessException

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -2,7 +2,6 @@ import datetime
 
 from collections import OrderedDict
 from decimal import Decimal
-from enum import Enum
 from json import encoder
 from typing import (
     Any,
@@ -18,7 +17,6 @@ from typing import (
     Set,
     Tuple,
     Type,
-    TypeVar,
     Union,
 )
 from uuid import UUID

--- a/faker/sphinx/autodoc.py
+++ b/faker/sphinx/autodoc.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from faker.sphinx.docstring import ProviderMethodDocstring
 from faker.sphinx.documentor import write_provider_docs
 

--- a/faker/sphinx/docstring.py
+++ b/faker/sphinx/docstring.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import inspect
 import logging
 import re

--- a/faker/sphinx/documentor.py
+++ b/faker/sphinx/documentor.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import importlib
 import inspect
 import os
@@ -145,7 +144,7 @@ def _write_localized_provider_docs():
     (DOCS_ROOT / "locales").mkdir(parents=True, exist_ok=True)
     for locale in AVAILABLE_LOCALES:
         info = _get_localized_provider_info(locale)
-        with (DOCS_ROOT / "locales" / "{}.rst".format(locale)).open("wb") as fh:
+        with (DOCS_ROOT / "locales" / f"{locale}.rst").open("wb") as fh:
             _hide_edit_on_github(fh)
             _write_title(fh, f"Locale {locale}")
             _write_includes(fh)

--- a/faker/sphinx/validator.py
+++ b/faker/sphinx/validator.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import ast
 import traceback
 

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -7,14 +7,15 @@ from typing import Sequence, Union
 try:
     from typing import List, Literal, TypeVar  # type: ignore
 except ImportError:
-    from typing_extensions import List, Literal, TypeVar  # type: ignore
+    from typing_extensions import Literal, TypeVar  # type: ignore
+    from typing import List
 
 if sys.version_info >= (3, 9):
     from collections import OrderedDict as OrderedDictType
 elif sys.version_info >= (3, 7, 2):
     from typing import OrderedDict as OrderedDictType
 else:
-    from typing_extensions import OrderedDict as OrderedDictType  # NOQA
+    from typing import OrderedDict as OrderedDictType  # NOQA
 
 
 class CreditCard:

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -12,10 +12,8 @@ except ImportError:
 
 if sys.version_info >= (3, 9):
     from collections import OrderedDict as OrderedDictType
-elif sys.version_info >= (3, 7, 2):
-    from typing import OrderedDict as OrderedDictType
 else:
-    from typing import OrderedDict as OrderedDictType  # NOQA
+    from typing import OrderedDict as OrderedDictType
 
 
 class CreditCard:

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -73,6 +70,5 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "python-dateutil>=2.4",
-        "typing-extensions>=3.10.0.1;python_version<='3.8'",
     ],
 )

--- a/tests/providers/test_enum.py
+++ b/tests/providers/test_enum.py
@@ -45,6 +45,6 @@ class TestEnumProvider:
             faker.enum(None)
 
     def test_incorrect_type_raises(self, faker):
-        not_an_enum_type = type("NotAnEnumType")
+        not_an_enum_type = str
         with pytest.raises(TypeError):
             faker.enum(not_an_enum_type)

--- a/tests/sphinx/test_docstring.py
+++ b/tests/sphinx/test_docstring.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import inspect
 
 from unittest import mock

--- a/tests/sphinx/test_validator.py
+++ b/tests/sphinx/test_validator.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import sys
 
 from unittest import mock

--- a/tests/sphinx/test_validator.py
+++ b/tests/sphinx/test_validator.py
@@ -99,8 +99,7 @@ class TestSampleCodeValidator:
 
     def test_prohibited_literal_types(self):
         commands = ["variable.method(...)"]
-        if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
-            commands.append('f"{variable}"')
+        commands.append('f"{variable}"')
 
         for command in commands:
             validator = SampleCodeValidator(command)


### PR DESCRIPTION
### What does this change
According to https://endoflife.date/python python 3.7 has been EOSed at 7 Jun 2023.
- filter all code over `pyupgrade --py38-plus`.
- manual cleanups removing some older python version code
- filter all code over ruff to remove unused imports