### PR TITLE
Fix Python 3.8 Compatibility: Replace functools.cache with functools.lru_cache

### DIFF
--- a/faker/factory.py
+++ b/faker/factory.py
@@ -65,7 +65,7 @@ class Factory:
         return faker
 
     @classmethod
-    @functools.cache
+    @functools.lru_cache(maxsize=None)
     def _find_provider_class(
         cls,
         provider_path: str,


### PR DESCRIPTION
### What does this change

Changed code to be functional in python 3.8

### What was wrong

`functools.cache`, a shorthand for `functools.lru_cache(maxsize=None)` was causing errors

### How this fixes it

Replaced `@functools.cache` with `@functools.lru_cache(maxsize=None)`

Fixes #2112

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have run `make lint`
