### PR TITLE
Added passport provider for ru_RU language

### DIFF
--- a/faker/providers/passport/ru_RU/__init__.py
+++ b/faker/providers/passport/ru_RU/__init__.py
@@ -1,0 +1,11 @@
+from typing import Tuple
+
+from faker.typing import SexLiteral
+
+from .. import Provider as PassportProvider
+
+
+class Provider(PassportProvider):
+    def passport_owner(self, gender: SexLiteral = "M") -> Tuple[str, str]:
+        given_name, surname = super().passport_owner(gender)
+        return surname, given_name

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -332,7 +332,6 @@ class TestEnIN(unittest.TestCase):
 
 
 class TestEnPk(unittest.TestCase):
-
     def setUp(self):
         """Set up the Faker instance with the Pakistani locale."""
         self.fake = Faker("en_PK")
@@ -1214,6 +1213,11 @@ class TestRuRU(unittest.TestCase):
     def test_language_name(self):
         language_name = self.fake.language_name()
         assert language_name in RuProvider.language_names
+
+    def test_passport_owner(self):
+        surname, given_name = self.fake.passport_owner()
+        assert surname in RuProvider.last_names
+        assert given_name in RuProvider.first_names
 
 
 class TestSvSE(unittest.TestCase):


### PR DESCRIPTION
### What does this change

Added new passport provider for ru_RU language

### What was wrong

It looks like based on an issue https://github.com/joke2k/faker/issues/2061 for passport_owners we need to return first surname and then given_name

### How this fixes it

I created a new provider class in the path: faker/providers/passport/ru_RU/__init__.py and overloaded the function passport_owner


