### PR TITLE
Use comprehension in it_IT address provider to populate cities

### DIFF
--- a/faker/providers/address/it_IT/__init__.py
+++ b/faker/providers/address/it_IT/__init__.py
@@ -4,11 +4,7 @@ from .. import Provider as AddressProvider
 
 
 def getcities(fulldict):
-    cities = []
-    for cap in fulldict:
-        for c in fulldict[cap]:
-            cities.append(c[0]) if c[0] not in cities else cities
-    return cities
+    return list({c[0] for _cap, cities in fulldict.items() for c in cities})
 
 
 class Provider(AddressProvider):


### PR DESCRIPTION
### What does this change
This PR uses a single set-comprehension to populate the `cities` list for it_IT locale.

### What was wrong
The previous implementation used a series of nested for-loops to build up a unique list of cities in the it_IT locale using a strange inline at line 10 to avoid using a normal IF statement.

https://github.com/joke2k/faker/blob/2069bd3f57caff88fd0b7cbcd51f970890be43bd/faker/providers/address/it_IT/__init__.py#L6-L11

While profiling the code in which I use this provider I found out it was taking a long time to load.

### How this fixes it
Using a set-comprehension and then turning that into a list takes advantages of built-in features of set and the usage of `.items()` for iterating over a dict provide better performances.

Local benchmark tests with timeit shows the latter is at least 100x faster.

```python
from timeit import timeit
from faker.providers.address.it_IT import Provider

fragment = 'getcities(cap_city_province)'

def original_getcities(fulldict):
    cities = []
    for cap in fulldict:
        for c in fulldict[cap]:
            cities.append(c[0]) if c[0] not in cities else cities
    return cities

def new_getcities(fulldict):
    return list({c[0] for _cap, cities in fulldict.items() for c in cities})

print(timeit(fragment, globals={'cap_city_province': Provider.cap_city_province, 'getcities': original_getcities}))
print(timeit(fragment, globals={'cap_city_province': Provider.cap_city_province, 'getcities': new_getcities}))


```

