### PR TITLE
Close #2070. Re-introduce `part_of_speech` argument to `words()` method

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -66,6 +66,7 @@ class Provider(BaseProvider):
         self,
         nb: int = 3,
         ext_word_list: Optional[List[str]] = None,
+        part_of_speech: Optional[str] = None,
         unique: bool = False,
     ) -> List[str]:
         """Generate a tuple of words.
@@ -89,10 +90,7 @@ class Provider(BaseProvider):
         :sample: nb=4, ext_word_list=['abc', 'def', 'ghi', 'jkl'], unique=True
         """
 
-        if ext_word_list is None:
-            word_list = self.get_words_list()
-        else:
-            word_list = ext_word_list
+        word_list = self.get_words_list(part_of_speech=part_of_speech, ext_word_list=ext_word_list)
 
         if unique:
             unique_samples = cast(List[str], self.random_sample(word_list, length=nb))

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -1729,7 +1729,13 @@ class Faker:
         :sample: ext_word_list=['abc', 'def', 'ghi', 'jkl']
         """
         ...
-    def words(self, nb: int = ..., ext_word_list: Optional[List[str]] = ..., unique: bool = ...) -> List[str]:
+    def words(
+        self,
+        nb: int = ...,
+        ext_word_list: Optional[List[str]] = ...,
+        part_of_speech: Optional[str] = ...,
+        unique: bool = ...,
+    ) -> List[str]:
         """
         Generate a tuple of words.
 


### PR DESCRIPTION
### What does this change

#2067 changed the signature of the `words` provider and removed the `part_of_speech` kwarg.

### What was wrong

#2067 changed the signature of the `words` provider and removed the `part_of_speech` kwarg.

### How this fixes it

Add the kwarg back

Fixes #2070
