### PR TITLE
fixed issue 2100: faker does not properly convert min/max value to de…

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -352,9 +352,9 @@ class Provider(BaseProvider):
         # Because the random result might have the same number of decimals as max_value the random number
         # might be above max_value or below min_value
         if max_value is not None and result > max_value:
-            result = Decimal(max_value)
+            result = Decimal(str(max_value))
         if min_value is not None and result < min_value:
-            result = Decimal(min_value)
+            result = Decimal(str(min_value))
 
         return result
 

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -506,6 +506,16 @@ class TestPydecimal(unittest.TestCase):
         result = self.fake.pydecimal(min_value=10**1000)
         self.assertGreater(result, 10**1000)
 
+    def test_min_value_float_returns_correct_digit_number(self):
+        Faker.seed("6")
+        result = self.fake.pydecimal(left_digits=1, right_digits=1, min_value=0.2, max_value=0.3)
+        self.assertEqual(decimal.Decimal("0.2"), result)
+
+    def test_max_value_float_returns_correct_digit_number(self):
+        Faker.seed("3")
+        result = self.fake.pydecimal(left_digits=1, right_digits=1, min_value=0.2, max_value=0.3)
+        self.assertEqual(decimal.Decimal("0.3"), result)
+
 
 class TestPystr(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this change

Cast min and max value to string before trying to cast them to Decimal (to avoid floating point issues).

### What was wrong

The float was directly passed to Decimal.

### How this fixes it

Casting to string makes sure that the Decimal is created with the expected value.

Fixes #2100 
