### PR TITLE
issue2085_pydecimal_wrong_distribution_for_min_max_values_of_dif_size

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -335,7 +335,7 @@ class Provider(BaseProvider):
                 left_number = str(self._random_int_of_length(left_digits))
         else:
             if min_value is not None:
-                left_number = str(self.random_int(int(max(max_value or 0, 0)), int(abs(min_value))))
+                left_number = str(self.random_int(int(abs(min(max_value or 0, 0))), int(abs(min_value))))
             else:
                 min_left_digits = math.ceil(math.log10(abs(min(max_value or 1, 1))))
                 if left_digits is None:
@@ -345,7 +345,7 @@ class Provider(BaseProvider):
         if right_digits is None:
             right_digits = self.random_int(0, max_random_digits)
 
-        right_number = "".join([str(self.random_digit()) for i in range(0, right_digits)])
+        right_number = "".join([str(self.random_digit()) for _ in range(0, right_digits)])
 
         result = Decimal(f"{sign}{left_number}.{right_number}")
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import decimal
 import sys
 import unittest
@@ -505,6 +506,29 @@ class TestPydecimal(unittest.TestCase):
         Faker.seed("2")
         result = self.fake.pydecimal(min_value=10**1000)
         self.assertGreater(result, 10**1000)
+
+    def test_min_value_and_max_value_have_different_signs_return_evenly_distributed_values(self):
+        result = []
+        boundary_value = 10
+        for _ in range(1000):
+            result.append(self.fake.pydecimal(min_value=-boundary_value, max_value=boundary_value, right_digits=0))
+        self.assertEqual(len(Counter(result)), 2 * boundary_value + 1)
+
+    def test_min_value_and_max_value_negative_return_evenly_distributed_values(self):
+        result = []
+        min_value = -60
+        max_value = -50
+        for _ in range(1000):
+            result.append(self.fake.pydecimal(min_value=min_value, max_value=max_value, right_digits=0))
+        self.assertGreater(len(Counter(result)), max_value-min_value)
+
+    def test_min_value_and_max_value_positive_return_evenly_distributed_values(self):
+        result = []
+        min_value = 50
+        max_value = 60
+        for _ in range(1000):
+            result.append(self.fake.pydecimal(min_value=min_value, max_value=max_value, right_digits=0))
+        self.assertGreater(len(Counter(result)), max_value-min_value)
 
 
 class TestPystr(unittest.TestCase):


### PR DESCRIPTION
fixed issue 2085: if min and max values for pydecimal have different signs, faker returned only min_value for negatives

### What does this change

- Changed calculation of left_number when '-' sign is selected and min value is specified
```
                left_number = str(self.random_int(int(max(max_value or 0, 0)), int(abs(min_value))))
->
                left_number = str(self.random_int(int(abs(min(max_value or 0, 0))), int(abs(min_value))))
```
- Added tests to check that all values could be selected from ranges: (-min ... -max), (-min ... +max), (+min ... +max)

### What was wrong

When specified equal min and max values with different signs (-min and  +max), then for selected '-' sign, left_number always calculated to -min value
left_number = str(self.random_int(int(max(max_value or 0, 0)), int(abs(min_value))))  # min_value is substituted with max_value  as they equal by absolute value
->
left_number = str(self.random_int(int(max(max_value or 0, 0)), int(max_value)))
->
left_number = str(self.random_int(int(max_value), int(max_value)) -> max_value

### How this fixes it

IF '-' sign is selected, AND min_value is specified, AND max_value is positive, max_value will be calculated as 0.

Fixes #2085 
