### PR TITLE
fix(pytest): make fixture session scoped

### DIFF
--- a/faker/contrib/pytest/plugin.py
+++ b/faker/contrib/pytest/plugin.py
@@ -20,7 +20,7 @@ def _session_faker(request):
     return Faker(locale=locale)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def faker(request):
     """Fixture that returns a seeded and suitable ``Faker`` instance."""
     if "faker_locale" in request.fixturenames:


### PR DESCRIPTION
### What does this change

Fixes #2055

The issue suggest to bump the major version. I cannot find any instructions on this in the contribs guidelines so waiting for instruction here 

### What was wrong

The `faker` PyTest fixture is not scoped, so it cannot be used is a scoped fixture.

### How this fixes it

This defines the scope of the fixture to be session scoped, as per the maximum scope possible

### Checklist

- [X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [X] I have run `make lint`
