### PR TITLE
Declare support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
-        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          allow-prereleases: true
       - name: Install Tox and any other packages
         run: python -m pip install tox coveralls
       - name: Run Tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          allow-prereleases: true
       - name: Install Tox and any other packages
         run: python -m pip install tox coveralls
       - name: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python:
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
 
     steps:
     - uses: actions/checkout@v4
@@ -154,6 +160,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install mypy
@@ -168,7 +175,14 @@ jobs:
     needs: [flake8, isort, black, doc8, checkmanifest, typing]
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+        python:
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "pypy-3.10"
 
     steps:
       - uses: actions/checkout@v4
@@ -184,6 +198,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install Tox and any other packages
         run: python -m pip install tox coveralls
       - name: pytest
@@ -209,7 +224,13 @@ jobs:
     needs: [flake8, isort, black, doc8, checkmanifest, typing]
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python:
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
         arch: ["x86", "x64"]
 
     steps:
@@ -226,6 +247,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install Tox and any other packages
         run: python -m pip install tox coveralls
       - name: Run Tox

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{38,39,310,311,312,py3},alpine,flake8,checkmanifest,isort,mypy,doc8
+envlist=py{38,39,310,311,312,313,py3},alpine,flake8,checkmanifest,isort,mypy,doc8
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 deps =
     coverage>=5.2
-    freezegun<0.4
+    freezegun<2
     pytest>=6.0.1
     ukpostcodeparser>=1.1.1
     validators>=0.13.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 deps =
     coverage>=5.2
-    freezegun<2
+    freezegun
     pytest>=6.0.1
     ukpostcodeparser>=1.1.1
     validators>=0.13.0


### PR DESCRIPTION
### What does this change

The first release candidate of Python 3.13 is around the corner ([2024-07-30](https://peps.python.org/pep-0719/)), this adds it to the test matrix and declares support in the project metadata.

### What was wrong

Python 3.13 seems to be supported without any code changes, but this makes sure it's tested.

### How this fixes it

* Adds PyPI trove classifier
* Adds `3.13` to the list of versions for `actions/setup-python`
