### PR TITLE
Fix `pydecimal` handling of `positive` keyword

### DIFF
--- a/faker/providers/color/color.py
+++ b/faker/providers/color/color.py
@@ -144,8 +144,8 @@ class RandomColor:
         if generator:
             self.random = generator.random
         else:
-            self.seed = int(seed) if seed else random.randint(0, sys.maxsize)
-            self.random = random.Random(self.seed)
+            self.seed = seed if seed else random.randint(0, sys.maxsize)
+            self.random = random.Random(int(self.seed))
 
     def generate(
         self,

--- a/faker/providers/color/color.py
+++ b/faker/providers/color/color.py
@@ -144,7 +144,7 @@ class RandomColor:
         if generator:
             self.random = generator.random
         else:
-            self.seed = seed if seed else random.randint(0, sys.maxsize)
+            self.seed = int(seed) if seed else random.randint(0, sys.maxsize)
             self.random = random.Random(self.seed)
 
     def generate(

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -320,7 +320,7 @@ class Provider(BaseProvider):
         elif max_value is not None and max_value <= 0:
             sign = "-"
         else:
-            if positive == None:
+            if positive is None:
                 sign = self.random_element(("+", "-"))
             else:
                 sign = "+" if positive else "-"

--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -285,7 +285,7 @@ class Provider(BaseProvider):
         self,
         left_digits: Optional[int] = None,
         right_digits: Optional[int] = None,
-        positive: bool = False,
+        positive: Optional[bool] = None,
         min_value: Optional[BasicNumber] = None,
         max_value: Optional[BasicNumber] = None,
     ) -> Decimal:
@@ -320,7 +320,10 @@ class Provider(BaseProvider):
         elif max_value is not None and max_value <= 0:
             sign = "-"
         else:
-            sign = "+" if positive else self.random_element(("+", "-"))
+            if positive == None:
+                sign = self.random_element(("+", "-"))
+            else:
+                sign = "+" if positive else "-"
 
         if sign == "+":
             if max_value is not None:


### PR DESCRIPTION
### What does this change

- `pydecimal` now handles `positive` keyword as expected 
- `random.Random` now takes in expected type `int` for parameter

### What was wrong

- Same as #1954 
- `random.Random` no longer accepts any hashable object as param [(link)](https://docs.python.org/3/library/random.html#alternative-generator)

### How this fixes it

- Now it is checked weather `positive` is None by default (in which case sign assigning is random) or it has been explicitly passed a s `True`/`Flase` (handled in `else` block)
- Explicit typecasting from `Hashable` to `int`

Fixes #2051 