### PR TITLE
BE Vat Numbers should have a modulo 97 check and start wit 1 or 0

### DIFF
--- a/faker/providers/ssn/nl_BE/__init__.py
+++ b/faker/providers/ssn/nl_BE/__init__.py
@@ -57,8 +57,24 @@ class Provider(SsnProvider):
     vat_id_formats = ("BE##########",)
 
     def vat_id(self) -> str:
+
+        vat_id_random_section = (
+            '#######'
+        )
+
+        vat_id_possible_initial_numbers = (
+            '0',
+            '1'
+        )
         """
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
-        :return: A random Belgian VAT ID
+        https://en.wikipedia.org/wiki/VAT_identification_number
+        :return: A random Belgian VAT ID starting with 0 or 1 and has a correct checksum with a modulo 97 check
         """
-        return self.bothify(self.random_element(self.vat_id_formats))
+        generated_initial_number = self.random_element(vat_id_possible_initial_numbers)
+        vat_without_check = self.bothify(generated_initial_number + vat_id_random_section)
+        vat_as_int = int(vat_without_check)
+        vat_check = 97 - (vat_as_int % 97)
+        vat_check_str = f"{vat_check:0>2}"
+
+        return "BE" + vat_without_check + vat_check_str


### PR DESCRIPTION
Close #2037 
* Faker version: 25
* OS: OS. X Monterery

VAT Numbers generated in Belgium (currently set-up in the provider ssn for locale nl_BE should start with 1 or 0 and have a controle number with a module 97 check.

Refer to https://en.wikipedia.org/wiki/VAT_identification_number

### Steps to reproduce

1. Generate vat_id wit locale nl_BE


### Expected behavior

Vat numbers should be starting with BE0 or BE1 and have a module 97 check as the last two numbers

