### PR TITLE
Add custom Animals Provider

### DIFF
--- a/docs/animals/index.rst
+++ b/docs/animals/index.rst
@@ -1,0 +1,111 @@
+Animals Provider
+================
+
+The Animals provider offers comprehensive and accurate animals data,covering an extensive range of species. It includes info like the common name and the scientific name. This data can be useful for applications requiring realistic representations of biological diversity, educational tools, wildlife databases, or any project that needs accurate animal species data.
+
+**Installation**
+
+Install with pip:
+
+.. code-block:: python
+
+    >>> pip install faker-animals
+
+Add as a provider to your Faker instance:
+
+.. code-block:: python
+
+    >>> from faker import Faker
+    >>> from faker_animals import AnimalsProvider
+    >>> fake = Faker()
+    >>> fake.add_provider(AnimalsProvider)
+
+
+**Usage examples**
+
+**Animal**
+
+.. code-block:: python
+
+    >>> fake.animal()
+    {
+        'common_name': 'Kangaroo',
+        'scientific_name': 'Macropodidae',
+        'class': 'mammals'
+    }
+
+**Animal Common Name**
+
+.. code-block:: python
+
+    >>> fake.animal_name()
+    'Brown Bear'
+
+
+**Animal Scientific Name**
+
+.. code-block:: python
+
+    >>> fake.animal_name_scientific()
+    'Ursus arctos'
+
+
+**Bird**
+
+.. code-block:: python
+
+    >>> fake.bird()
+    {
+      'common_name': 'African Grey Parrot',
+      'scientific_name': 'Psittacus erithacus',
+      'class': 'birds'
+    }
+
+
+**Mammal**
+
+.. code-block:: python
+
+    >>> fake.mammal()
+    {
+      'common_name': 'Alaskan Husky',
+      'scientific_name': 'Canis lupus',
+      'class': 'mammals'
+    }
+
+
+**Fish**
+
+.. code-block:: python
+
+    >>> fake.fish()
+    {
+      'common_name': 'White Catfish',
+      'scientific_name': 'A. catus',
+      'class': 'fish'
+    }
+
+
+**Reptile**
+
+.. code-block:: python
+
+    >>> fake.reptile()
+    {
+      'common_name': 'Black Mamba',
+      'scientific_name': 'D. polylepis',
+      'class': 'reptiles'
+    }
+
+
+**Amphibian**
+
+.. code-block:: python
+
+    >>> fake.amphibian()
+    {
+      'common_name': 'Green Frog',
+      'scientific_name': 'Lithobates clamitans',
+      'class': 'amphibians'
+    }
+

--- a/faker/providers/animals/__init__.py
+++ b/faker/providers/animals/__init__.py
@@ -1,0 +1,1 @@
+from .animals import Provider

--- a/faker/providers/animals/animals.py
+++ b/faker/providers/animals/animals.py
@@ -1,0 +1,44 @@
+from faker.providers import BaseProvider
+from .constants import animals
+from random import choice
+
+class Provider(BaseProvider):
+
+    def animal(self,animal_class=None):
+        if animal_class:
+            filtered_animals = [animal for animal in animals if animal['class'] == animal_class]
+            animal = choice(filtered_animals)
+        else:
+            animal = choice(animals)
+        return animal
+
+    def animal_name(self):
+        animal = self.animal()
+        name = animal.get('common_name')
+        return name
+
+    def animal_name_scientific(self):
+        animal = self.animal()
+        scientific = animal.get('scientific_name')
+        return scientific
+
+    def bird(self):
+        animal = self.animal(animal_class='birds')
+        return animal
+
+    def fish(self):
+        animal = self.animal(animal_class='fish')
+        return animal
+
+    def mammal(self):
+        animal = self.animal(animal_class='mammals')
+        return animal
+
+    def reptile(self):
+        animal = self.animal(animal_class='reptiles')
+        return animal
+
+    def amphibian(self):
+        animal = self.animal(animal_class='amphibians')
+        return animal
+

--- a/faker/providers/animals/constants.py
+++ b/faker/providers/animals/constants.py
@@ -1,0 +1,9122 @@
+animals = [
+  {
+    'common_name': 'Adélie Penguin',
+    'scientific_name': 'Pygoscelis adeliae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'African Fish Eagle',
+    'scientific_name': 'Haliaeetus Vocifer',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'African Grey Parrot',
+    'scientific_name': 'Psittacus erithacus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'African Jacana',
+    'scientific_name': 'Actophilornis Africanus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'African Penguin',
+    'scientific_name': 'Spheniscus demersus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Albatross',
+    'scientific_name': 'Diomedeidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Amazon Parrot',
+    'scientific_name': 'Amazona',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Amazonian Royal Flycatcher',
+    'scientific_name': 'Animalia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'American Robin',
+    'scientific_name': 'Turdus migratorius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Anhinga',
+    'scientific_name': 'Anhinga anhinga',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Anna’s Hummingbird',
+    'scientific_name': 'Calypte anna',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Australian Firehawk',
+    'scientific_name': 'Accipitriformes & Falconiformes',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Avocet',
+    'scientific_name': 'Recurvirostra',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ayam Cemani',
+    'scientific_name': 'Ayam Cemani',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bald Eagle',
+    'scientific_name': 'haliaeetus leucocephalus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Barn Owl',
+    'scientific_name': 'Tyto alba',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Barn Swallow',
+    'scientific_name': 'Hirundo rustica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Barred Owl',
+    'scientific_name': 'Strix varia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Baya',
+    'scientific_name': 'Ploceus philippinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bearded Vulture',
+    'scientific_name': 'Gypaetus barbatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bee-Eater',
+    'scientific_name': 'Nyctyornis amictus, Merops pusillus, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Belgian Canary',
+    'scientific_name': 'Serinus canaria domestica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Belted Kingfisher',
+    'scientific_name': 'M. alcyon',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bird',
+    'scientific_name': 'Aves',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bird Of Paradise',
+    'scientific_name': 'Paradisaeidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Black and White Warbler',
+    'scientific_name': 'Mniotilta Varia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Black-Bellied Whistling Duck',
+    'scientific_name': 'Dendrocygna autumnalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Black-Capped Chickadee',
+    'scientific_name': 'P. atricapillus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blackburnian Warbler',
+    'scientific_name': 'Setophaga fusca',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blackpoll Warbler',
+    'scientific_name': 'Setophaga striata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blue Gray Gnatcatcher',
+    'scientific_name': 'Polioptila caerulea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blue grosbeak',
+    'scientific_name': 'Passerina caerulea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blue Jay',
+    'scientific_name': 'Cyanocitta cristata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Blue Tit',
+    'scientific_name': 'Cyanistes caeruleus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bobolink',
+    'scientific_name': 'Dolichonyx oryzivorus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Booby',
+    'scientific_name': 'Sula',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Bronze-winged Jacana',
+    'scientific_name': 'M. indicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Brown Headed Cowbird',
+    'scientific_name': 'Molothrus ater',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Budgerigar',
+    'scientific_name': 'Melopsittacus undulatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Burrowing Owl',
+    'scientific_name': 'Athene cunicularia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cactus Wren',
+    'scientific_name': 'Campylorhynchus Brunneicapillus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Canada Warbler',
+    'scientific_name': 'Cardellina canadensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cardinal',
+    'scientific_name': 'Cardinalis cardinalis, Piranga rubra, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Carolina Parakeet',
+    'scientific_name': '†Conuropsis carolinensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cassowary',
+    'scientific_name': 'Casuarius spp.',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cedar Waxwing',
+    'scientific_name': 'Bombycilla cedrorum',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chestnut-Sided Warbler',
+    'scientific_name': 'Setophaga Pensylvanica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chickadee',
+    'scientific_name': 'Paridae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chicken',
+    'scientific_name': 'Gallus gallus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chinese Geese',
+    'scientific_name': 'Anser cygnoides domesticus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chinstrap Penguin',
+    'scientific_name': 'Pygoscelis Antarcticus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Chipping Sparrow',
+    'scientific_name': 'Spizella passerina',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cinereous Vulture',
+    'scientific_name': 'Aegypius monachus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Clark’s Grebe',
+    'scientific_name': 'Aechmophorus clarkii',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cockatiel',
+    'scientific_name': 'Nymphicus hollandicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cockatoo',
+    'scientific_name': 'Cacatuidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Comb-crested Jacana',
+    'scientific_name': 'Irediparra gallinacea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Buzzard',
+    'scientific_name': 'Buteo buteo',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Grackle',
+    'scientific_name': 'Quiscalus quiscula',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Green Magpie',
+    'scientific_name': 'Cissa Chinensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Loon',
+    'scientific_name': 'Gavia Immer',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Raven',
+    'scientific_name': 'Corvus corax',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Common Yellowthroat',
+    'scientific_name': 'Geothlypis trichas',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Conure',
+    'scientific_name': 'Psittatus solstitialis, Aratinga nenday, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cooper’s Hawk',
+    'scientific_name': 'Accipiter cooperii',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cormorant',
+    'scientific_name': 'Phalacrocoracidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Costa’s Hummingbird',
+    'scientific_name': 'Calypte costae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Crane',
+    'scientific_name': 'Gruidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Crested Penguin',
+    'scientific_name': 'Eudyptes robustus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Crow',
+    'scientific_name': 'Corvus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Cuckoo',
+    'scientific_name': 'Cuculidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Dark-Eyed Junco',
+    'scientific_name': 'Junco',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Dark-Eyed Junco',
+    'scientific_name': '',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Dodo',
+    'scientific_name': 'Raphus cucullatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Downy Woodpecker',
+    'scientific_name': 'D. pubescens',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Dromornis stirtoni',
+    'scientific_name': 'Dromornis stirtoni',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Duck',
+    'scientific_name': 'Anatidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Dunnock',
+    'scientific_name': 'Prunella modularis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eagle',
+    'scientific_name': 'Accipitridae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eared Grebe',
+    'scientific_name': 'Podiceps nigricollis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eastern Bluebird',
+    'scientific_name': 'Sialia sialis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eastern Kingbird',
+    'scientific_name': 'Tyrannus tyrannus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eastern Meadowlark',
+    'scientific_name': 'Sturnella Magna',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eastern Phoebe',
+    'scientific_name': 'Sayornis phoebe',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eastern Turkey (Wild Turkey)',
+    'scientific_name': 'Meleagris gallopavo silvestris',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eclectus Parrot',
+    'scientific_name': 'Eclectus roratus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Egyptian Goose',
+    'scientific_name': 'Alopochen aegyptiacus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Egyptian Vulture',
+    'scientific_name': 'Neophron percnopterus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eider',
+    'scientific_name': 'S. mollissima, S. fischeri, S. spectabilis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Elegant Tern',
+    'scientific_name': 'Thalasseus elegans',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Elephant Bird',
+    'scientific_name': 'Aepyornithidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Elf Owl',
+    'scientific_name': 'Micrathene Whitneyi',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Emerald Toucanet',
+    'scientific_name': 'Aulacorhynchus prasinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Emperor Penguin',
+    'scientific_name': 'Aptenodytes forsteri',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Emu',
+    'scientific_name': 'Dromaius novaehollandiae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Bullfinch',
+    'scientific_name': 'Pyrrhula pyrrhula',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Collared Dove',
+    'scientific_name': 'Streptopelia decaocto',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Eagle-owl',
+    'scientific_name': 'Bubo bubo',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Jay',
+    'scientific_name': 'Garrulus glandarius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Nuthatch',
+    'scientific_name': 'Sitta europaea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Eurasian Sparrowhawk',
+    'scientific_name': 'Accipiter nisus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'European Bee-Eater',
+    'scientific_name': 'Merops apiaster',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'European Goldfinch',
+    'scientific_name': 'Carduelis carduelis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'European Robin',
+    'scientific_name': 'Erithacus rubecula',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'European Starling',
+    'scientific_name': 'Sturnus vulgaris',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Evening Grosbeak',
+    'scientific_name': 'Hesperiphona vespertina',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Fairy-Wren',
+    'scientific_name': 'Malurus Splendens, Malurus cyaneus, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Falcon',
+    'scientific_name': 'Falco',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ferruginous Hawk',
+    'scientific_name': 'Buteo regalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Finch',
+    'scientific_name': 'Fringillidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Flamingo',
+    'scientific_name': 'Phoenicopterus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Frigatebird',
+    'scientific_name': 'Fregata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Galapagos Penguin',
+    'scientific_name': 'Spheniscus Mendiculus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Gentoo Penguin',
+    'scientific_name': 'Pygoscelis papua',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Goldcrest',
+    'scientific_name': 'Regulus regulus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Golden Masked Owl',
+    'scientific_name': 'Tyto aurantia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Golden Oriole',
+    'scientific_name': 'Oriolus oriolus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Golden-Crowned Kinglet',
+    'scientific_name': 'Regulus Satrapa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Goose',
+    'scientific_name': 'Anatidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Goshawk',
+    'scientific_name': 'Accipiter gentilis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Gouldian Finch',
+    'scientific_name': 'Erythrura gouldiae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Gray Catbird',
+    'scientific_name': 'Dumetella carolinensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Great Blue Heron',
+    'scientific_name': 'Ardea herodias',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Great Crested Flycatcher',
+    'scientific_name': 'Myiarchus crinitus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Great Egret',
+    'scientific_name': 'Ardea alba',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Great Kiskadee',
+    'scientific_name': 'Pitangus sulphuratus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Great Potoo Bird',
+    'scientific_name': 'Nyctibius grandis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Grebe',
+    'scientific_name': 'Podilymbus podiceps, Tachybaptus ruficollis, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Green Bee-Eater',
+    'scientific_name': 'Merops orientalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Green Heron',
+    'scientific_name': 'Butorides virescens',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Grey Heron',
+    'scientific_name': 'Ardea cinerea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Griffon Vulture',
+    'scientific_name': 'Gyps fulvus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Grouse',
+    'scientific_name': 'Tetraoninae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Guinea Fowl',
+    'scientific_name': 'Numididae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hairy Woodpecker',
+    'scientific_name': 'Leuconotopicus villosus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Harpy Eagle',
+    'scientific_name': 'Harpia harpyja',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Harris’s Hawk',
+    'scientific_name': 'Parabuteo unicinctus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hawaiian Crow',
+    'scientific_name': 'Corvus Hawaiiensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hawaiian Goose (Nene)',
+    'scientific_name': 'Branta sandvicensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hawk',
+    'scientific_name': 'Buteo',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hepatic Tanager (Red Tanager)',
+    'scientific_name': 'Piranga Flava',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Heron',
+    'scientific_name': 'Ardeidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Herring Gull',
+    'scientific_name': 'Larus Smithsonianus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Honey Buzzard',
+    'scientific_name': 'Accipitridae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hooded Oriole',
+    'scientific_name': 'Icterus cucullatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hoopoe',
+    'scientific_name': 'Upupa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hornbill',
+    'scientific_name': 'Bucerotidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'House Finch',
+    'scientific_name': 'Haemorhous mexicanus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'House Sparrow (English Sparrow)',
+    'scientific_name': 'Passer domesticus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'House wren',
+    'scientific_name': 'Troglodytes aedon',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Humboldt Penguin',
+    'scientific_name': 'Spheniscus humboldti',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hummingbird',
+    'scientific_name': 'Trochilinae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Hyacinth Macaw',
+    'scientific_name': 'Anodorhynchus hyacinthinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ibis',
+    'scientific_name': 'Threskiornithidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ivory-billed woodpecker',
+    'scientific_name': 'Campephilus principalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Jabiru',
+    'scientific_name': 'Jabiru mycteria',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Jacana',
+    'scientific_name': 'Jacanidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Jackdaw',
+    'scientific_name': 'Corvidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Junglefowl',
+    'scientific_name': 'Gallus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kagu',
+    'scientific_name': 'Rhynochetos jubatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kakapo',
+    'scientific_name': 'Strigops habroptilus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kaua’i ‘Ō‘ō',
+    'scientific_name': 'Moho braccatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Keel-Billed Toucan',
+    'scientific_name': 'Ramphastos sulfuratus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kentucky Warbler',
+    'scientific_name': 'Geothlypis formosa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kestrel',
+    'scientific_name': 'Falco sparverius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Killdeer',
+    'scientific_name': 'Charadrius vociferus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'King Penguin',
+    'scientific_name': 'Aptenodytes patagonicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'King Quail',
+    'scientific_name': 'Synoicus chinensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'King Vulture',
+    'scientific_name': 'Sarcoramphus papa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kingfisher',
+    'scientific_name': 'Alcedines',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kiwi',
+    'scientific_name': 'Apteryx',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Kori Bustard',
+    'scientific_name': 'Ardeotis kori',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Lappet-faced Vulture',
+    'scientific_name': 'Torgos tracheliotos',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Laughing Kookaburra',
+    'scientific_name': 'Dacelo',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Least Flycatcher',
+    'scientific_name': 'Empidonax minimus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Lesser Jacana',
+    'scientific_name': 'Microparra capensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Lesser Scaup',
+    'scientific_name': 'Aythya affinis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Linnet',
+    'scientific_name': 'Linaria cannabina',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Little Penguin',
+    'scientific_name': 'Eudyptula Minor',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Long-Eared Owl',
+    'scientific_name': 'Casuarius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Long-Tailed Tit',
+    'scientific_name': 'Aegithalos caudatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Lorikeet',
+    'scientific_name': 'Psittaculidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Lyrebird',
+    'scientific_name': 'Menura',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Macaroni Penguin',
+    'scientific_name': 'Eudyptes Chrysolophus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Macaw',
+    'scientific_name': 'Arini',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'MacGillivray’s Warbler',
+    'scientific_name': 'Geothlypis tolmiei',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Madagascar Jacana',
+    'scientific_name': 'Actophilornis albinucha',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Magellanic Penguin',
+    'scientific_name': 'Spheniscus magellanicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Magnolia Warbler',
+    'scientific_name': 'Setophaga Magnolia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Magpie',
+    'scientific_name': 'Pica Pica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mallard',
+    'scientific_name': 'Anas platyrhynchos',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Marabou Stork',
+    'scientific_name': 'Leptoptilos crumenifer',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mexican Eagle (Northern crested caracara)',
+    'scientific_name': 'Caracara cheriway',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mississippi Kite',
+    'scientific_name': 'Ictinia mississippiensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mockingbird',
+    'scientific_name': 'Mimidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mountain Bluebird',
+    'scientific_name': 'Sialia currucoides',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mourning Dove',
+    'scientific_name': 'Zenaida macroura',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Mourning Warbler',
+    'scientific_name': 'Geothlypis philadephia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Muscovy Duck',
+    'scientific_name': 'Cairina moschata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Myna Bird',
+    'scientific_name': 'Sturnidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Nicobar pigeon',
+    'scientific_name': 'Caloenas nicobarica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Night Heron',
+    'scientific_name': 'Nycticorax nycticorax',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Nightingale',
+    'scientific_name': 'Luscinia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Nightjar',
+    'scientific_name': 'Caprimulgus ruficollis, Eurostopodus argus, and others',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Bobwhite',
+    'scientific_name': 'Colinus virginianus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Cardinal',
+    'scientific_name': 'Cardinalis cardinalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Flicker',
+    'scientific_name': 'C. Auratus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Jacana',
+    'scientific_name': 'Jacana Spinosa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Pintail',
+    'scientific_name': 'Anas acuta',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Potoo',
+    'scientific_name': 'Nyctibius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Northern Screamer',
+    'scientific_name': 'Chauna Chavaria',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Nuthatch',
+    'scientific_name': 'Sitta',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Orange-Crowned Warbler',
+    'scientific_name': 'Leiothlypis celata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Orchard Oriole',
+    'scientific_name': 'Icterus spurius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Oriental Dwarf Kingfisher',
+    'scientific_name': 'Ceyx erithaca',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ortolan Bunting',
+    'scientific_name': 'Emberiza hortulana',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Osprey',
+    'scientific_name': 'Pandion haliaetus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ostrich',
+    'scientific_name': 'Struthio camelus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ovenbird',
+    'scientific_name': 'Seiurus aurocapilla',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Owl',
+    'scientific_name': 'Strigiformes',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Oxpecker',
+    'scientific_name': 'Buphagus erythrorhyncus & Buphagus africanus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Painted Bunting',
+    'scientific_name': 'Passerina ciris',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Parakeet',
+    'scientific_name': 'Psittacidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Parrot',
+    'scientific_name': 'Psittacidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Parrotlet',
+    'scientific_name': 'Forpus cyanopygius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Partridge',
+    'scientific_name': 'Phasianidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Peacock',
+    'scientific_name': 'Pavo',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pelican',
+    'scientific_name': 'Pelecanus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Penguin',
+    'scientific_name': 'Aptenodytes Forsteri',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Peregrine Falcon',
+    'scientific_name': 'Falco peregrinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pesquet’s Parrot (Dracula Parrot)',
+    'scientific_name': 'Psittrichas fulgidus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pheasant-tailed Jacana',
+    'scientific_name': 'Hydrophasianus chirurgus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Phoenix Chicken',
+    'scientific_name': 'Gallus gallus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pied-Billed Grebe',
+    'scientific_name': 'Podilymbus podiceps',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pigeon',
+    'scientific_name': 'Columbidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pileated Woodpecker',
+    'scientific_name': 'Dryocopus pileatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pine Siskin',
+    'scientific_name': 'Spinus pinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Pink-Necked Green Pigeon',
+    'scientific_name': 'Treron Vernans',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Potoo',
+    'scientific_name': 'Nyctibius bracteatus, Nyctibius grandis, Nyctibius aethereus, Nyctibius leucopterus, Nyctibius maculosus, Nyctibius griseus, Nyctibius jamaicensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Prairie Chicken',
+    'scientific_name': 'Tetraonini',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Puffin',
+    'scientific_name': 'Fratercula arctica',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Purple Finch',
+    'scientific_name': 'Haemorhous purpureus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Purple Gallinule',
+    'scientific_name': 'Porphyrio martinicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Quail',
+    'scientific_name': 'Coturnix Coturnix',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Quetzal',
+    'scientific_name': 'Pharomachrus, Euptilotis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red Finch',
+    'scientific_name': 'Haemorhous mexicanus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red Kite',
+    'scientific_name': 'Milvus milvus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red-Bellied Woodpecker',
+    'scientific_name': 'M. carolinus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red-Billed Quelea Bird',
+    'scientific_name': 'Quelea quelea',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red-Shouldered Hawk',
+    'scientific_name': 'B. lineatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Red-winged blackbird',
+    'scientific_name': 'Agelaius phoeniceus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Redstart',
+    'scientific_name': 'Phoenicurus phoenicurus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Rhea',
+    'scientific_name': 'Rhea americana & Rhea pennata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ring-billed Gull',
+    'scientific_name': 'Larus delawarensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ringed Kingfisher',
+    'scientific_name': 'Megaceryle torquata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Robin',
+    'scientific_name': 'Muscicapidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Rockhopper Penguin',
+    'scientific_name': 'Eudyptes chrysocome',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Rooster',
+    'scientific_name': 'Gallus domesticus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Rose-Breasted Grosbeak',
+    'scientific_name': 'Pheucticus ludovicianus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Roseate Spoonbill',
+    'scientific_name': 'Ajaja ajaja',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Royal Penguin',
+    'scientific_name': 'Eudyptes schlegeli',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ruby-Crowned Kinglet',
+    'scientific_name': 'Corthylio Calendula',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ruby-Throated Hummingbird',
+    'scientific_name': 'Archilochus colubris',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ruddy Duck',
+    'scientific_name': 'Oxyura jamaicensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ruddy Turnstone',
+    'scientific_name': 'Arenaria interpres',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Rufous Hummingbird',
+    'scientific_name': 'Selasphorus rufus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sandhill Crane',
+    'scientific_name': 'A. canadensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sandpiper',
+    'scientific_name': 'Scolopacidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sarus Crane',
+    'scientific_name': 'Antigone antigone',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Savannah Sparrow',
+    'scientific_name': 'Passerculus sandwichensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Scale-Crested Pygmy Tyrant',
+    'scientific_name': 'Lophotriccus pileatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Scarlet Macaw',
+    'scientific_name': 'Ara macao',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Scissor-tailed Flycatcher',
+    'scientific_name': 'Tyrannus forficatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sea Eagle',
+    'scientific_name': 'Haliaeetus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Seagull',
+    'scientific_name': 'Larus argentatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sedge Warbler',
+    'scientific_name': 'Acrocephalus schoenobaenus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Senegal Parrot',
+    'scientific_name': 'Poicephalus senegalus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sharp-Shinned Hawk',
+    'scientific_name': 'Accipiter striatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Shoebill Stork',
+    'scientific_name': 'Balaeniceps rex',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Short-Eared Owl',
+    'scientific_name': 'Asio flammeus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Silkie Chicken',
+    'scientific_name': 'Gallus gallus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Skua',
+    'scientific_name': 'Stercorarius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Snow Bunting',
+    'scientific_name': 'P. nivalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Snow Goose',
+    'scientific_name': 'Anser caerulescens',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Snowy Owl',
+    'scientific_name': 'Bubo scandiacus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Song Sparrow',
+    'scientific_name': 'Melospiza melodia',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Song Thrush',
+    'scientific_name': 'Turdus philomelos',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sparrow',
+    'scientific_name': 'Passeridae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Sparrowhawk',
+    'scientific_name': 'Accipiter nisus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Spixs Macaw',
+    'scientific_name': 'Cyanopsitta spixii',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Stork',
+    'scientific_name': 'Ciconiidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Summer Tanager',
+    'scientific_name': 'Piranga Rubra',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Swainson’s Hawk',
+    'scientific_name': 'Buteo swainsoni',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Swallow',
+    'scientific_name': 'Tachycineta bicolor, Atticora fasciata, and more',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Swan',
+    'scientific_name': 'Cygnus atratus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tawny Frogmouth',
+    'scientific_name': 'Podargus strigoides',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tawny Owl',
+    'scientific_name': 'Strix aluco',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Thrush',
+    'scientific_name': 'Turdidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Toucan',
+    'scientific_name': 'Ramphastos',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Towhee',
+    'scientific_name': 'Pipilo erythrophthalmus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tree swallow',
+    'scientific_name': 'Tachycineta bicolor',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Treecreeper',
+    'scientific_name': 'Certhia familiarus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tropicbird',
+    'scientific_name': 'Phaethon',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tufted Coquette',
+    'scientific_name': 'Lophornis ornatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tufted Titmouse',
+    'scientific_name': 'B. bicolor',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Tundra Swan',
+    'scientific_name': 'Cygnus columbianus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Turaco',
+    'scientific_name': 'Corythaeola, Crinifer, Tauraco, Musophaga, Gallirex',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Turkey',
+    'scientific_name': 'Meleagris',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Turkey Vulture',
+    'scientific_name': 'Cathartes Aura',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Uguisu',
+    'scientific_name': 'Cettia diphone',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Umbrellabird',
+    'scientific_name': 'Cephalopterus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Ural owl',
+    'scientific_name': 'Strix uralensis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Veery',
+    'scientific_name': 'Catharus fuscescens',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Vermilion Flycatcher',
+    'scientific_name': 'Pyrocephalus obscurus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Vulture',
+    'scientific_name': 'Cathartes aura',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Wandering Albatross',
+    'scientific_name': 'Diomedea exulans',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Warbler',
+    'scientific_name': 'Passeriformes',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Wattled Jacana',
+    'scientific_name': 'Jacana Jacana',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Weaver Bird',
+    'scientific_name': 'Ploceus cucullatus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Western Kingbird',
+    'scientific_name': 'Tyrannus verticalis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Western Tanager',
+    'scientific_name': 'Piranga Ludoviciana',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Whimbrel',
+    'scientific_name': 'Numenius phaeopus, Numenius hudsonicus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Whinchat',
+    'scientific_name': 'Saxicola rebetra',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'White-Crowned Sparrow',
+    'scientific_name': 'Zonotrichia leucophrys',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'White-Tailed Eagle',
+    'scientific_name': 'Haliaeetus albicilla',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Whooping Crane',
+    'scientific_name': 'Grus americana',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Willow Flycatcher',
+    'scientific_name': 'Empidonax traillii',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Willow Warbler',
+    'scientific_name': 'Phylloscopus trochilus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Wood Duck',
+    'scientific_name': 'Aix sponsa',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Woodpecker',
+    'scientific_name': 'Picidae',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Wryneck',
+    'scientific_name': 'Jynx torquilla and Jynx ruficollis',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Xeme (Sabine’s Gull)',
+    'scientific_name': 'Xema Sabini',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Yellow Bellied Sapsucker',
+    'scientific_name': 'Sphyrapicus varius',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Yellow-Eyed Penguin',
+    'scientific_name': 'Megadyptes antipodes',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Yellowhammer',
+    'scientific_name': 'Emberiza citrinella',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Yokohama Chicken',
+    'scientific_name': 'Gallus gallus',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Zebra Finch',
+    'scientific_name': 'Taeniopygia guttata',
+    'class': 'birds'
+  },
+  {
+    'common_name': 'Alaskan Pollock',
+    'scientific_name': 'Gadus chalcogrammus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Albacore Tuna',
+    'scientific_name': 'Thunnus alalunga',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Alligator Gar',
+    'scientific_name': 'Atractosteus spatula',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Amano Shrimp',
+    'scientific_name': 'Caridina multidentata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Amberjack',
+    'scientific_name': 'Seriola',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'American Eel',
+    'scientific_name': 'Anguilla rostrata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'American Paddlefish',
+    'scientific_name': 'Polyodon spathula',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Anchovies',
+    'scientific_name': 'Engraulidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Angelfish',
+    'scientific_name': 'Pomacanthidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Anglerfish',
+    'scientific_name': 'Lophiiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Arapaima',
+    'scientific_name': 'Arapaima',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Archerfish',
+    'scientific_name': 'Labrus jaculator',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Arctic Char',
+    'scientific_name': 'Salvelinus alpinus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Asian Arowana',
+    'scientific_name': 'Scleropages formosus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Asian Carp',
+    'scientific_name': 'Dependent on species',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Atlantic Cod',
+    'scientific_name': 'Gadus morhua',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Atlantic Salmon',
+    'scientific_name': 'Salmo salar',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Atlantic Sturgeon',
+    'scientific_name': 'Acipenser oxyrinchus oxyrinchus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Australian Flathead Perch',
+    'scientific_name': 'Rainfordia opercularis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Banana Eel',
+    'scientific_name': 'Gymnothorax miliaris',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Banjo Catfish',
+    'scientific_name': 'Animalia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Barb',
+    'scientific_name': 'Barbus Barbus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Barracuda',
+    'scientific_name': 'Sphyraena',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Barramundi Fish',
+    'scientific_name': 'Lates calcarifer',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Barreleye Fish (Barrel Eye)',
+    'scientific_name': 'Macropinna microstoma',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Basking Shark',
+    'scientific_name': 'Cetorhinus Maximus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bass',
+    'scientific_name': 'Perciformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Batfish',
+    'scientific_name': 'Ogcocephalidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Beluga Sturgeon',
+    'scientific_name': 'Huso huso',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Beluga Sturgeon',
+    'scientific_name': '',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Betta Fish (Siamese Fighting Fish)',
+    'scientific_name': 'Betta splendens',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bigfin Reef Squid',
+    'scientific_name': 'Sepioteuthis lessoniana',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Black Bass',
+    'scientific_name': 'Micropterus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Black Marlin',
+    'scientific_name': 'Istiompax Indica',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blacknose Shark',
+    'scientific_name': 'Carcharhinus acronotus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bladefin Basslet',
+    'scientific_name': 'Jeboehlkia gladifer',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blobfish',
+    'scientific_name': 'Psychrolutes marcidus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blue Catfish',
+    'scientific_name': 'Ictalurus furcatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blue Eyed Pleco',
+    'scientific_name': 'Panaque cochliodon',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blue Shark',
+    'scientific_name': 'Prionace glauca',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Blue Tang',
+    'scientific_name': 'Acanthurus coeruleus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bluefin Tuna',
+    'scientific_name': 'Thunnus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bluegill',
+    'scientific_name': 'Lepomis macrochirus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bonefish',
+    'scientific_name': 'Albula vulpes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bonito Fish',
+    'scientific_name': 'Sarda',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bonnethead Shark',
+    'scientific_name': 'Sphyrna tiburo',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bowfin',
+    'scientific_name': 'Amia calva',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Boxfish',
+    'scientific_name': 'Ostracion cubicus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bronze Whaler Shark',
+    'scientific_name': 'Carcharhinus brachyurus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Brook Trout',
+    'scientific_name': 'S. forntinalis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Buffalo Fish',
+    'scientific_name': 'Species dependent',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Bull Trout',
+    'scientific_name': 'Salvelinus confluentus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Butterfly Fish',
+    'scientific_name': 'Chaetodontidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Carp',
+    'scientific_name': 'Cyprinidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Catfish',
+    'scientific_name': 'Siluriformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Chain Pickerel',
+    'scientific_name': 'Animalia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Chimaera',
+    'scientific_name': 'Chimaeraformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Chinese Paddlefish',
+    'scientific_name': 'Psephurus gladius',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Chinook Salmon',
+    'scientific_name': 'Oncorhynchus tshawytscha',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Cichlid',
+    'scientific_name': 'Herotilapia multispinosa',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Clearnose Skate',
+    'scientific_name': 'Rostroraja eglanteria',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Clownfish',
+    'scientific_name': 'Amphiprion',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Cobia Fish',
+    'scientific_name': 'Rachycentron canadum',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Codfish',
+    'scientific_name': 'Gadus spp.',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Coelacanth',
+    'scientific_name': 'Coelacanthiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Comb Jellyfish',
+    'scientific_name': 'Ctenophora',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Common Carp',
+    'scientific_name': 'Cyprinus Carpio',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Conger Eel',
+    'scientific_name': 'Conger',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Cookiecutter Shark',
+    'scientific_name': 'Isistius',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Cory Catfish',
+    'scientific_name': 'Corydoras',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Crappie Fish',
+    'scientific_name': 'Pomoxis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Cubera Snapper',
+    'scientific_name': 'Lutjanus cyanopterus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Damselfish',
+    'scientific_name': 'Pomacentridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Danios',
+    'scientific_name': 'Danio rerio',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Discus',
+    'scientific_name': 'Symphysodon',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Dragon Eel',
+    'scientific_name': 'Enchelycore pardalis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Dragonfish',
+    'scientific_name': 'Eurypegasus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Drum Fish',
+    'scientific_name': 'Sciaenidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Dusky Shark',
+    'scientific_name': 'Carcharhinus obscurus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Dwarf Gourami',
+    'scientific_name': 'Trichogaster lalius',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Eagle Ray',
+    'scientific_name': 'Aetomylaesus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Eel',
+    'scientific_name': 'Anguilliformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Eel catfish',
+    'scientific_name': 'Channallabes\xa0apus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Eelpout',
+    'scientific_name': 'Zoarcidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Electric Catfish',
+    'scientific_name': 'Malapteruridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Electric Eel',
+    'scientific_name': 'Electrophorus Electricus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Elephant Fish',
+    'scientific_name': 'Callorhinchus Milii',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ember Tetra',
+    'scientific_name': 'Hyphessobrycon amandae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Emperor Angelfish',
+    'scientific_name': 'P. imperator',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Escolar',
+    'scientific_name': 'Lepidocybium flavobrunneum',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Fangtooth',
+    'scientific_name': 'Anoplogaster spp.',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Fire Eel',
+    'scientific_name': 'Mastacembelus erythrotaenia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Fish',
+    'scientific_name': 'Chordata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Flathead Catfish',
+    'scientific_name': 'Pylodictis olivaris',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Florida Gar',
+    'scientific_name': 'Lepisosteus platyrhincus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Flounder',
+    'scientific_name': 'Paralichthys',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Flounder Fish',
+    'scientific_name': 'Paralichthys',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Flowerhorn Fish',
+    'scientific_name': 'Cichlidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Fluke Fish (summer flounder)',
+    'scientific_name': 'Paralichthys dentatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Flying Fish',
+    'scientific_name': 'Exocoetidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Football Fish',
+    'scientific_name': 'Himantolophus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Freshwater Drum',
+    'scientific_name': 'Aplodinotus grunniens',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Freshwater Eel',
+    'scientific_name': 'Anguilla anguilla',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Freshwater Jellyfish',
+    'scientific_name': 'Craspedacusta sowerbyi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Freshwater Sunfish',
+    'scientific_name': 'Centrarchus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Frilled Shark',
+    'scientific_name': 'Chlamydoselachus anguineus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Frogfish',
+    'scientific_name': 'Antennariidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Galapagos Shark',
+    'scientific_name': 'Carcharhinus galapagensis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Gar',
+    'scientific_name': 'Lepisosteidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Garden Eel',
+    'scientific_name': 'Congridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ghost Catfish',
+    'scientific_name': 'Kryptopterus vitreolus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Giant Trevally',
+    'scientific_name': 'Caranx ignobilis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Goblin Shark',
+    'scientific_name': 'Mitsukurina owstoni',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Goby Fish',
+    'scientific_name': 'Gobiidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Golden Shiner',
+    'scientific_name': 'Notemigonus crysoleucas',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Golden Trout',
+    'scientific_name': 'Oncorhynchus aguabonita',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Goldfish',
+    'scientific_name': 'Carassius auratus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Goliath Tigerfish',
+    'scientific_name': 'Hydrocynus goliath',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Goonch Catfish',
+    'scientific_name': 'Bagarius yarrelli',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Gourami',
+    'scientific_name': 'Osphronemidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Grass Carp',
+    'scientific_name': 'Ctenopharyngodon idella',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Great Hammerhead Shark',
+    'scientific_name': 'Sphyrna mokarran',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Great White Shark',
+    'scientific_name': 'Carcharodon carcharias',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Green Sunfish',
+    'scientific_name': 'Lepomis cyanellus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Greenland Shark',
+    'scientific_name': 'Somniosus microcephalus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Grey Reef Shark',
+    'scientific_name': 'Carcharhinus Amblyrhynchos',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Grunion',
+    'scientific_name': 'Leuresthes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Guadalupe Bass',
+    'scientific_name': 'Micropterus treculii',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Gulper Catfish',
+    'scientific_name': 'Asterophysus batrachus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Gulper Eel',
+    'scientific_name': 'Eurypharynx pelecanoides',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Guppy',
+    'scientific_name': 'Poecilia reticulata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Haddock',
+    'scientific_name': 'Melanogrammus aeglefinus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Hagfish',
+    'scientific_name': 'Myxinidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Haikouichthys',
+    'scientific_name': 'Haikouichthys ercaicunensis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Hairy Frogfish',
+    'scientific_name': 'Antennarius striatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Halibut',
+    'scientific_name': 'stenolepis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Hammerhead Shark',
+    'scientific_name': 'Sphyrnidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Hardhead Catfish',
+    'scientific_name': 'Ariopsis felis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Herring',
+    'scientific_name': 'Clupea',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Hogfish',
+    'scientific_name': 'Lachnolaimus maximus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Horn Shark',
+    'scientific_name': 'Heterodontus francisci',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Horse Mackerel',
+    'scientific_name': 'Trachurus Trachurus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Immortal Jellyfish',
+    'scientific_name': 'Turritopsis dohrnii',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Irukandji Jellyfish',
+    'scientific_name': 'C. barnesi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Jack Crevalle',
+    'scientific_name': 'Caranx hippos',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Jellyfish',
+    'scientific_name': 'Cyaneidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'John Dory',
+    'scientific_name': 'Zeus faber',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kaluga Sturgeon',
+    'scientific_name': 'Huso dauricus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kelp Greenling',
+    'scientific_name': 'Hexagrammos decagrammus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Keta Salmon',
+    'scientific_name': 'Oncorhynchus keta',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Keyhole Cichlid',
+    'scientific_name': 'Cleithracara maronii',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Killifish',
+    'scientific_name': 'Cyprinodontiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'King Mackerel',
+    'scientific_name': 'Scomberomorus cavalla',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'King Salmon',
+    'scientific_name': 'Oncorhynchus tshawytscha',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kingklip',
+    'scientific_name': 'Genypterus capensis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kissing Gourami',
+    'scientific_name': 'Helostoma temminckii',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kitefin Shark',
+    'scientific_name': 'Dalatias licha',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Knifefish',
+    'scientific_name': 'Gymnotiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Koi Fish',
+    'scientific_name': 'Cyprinus rubrofuscus "koi"',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Kokanee Salmon',
+    'scientific_name': 'Oncorhynchus nerka',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Krill',
+    'scientific_name': 'Euphausiacea',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Labout’s Fairy Wrasse',
+    'scientific_name': 'Cirrhilabrus laboutei',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lake Sturgeon',
+    'scientific_name': 'Acipenser fulvescens',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lake Trout',
+    'scientific_name': 'Salvelinus namaycush',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lamprey',
+    'scientific_name': 'Petromyzontiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lancetfish',
+    'scientific_name': 'Alepisaurus ferox',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Largemouth Bass',
+    'scientific_name': 'M. salmoides',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lawnmower Blenny',
+    'scientific_name': 'Salarias fasciatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Leopard Shark',
+    'scientific_name': 'Triakis semifasciata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Leptocephalus',
+    'scientific_name': 'Leptocephalus brevirostris',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lionfish',
+    'scientific_name': 'Pterois volitans',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lizardfish',
+    'scientific_name': 'Synodus lucioceps',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Loach',
+    'scientific_name': 'Cypriniformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Longfin Mako Shark',
+    'scientific_name': 'Isurus paucus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Longnose Gar',
+    'scientific_name': 'Lepisosteus osseus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lumpfish',
+    'scientific_name': 'Cyclopterus lumpus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Lungfish',
+    'scientific_name': 'Dipnoi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mahi Mahi (Dolphin Fish)',
+    'scientific_name': 'Coryphaena hippurus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mangrove Snapper',
+    'scientific_name': 'Lutjanus griseus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Manta Ray',
+    'scientific_name': 'Manta',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Masked Angelfish',
+    'scientific_name': 'G. personatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mayan Cichlid',
+    'scientific_name': 'Mayheros urophthalmus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Megalodon',
+    'scientific_name': 'Otodus megalodon',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Megamouth Shark',
+    'scientific_name': 'Megachasma pelagios',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mekong Giant Catfish',
+    'scientific_name': 'Pangasianodon gigas',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Milkfish',
+    'scientific_name': 'Chanos chanos',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mojarra',
+    'scientific_name': 'Gerreidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mola mola (Ocean Sunfish)',
+    'scientific_name': 'Mola mola',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Molly',
+    'scientific_name': 'Poecilia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Monkfish',
+    'scientific_name': 'Lophius spp.',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Moon Jellyfish',
+    'scientific_name': 'Aurelia aurita',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Moray Eel',
+    'scientific_name': 'Muraenidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mudskipper',
+    'scientific_name': 'Oxudercidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Mullet Fish',
+    'scientific_name': 'Mugil cephalus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Muskellunge (Muskie)',
+    'scientific_name': 'Esox masquinongy',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Needlefish',
+    'scientific_name': 'Platybelone argalus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Neon Tetra',
+    'scientific_name': 'Paracheirodon innesi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Neptune Grouper',
+    'scientific_name': 'Cephalopholis igarashiensis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Oarfish',
+    'scientific_name': 'Regalecus glesne',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ocean Perch',
+    'scientific_name': 'Sebastes alutus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ocean Pout',
+    'scientific_name': 'Zoarces americanus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ocean Whitefish',
+    'scientific_name': 'Caulolatilus princeps',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Oilfish',
+    'scientific_name': 'Ruvettus pretiosus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Opah',
+    'scientific_name': 'Lampris guttatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Opaleye (Rudderfish)',
+    'scientific_name': 'Girella nigricans',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Orange Roughy',
+    'scientific_name': 'Hoplostethus atlanticus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Orchid Dottyback',
+    'scientific_name': 'Pseudochromis fridmani',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Oscar Fish',
+    'scientific_name': 'Astronotus ocellatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Oyster Toadfish',
+    'scientific_name': 'Opsanus tau',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Ozark Bass',
+    'scientific_name': 'Ambloplites constellatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pacific Sleeper Shark',
+    'scientific_name': 'Somniosus pacificus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Paddlefish',
+    'scientific_name': 'Polyodontidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Parrotfish',
+    'scientific_name': 'scaridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pea Puffer',
+    'scientific_name': 'Carinotetraodon travancoricus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Peacock Bass',
+    'scientific_name': 'Cichla ocellaris',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Peppermint Angelfish',
+    'scientific_name': 'Centropyge boylei',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Perch Fish',
+    'scientific_name': 'Perca fluviatilis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pictus Catfish',
+    'scientific_name': 'Pimelodus pictus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pike Fish',
+    'scientific_name': 'Esox spp.',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pinfish',
+    'scientific_name': 'Lagodon rhomboides',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pink Salmon',
+    'scientific_name': 'Oncorhynchus gorbuscha',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pipefish',
+    'scientific_name': 'Syngnathinae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Piranha',
+    'scientific_name': 'Characidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Platinum Arowana',
+    'scientific_name': 'Scleropages formosus, Osteoglossum bicirrhosum, Scleropages formosus, Scleropages inscriptus, Scleropages jardinii, Scleropages leichardti',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pollock Fish',
+    'scientific_name': 'Pollachius',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pompano Fish',
+    'scientific_name': 'Trachinotus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Porbeagle Shark',
+    'scientific_name': 'Lamna nasus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Porcupinefish',
+    'scientific_name': 'Diodon hystrix',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pufferfish',
+    'scientific_name': 'Tetraodontidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pygmy Shark',
+    'scientific_name': 'Euprotomicrus bispinatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Pyjama Shark',
+    'scientific_name': 'Poroderma africanum',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Rainbow Kribs (Kribensis)',
+    'scientific_name': 'Pelvicachromis pulcher',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Rainbow Shark',
+    'scientific_name': 'Epalzeorhynchos frenatum',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Red Drum Fish',
+    'scientific_name': 'Sciaenops ocellatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Red-Lipped Batfish',
+    'scientific_name': 'Ogcocephalus darwini',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Redear Sunfish',
+    'scientific_name': 'Animalia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Redhump Eartheater',
+    'scientific_name': 'Geophagus steindachneri',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Redtail Catfish',
+    'scientific_name': 'Phractocephalus hemioliopterus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Reef Shark',
+    'scientific_name': 'Carcharhinidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Rockfish',
+    'scientific_name': 'Scorpaeniformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sailfish',
+    'scientific_name': 'Istiophorus platypterus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Salmon',
+    'scientific_name': 'Salmonidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Salmon Shark',
+    'scientific_name': 'Lamna ditropis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sand Tiger Shark',
+    'scientific_name': 'Odontaspididae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sardines',
+    'scientific_name': 'Clupeidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sawfish',
+    'scientific_name': 'Pristidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Scorpion Fish',
+    'scientific_name': 'Scorpaenidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sculpin',
+    'scientific_name': 'Cottus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sea Dragon',
+    'scientific_name': 'Phycodurus eques',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sea Slug',
+    'scientific_name': 'Nudibranchia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sea Trout',
+    'scientific_name': 'Salmo trutta morpha trutta',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sea Urchin',
+    'scientific_name': 'Echinoidea',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Seahorse',
+    'scientific_name': 'Hippocampus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Shark',
+    'scientific_name': 'Chondrichthyes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sheepshead Fish',
+    'scientific_name': 'Archosargus probatocephalus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Shortfin Mako Shark',
+    'scientific_name': 'Isurus oxyrinchus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Silky Shark',
+    'scientific_name': 'C. falciformis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Silver Dollar',
+    'scientific_name': 'Characidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sixgill shark',
+    'scientific_name': 'Hexanchus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Skate Fish',
+    'scientific_name': 'Rajidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Skipjack Tuna',
+    'scientific_name': 'Katsuwonus pelamis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sleeper Shark',
+    'scientific_name': 'Somniosidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Smallmouth Bass',
+    'scientific_name': 'Micropterus dolomieu',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Smooth Hammerhead Shark',
+    'scientific_name': 'Sphyrna zygaena',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Snailfish',
+    'scientific_name': 'Liparidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Snook Fish',
+    'scientific_name': 'Centropomus undecimalis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Snowflake Eel',
+    'scientific_name': 'Echidna nebulosa',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sockeye Salmon',
+    'scientific_name': 'Oncorhynchus nerka',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Spanish Mackerel',
+    'scientific_name': 'Scombridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Speckled Trout',
+    'scientific_name': 'Cynoscion nebulosus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Spinner Shark',
+    'scientific_name': 'Carcharhinus brevipinna',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Spiny Dogfish',
+    'scientific_name': 'Squalus acanthias',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sponge',
+    'scientific_name': 'Demospongiae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Spotted Gar',
+    'scientific_name': 'Lepisosteus oculatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Spotted Garden Eel',
+    'scientific_name': 'heteroconger hassi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Squirrelfish',
+    'scientific_name': 'Holocentrus adscensionis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Starfish',
+    'scientific_name': 'Asteroidea',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Stargazer Fish',
+    'scientific_name': 'Uranoscopus scaber',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Steelhead Salmon',
+    'scientific_name': 'Oncorhynchus mykiss',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Stingray',
+    'scientific_name': 'Myliobatiformes',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Stonefish',
+    'scientific_name': 'Synanceia',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Stoplight Loosejaw',
+    'scientific_name': 'Malacosteus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Striped Bass',
+    'scientific_name': 'Morone saxatilis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Sturgeon',
+    'scientific_name': 'Acipenseridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Suckerfish',
+    'scientific_name': 'Catostomidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Surgeonfish',
+    'scientific_name': 'Acanthuridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Swai Fish',
+    'scientific_name': 'Pangasianodon hypophthalmus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Swordfish',
+    'scientific_name': 'Xiphias gladius',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Taimen Fish',
+    'scientific_name': 'Hucho Taimen',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tang',
+    'scientific_name': 'Acanthuridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tarpon',
+    'scientific_name': 'Megalops',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Telescope Fish',
+    'scientific_name': 'Gigantura',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tetra',
+    'scientific_name': 'Paracheirodon Axelrodi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Thornback Ray',
+    'scientific_name': 'Raja clavata',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Thresher Shark',
+    'scientific_name': 'Alopias',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tiger Muskellunge (Muskie)',
+    'scientific_name': 'Esox lucius x Esox masquinongy',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tiger Shark',
+    'scientific_name': 'Galeocerdo Cuvier',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tiger Trout',
+    'scientific_name': 'Salmonidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tire Track Eel',
+    'scientific_name': 'Mastacembelus armatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Toadfish',
+    'scientific_name': 'Batrachoididae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Triggerfish',
+    'scientific_name': 'Balistidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Trout',
+    'scientific_name': 'Salmo, Oncorhynchus, Salvelinus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Tuna',
+    'scientific_name': 'Scombridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Uaru Cichlid',
+    'scientific_name': 'Uaru amphiacanthoides',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Urechis unicinctus (Penis Fish)',
+    'scientific_name': 'Urechis unicinctus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Viper Shark (dogfish)',
+    'scientific_name': 'Trigonognathus kabeyai',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Viperfish',
+    'scientific_name': 'Chauliodus sp.',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wahoo Fish',
+    'scientific_name': 'Acanthocybium solandri',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Walking Catfish',
+    'scientific_name': 'Clarias batrachus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Walleye Fish',
+    'scientific_name': 'Sander vitreus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wels Catfish',
+    'scientific_name': 'Silurus glanis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Whale Shark',
+    'scientific_name': 'Rhincodon Typus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'White Bass',
+    'scientific_name': 'Morone chrysops',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'White Catfish',
+    'scientific_name': 'A. catus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'White Crappie',
+    'scientific_name': 'Pomoxis annularis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'White Sturgeon',
+    'scientific_name': 'Acipenser transmontanus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Whiting',
+    'scientific_name': 'Merlangius merlangus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wolf Eel',
+    'scientific_name': 'Anarrhichthys ocellatus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wolffish',
+    'scientific_name': 'Anarhichadidae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wrasse',
+    'scientific_name': 'Labridae',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Wrought Iron Butterflyfish',
+    'scientific_name': 'Chaetodon daedalma',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Xingu River Ray',
+    'scientific_name': 'Potamotrygon leopoldi',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Xiphactinus',
+    'scientific_name': 'Xiphactinus audax',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellow Bass',
+    'scientific_name': 'Morone mississippiensis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellow Bullhead Catfish',
+    'scientific_name': 'Ameiurus Natalis',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellow Perch',
+    'scientific_name': 'Perca flavescens',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellow Tang',
+    'scientific_name': 'Zebrasoma flavescens',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellowfin Tuna',
+    'scientific_name': 'Thunnus albacares',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Yellowtail Snapper',
+    'scientific_name': 'Ocyurus chrysurus',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Zebra Pleco',
+    'scientific_name': 'Hypancistrus zebra',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Zebra Shark',
+    'scientific_name': 'Stegostoma Fasciatum',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Zebrafish (Zebra Fish)',
+    'scientific_name': 'Danio rerio',
+    'class': 'fish'
+  },
+  {
+    'common_name': 'Aardvark',
+    'scientific_name': 'Orycteropus afer',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aardwolf',
+    'scientific_name': 'Proteles cristata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Abyssinian',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Addax',
+    'scientific_name': 'Addax nasomaculatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Affenpinscher',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Afghan Hound',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Bush Elephant',
+    'scientific_name': 'Loxodonta africana africana',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Civet',
+    'scientific_name': 'Civettictis civetta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Forest Elephant',
+    'scientific_name': 'Loxodonta cyclotis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Golden Cat',
+    'scientific_name': 'Caracal aurata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Palm Civet',
+    'scientific_name': 'Nandinia binotata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'African Wild Dog',
+    'scientific_name': 'Lycaon pictus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Agouti',
+    'scientific_name': 'Dasyprocta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aidi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ainu',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Airedale Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Airedoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Akbash',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Akita',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Akita Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alabai (Central Asian Shepherd)',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alaskan Husky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alaskan Klee Kai',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alaskan Malamute',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alaskan Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alpaca',
+    'scientific_name': 'Vicugna pacos',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alpine Dachsbracke',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alpine Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Alusky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Amazon River Dolphin (Pink Dolphin)',
+    'scientific_name': 'Platanistoidea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Alsatian',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Bulldog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Cocker Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Coonhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Eskimo Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Foxhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Hairless Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Leopard Hound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Pit Bull Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Pygmy Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Staffordshire Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'American Water Spaniel',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Amur Leopard',
+    'scientific_name': 'Panthera pardus orientalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Anatolian Shepherd Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Angora Ferret',
+    'scientific_name': 'Mustela furo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Angora Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Anteater',
+    'scientific_name': 'Myrmecophaga Tridactyla',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Antelope',
+    'scientific_name': 'Bovidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ape',
+    'scientific_name': 'Hominoidea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Appenzeller Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Apple Head Chihuahua',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Arctic Fox',
+    'scientific_name': 'Vulpes lagopus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Arctic Hare',
+    'scientific_name': 'Lepus Arcticus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Arctic Wolf',
+    'scientific_name': 'Canus Lupus Arcticus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Armadillo',
+    'scientific_name': 'Dasypodidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Asian Elephant',
+    'scientific_name': 'Elephas maximus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Asian Palm Civet',
+    'scientific_name': 'Paradoxurus hermaphroditus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Asiatic Black Bear',
+    'scientific_name': 'Ursus tibetanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aurochs',
+    'scientific_name': 'Bos',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aussiedoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aussiedor',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Bulldog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Cattle Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Kelpie Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Labradoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Mist',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Australian Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Axolotl',
+    'scientific_name': 'Ambystoma mexicanum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Aye-aye',
+    'scientific_name': 'Daubentonia madagascariensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Babirusa',
+    'scientific_name': 'Babyrousa spp.',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Baboon',
+    'scientific_name': 'Papio',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bactrian Camel',
+    'scientific_name': 'Camelus Bactrianus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Badger',
+    'scientific_name': 'Taxidea Taxus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Baleen Whale',
+    'scientific_name': 'Mysticeti',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Balinese',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Balkan Lynx',
+    'scientific_name': 'Lynx lynx balcanicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Banded Palm Civet',
+    'scientific_name': 'Hemigalus Derbyanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bandicoot',
+    'scientific_name': 'Perameles',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Barbet',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Basenji Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bassador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Basset Fauve de Bretagne',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Basset Hound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bassetoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bat',
+    'scientific_name': 'Chiroptera',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bat-Eared Fox',
+    'scientific_name': 'Otocyon megalotis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bavarian Mountain Hound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bea-Tzu',
+    'scientific_name': 'Canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beabull',
+    'scientific_name': 'Canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beagador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beagle Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beaglier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beago',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bear',
+    'scientific_name': 'Ursidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bearded Collie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beaski',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beauceron',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beaver',
+    'scientific_name': 'Castor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bedlington Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Beefalo',
+    'scientific_name': 'Bos taurus × Bison bison',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Belgian Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Belgian Tervuren',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bengal Tiger',
+    'scientific_name': 'Panthera Tigris Tigris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bergamasco',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Berger Picard',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bernedoodle',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bernese Mountain Dog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bernese Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bhutan Takin',
+    'scientific_name': 'Budorcas taxicolor whitei',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bichon Frise',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bichpoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Biewer Terrier',
+    'scientific_name': 'Canis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bighorn Sheep',
+    'scientific_name': 'Ovis canadensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bilby',
+    'scientific_name': 'Macrotis lagotis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Binturong',
+    'scientific_name': 'Arctictis binturong',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Birman',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bison',
+    'scientific_name': 'Bison Bison',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Black And Tan Coonhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Black Rhinoceros',
+    'scientific_name': 'Diceros Bicornis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Black Russian Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Black-Footed Ferret',
+    'scientific_name': 'Mustela nigripes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bloodhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Blue Lacy Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Blue Picardy Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Blue Whale',
+    'scientific_name': 'Balaenoptera musculus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bluetick Coonhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bobcat',
+    'scientific_name': 'Lynx rufus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boer Goat',
+    'scientific_name': 'Capra hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boggle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boglen Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bolognese Dog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bombay',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bongo',
+    'scientific_name': 'Tragelaphus eurycerus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bonobo',
+    'scientific_name': 'Pan paniscus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Borador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Border Collie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Border Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bordoodle',
+    'scientific_name': 'Mammalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Borkie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bornean Orangutan',
+    'scientific_name': 'Pongo pygmaeus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Borneo Elephant',
+    'scientific_name': 'Elephas maximus borneensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boston Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bottlenose Dolphin',
+    'scientific_name': 'Tursiops Truncatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bouvier Des Flandres',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bowhead Whale',
+    'scientific_name': 'Balaena mysticetus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boxador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boxer Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boxerdoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boxsky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boxweiler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Boykin Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brazilian Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'British Timber',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brittany',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brown Bear',
+    'scientific_name': 'Ursus arctos',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brown Hyena',
+    'scientific_name': 'Hyaena brunnea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brug',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Brussels Griffon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Buffalo',
+    'scientific_name': 'Syncerus caffer',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bull Shark',
+    'scientific_name': 'Carcharhinus Leucas',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bull Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bulldog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bullmastiff',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Burmese',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Bush Baby',
+    'scientific_name': 'Galagidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cactus Mouse',
+    'scientific_name': 'Peromyscus erimicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cairn Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Camel',
+    'scientific_name': 'Camelus dromedarius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Canaan Dog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Canada Lynx',
+    'scientific_name': 'Lynx canadensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Canadian Eskimo Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Canadian Horse',
+    'scientific_name': 'Equus ferus caballus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cane Corso',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cape Lion',
+    'scientific_name': 'Panthera leo melanochaitus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Capybara',
+    'scientific_name': 'Hydrochoerus hydrochaeris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Caracal',
+    'scientific_name': 'Caracal Caracal',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Caribou',
+    'scientific_name': 'Rangifer tarandus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Carolina Dog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cashmere Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cat',
+    'scientific_name': '',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Catahoula Leopard',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Catalan Sheepdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cava Tzu',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cavador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cavalier King Charles Spaniel',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cavapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cesky Fousek',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cesky Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chamois',
+    'scientific_name': 'Rupicapra rupicapra',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chartreux',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cheagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cheetah',
+    'scientific_name': 'Acinonyx jubatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chesapeake Bay Retriever',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chihuahua',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chimpanzee',
+    'scientific_name': 'Pan troglodytes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chinchilla',
+    'scientific_name': 'Chinchilla Lanigera',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chinese Crested Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chinese Shar-Pei',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chinook',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chipmunk',
+    'scientific_name': 'Sciuridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chipoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chiweenie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chorkie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chow Chow',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Chow Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cinnamon Bear',
+    'scientific_name': 'U. a. cinnamomum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cinnamon Ferret',
+    'scientific_name': 'Mustela furo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Clouded Leopard',
+    'scientific_name': 'Neofelis nebulosa',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Clumber Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Coati',
+    'scientific_name': 'Nasua nasua',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cockalier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cockapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cocker Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Collared Peccary',
+    'scientific_name': 'Pecari tajacu',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Collie',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Common Spotted Cuscus',
+    'scientific_name': 'Phalanger maculatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Common Toad',
+    'scientific_name': 'Bufo Bufo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Corgidor',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Corgipoo',
+    'scientific_name': 'Mammalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Corkie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Corman Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Corn Rex Cat (Cornish Rex)',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Coton de Tulear',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cotton-top Tamarin',
+    'scientific_name': 'Saguinus Oedipus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Coues Deer',
+    'scientific_name': 'Odocoileus virginianus couesi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cougar',
+    'scientific_name': 'Felis Concolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cow',
+    'scientific_name': 'Bos Taurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Coyote',
+    'scientific_name': 'Canis latrans',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Crab-Eating Fox',
+    'scientific_name': 'Cerdocyon thous',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Crab-Eating Macaque',
+    'scientific_name': 'Macaca Fascicularis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Crabeater Seal',
+    'scientific_name': 'Lobodon carcinophaga',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cross Fox',
+    'scientific_name': 'Vulpes vulpes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Cross River Gorilla',
+    'scientific_name': 'Gorilla gorilla diehli',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Curly Coated Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Czechoslovakian Wolfdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dachsador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dachshund',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dalmadoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dalmador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dalmatian',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dapple Dachshund',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Darwin’s fox',
+    'scientific_name': 'Lycalopex fulvipes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Deer',
+    'scientific_name': 'Odocoileus virginiana',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Deer Head Chihuahua',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Deer Mouse',
+    'scientific_name': 'Peromyscus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Deutsche Bracke',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Devon Rex',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dhole',
+    'scientific_name': 'Cuon alpinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dik-Dik',
+    'scientific_name': 'Madoqua',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Diminutive Woodrat',
+    'scientific_name': 'Nelsonia goldmani goldmani, Nelsonia goldmani cliftoni, Nelsonia neotomodon',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dingo',
+    'scientific_name': 'Canis Lupus Dingo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Doberman Pinscher',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dog',
+    'scientific_name': '',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dogo Argentino',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dogue De Bordeaux',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dolphin',
+    'scientific_name': 'Delphinidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Donkey',
+    'scientific_name': 'Equus Asinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dorgi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dorkie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dormouse',
+    'scientific_name': 'Gliridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Double Doodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Douc',
+    'scientific_name': 'Pygathrix',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Doxiepoo',
+    'scientific_name': 'Mammalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Doxle',
+    'scientific_name': 'canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Drever',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dugong',
+    'scientific_name': 'Dugong Dugon',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dunker',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dusky Dolphin',
+    'scientific_name': 'Lagenorhynchus obscurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Dwarf Hamster',
+    'scientific_name': 'Cricetulus barabensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eastern Barred Bandicoot',
+    'scientific_name': 'Perameles gunnii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eastern Chipmunk',
+    'scientific_name': 'Tamias striatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eastern Gorilla',
+    'scientific_name': 'Gorilla berengei',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eastern Lowland Gorilla',
+    'scientific_name': 'Gorilla Berengei Graueri',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Echidna',
+    'scientific_name': 'Tachyglossus Aculeatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Egyptian Mau',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eland',
+    'scientific_name': 'Taurotragus oryx',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Elasmotherium',
+    'scientific_name': '†Elasmotherium sibiricum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Elephant',
+    'scientific_name': 'Elephantidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Elephant Seal',
+    'scientific_name': 'Mirounga',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Elephant Shrew',
+    'scientific_name': 'Elephantulus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Elk',
+    'scientific_name': 'Cervus canadensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Emperor Tamarin',
+    'scientific_name': 'Saguinus Imperator',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Angora Rabbit',
+    'scientific_name': 'Oryctolagus cuniculus domesticus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Bulldog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Cocker Spaniel',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Cream Golden Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Foxhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Pointer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Setter',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'English Springer Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Entlebucher Mountain Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Epagneul Pont Audemer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ermine',
+    'scientific_name': 'Mustela erminea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eskimo Dog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eskipoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Estrela Mountain Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eurasian Beaver',
+    'scientific_name': 'Castor fiber',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eurasian Lynx',
+    'scientific_name': 'Lynx lynx',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Eurasian Wolf',
+    'scientific_name': 'Canis lupus lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'European Polecat',
+    'scientific_name': 'Mustela putorius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'European Wildcat',
+    'scientific_name': 'Felis catus silvestris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Evening Bat',
+    'scientific_name': 'Nycticeius humeralis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fainting Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fallow deer',
+    'scientific_name': 'Dama dama',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'False Killer Whale',
+    'scientific_name': 'Pseudorca crassidens',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Feist',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fennec Fox',
+    'scientific_name': 'Vulpes zerda',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ferret',
+    'scientific_name': 'Mustela furo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Field Spaniel',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fila Brasileiro',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fin Whale',
+    'scientific_name': 'Balaenoptera Physalus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Finnish Spitz',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fisher',
+    'scientific_name': 'Pekania pennanti',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fishing Cat',
+    'scientific_name': 'Prionailurus viverrinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Flat-Coated Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Florida Mouse',
+    'scientific_name': 'Podomys floridanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Florida Panther',
+    'scientific_name': 'Puma concolor couguar',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Flying Lemur',
+    'scientific_name': 'Cynocephalidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Flying Squirrel',
+    'scientific_name': 'Pteromyini',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Formosan Mountain Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fossa',
+    'scientific_name': 'Cryptoprocta ferox',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fox',
+    'scientific_name': 'Vulpes vulpes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fox Squirrel',
+    'scientific_name': 'Sciurus niger',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fox Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'French Bulldog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Frenchton',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Frengle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fruit Bat',
+    'scientific_name': 'Pteropodidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Fur Seal',
+    'scientific_name': 'Arctocephalinae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gazelle',
+    'scientific_name': 'Gazella gazella',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Genet',
+    'scientific_name': 'Genetta genetta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Geoffroys Tamarin',
+    'scientific_name': 'Saguinus Geoffroyi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gerberian Shepsky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gerbil',
+    'scientific_name': 'Muridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Pinscher',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Shepherd Guide',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Sheppit',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Sheprador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Shorthaired Pointer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'German Spitz',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giant Armadillo',
+    'scientific_name': 'Priodontes maximus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giant Golden Mole',
+    'scientific_name': 'Chrysospalax trevelyani',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giant Panda Bear',
+    'scientific_name': 'Ailuropoda melanoleuca',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giant Schnauzer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giant Schnoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gibbon',
+    'scientific_name': 'Hylobatidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Giraffe',
+    'scientific_name': 'Giraffa camelopardalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Glechon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Glen Of Imaal Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Goat',
+    'scientific_name': 'Capra',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Goberian',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Goldador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Dox',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Jackal',
+    'scientific_name': 'Canis aureus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Lion Tamarin',
+    'scientific_name': 'Leontopithecus rosalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Mole',
+    'scientific_name': 'Chrysochloridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Newfie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Pyrenees',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Retriever',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Saint',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Golden-Crowned Flying Fox',
+    'scientific_name': 'Acerodon jubatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Goldendoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gopher',
+    'scientific_name': 'Geomys bursarius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Goral',
+    'scientific_name': 'Naemorhedus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gordon Setter',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gorilla',
+    'scientific_name': 'Gorilla',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Grasshopper Mouse',
+    'scientific_name': 'Onychomys',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Gray Fox',
+    'scientific_name': 'Urocyon cinereoargenteus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Great Dane',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Great Danoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Great Pyrenees',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Greater Swiss Mountain Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Greenland Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Grey Mouse Lemur',
+    'scientific_name': 'Microcebus murinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Grey Seal',
+    'scientific_name': 'Halichoerus Grypus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Greyhound',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Griffonshire',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Grizzly Bear',
+    'scientific_name': 'Ursus Arctos Horriblis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Groenendael',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ground Squirrel',
+    'scientific_name': 'Sciuridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Guinea Pig',
+    'scientific_name': 'Cavia porcellus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hamster',
+    'scientific_name': 'Cricetidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Harbor Porpoise',
+    'scientific_name': 'Phocoenidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Harbor Seal',
+    'scientific_name': 'Phoca vitulina',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hare',
+    'scientific_name': 'Lepus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Harp Seal',
+    'scientific_name': 'Pagophilus groenlandicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Harrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hartebeest',
+    'scientific_name': 'Alcelaphus buselaphus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Havanese',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Havapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Havashire',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hawaiian Monk Seal',
+    'scientific_name': 'Neomonachus schauinslandi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hedgehog',
+    'scientific_name': 'Erinaceidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Highland Cattle',
+    'scientific_name': 'Bos Taurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Himalayan',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hippopotamus',
+    'scientific_name': 'Hippopotamus amphibius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hoary Bat',
+    'scientific_name': 'Lasiurus cinereus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hokkaido',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Honduran White Bat',
+    'scientific_name': 'Ectophylla alba',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Honey Badger',
+    'scientific_name': 'Mellivora Capensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hooded Seal',
+    'scientific_name': 'Cystophora cristata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Horgi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Horse',
+    'scientific_name': 'Equus caballus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Howler Monkey',
+    'scientific_name': 'Alouatta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Human',
+    'scientific_name': 'Homo Sapiens Sapiens',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Huntaway',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Huskador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Huskita',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Husky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Husky Jack',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Huskydoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Hyena',
+    'scientific_name': 'Crocuta Crocuta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ibex',
+    'scientific_name': 'Capra',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ibizan Hound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Icelandic Sheepdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Impala',
+    'scientific_name': 'Aepyceros Melampus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indian Elephant',
+    'scientific_name': 'Elephas maximus indicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indian Giant Squirrel',
+    'scientific_name': 'Ratufa indica',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indian Palm Squirrel',
+    'scientific_name': 'Funambulus Palmarum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indian Rhinoceros',
+    'scientific_name': 'Rhinoceros Unicornis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indochinese Tiger',
+    'scientific_name': 'Panthera Tigris Corbetti',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Indri',
+    'scientific_name': 'Indri indri',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Irish Doodle',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Irish Setter',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Irish Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Irish Water Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Irish WolfHound',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Italian Greyhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jack Russells',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jackabee',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jackal',
+    'scientific_name': 'Canis Aureus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jackrabbit',
+    'scientific_name': 'Lepus californicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jaguar',
+    'scientific_name': 'Panthera onca',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jaguarundi Cat',
+    'scientific_name': 'Herpailurus yagouaroundi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Japanese Chin',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Japanese Macaque',
+    'scientific_name': 'Macaca fuscata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Japanese Spitz',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Japanese Squirrel',
+    'scientific_name': 'Sciurus lis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Japanese Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Javan Rhinoceros',
+    'scientific_name': 'Rhinoceros Sondaicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Javanese',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Jerboa',
+    'scientific_name': 'Dipodidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kai Ken',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kangal Shepherd Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kangaroo',
+    'scientific_name': 'Macropodidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kangaroo Rat',
+    'scientific_name': 'Dipodomys',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kermode Bear (Spirit Bear)',
+    'scientific_name': 'Ursus americanus kermodei',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kerry Blue Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Key Deer',
+    'scientific_name': 'Odocoileus virginianus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kiang',
+    'scientific_name': 'Equus kiang',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kiko Goat',
+    'scientific_name': 'Capra aegagrus Hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Killer Whale',
+    'scientific_name': 'Orcinus orca',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Killifish',
+    'scientific_name': 'Cyprinodontiformes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kinder Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'King Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kinkajou',
+    'scientific_name': 'Potos flavus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kishu',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kit Fox',
+    'scientific_name': 'Vulpes macrotis merriam',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Koala',
+    'scientific_name': 'Phascolarctos cinereus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kodkod',
+    'scientific_name': 'Leopardus guigna',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kooikerhondje',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Koolie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kouprey',
+    'scientific_name': 'Bos sauveli',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kudu',
+    'scientific_name': 'Tragelaphus Strepsiceros',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Kuvasz',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labahoula',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labmaraner',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labradane',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labradoodle',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labrador Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Labraheeler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lakeland Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'LaMancha Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lancashire Heeler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lapponian Herder',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lemming',
+    'scientific_name': 'Lemmus Lemmus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lemur',
+    'scientific_name': 'Lemur Catta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Leonberger',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Leopard',
+    'scientific_name': 'Panthera pardus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Leopard Cat',
+    'scientific_name': 'Prionailurus bengalensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Leopard Seal',
+    'scientific_name': 'Hydrurga Leptonyx',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lhasa Apso',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lhasapoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Liger',
+    'scientific_name': 'Panthera leo × Panthera tigris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lion',
+    'scientific_name': 'Panthera leo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Little Brown Bat',
+    'scientific_name': 'Myotis lucifugus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Livyatan',
+    'scientific_name': '†Livyatan melvillei',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Llama',
+    'scientific_name': 'Lama Glama',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Long-Haired Rottweiler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Loris',
+    'scientific_name': 'Lorisidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lowchen',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Lynx',
+    'scientific_name': 'Felis lynx',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Macaque',
+    'scientific_name': 'Macaca',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mackenzie Valley Wolf',
+    'scientific_name': 'Canis lupus occidentalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Maine Coon',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Malayan Civet',
+    'scientific_name': 'Viverra tangalunga',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Malayan Tiger',
+    'scientific_name': 'Panthera Tigris Jacksoni',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Malchi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Malteagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Maltese',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Maltese Shih Tzu',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Maltipoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Manatee',
+    'scientific_name': 'Trichechus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Manchester Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mandrill',
+    'scientific_name': 'Mandrillus Sphinx',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Maned Wolf',
+    'scientific_name': 'Chyrsocyon brachyurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Marble Fox',
+    'scientific_name': 'Vulpes vulpes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Margay',
+    'scientific_name': 'Leopardus wiedii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Markhor',
+    'scientific_name': 'Capra falconeri',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Marmoset',
+    'scientific_name': 'Callihrix jacchus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Marmot',
+    'scientific_name': 'Marmota',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Marsican Brown Bear',
+    'scientific_name': 'Ursus arctos',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Masked Palm Civet',
+    'scientific_name': 'Paguma larvata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mastador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mastiff',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Meagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Meerkat',
+    'scientific_name': 'Suricata suricatta',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mexican Free-Tailed Bat',
+    'scientific_name': 'Tadarida brasiliensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Miki',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mini Labradoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Miniature Bull Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Miniature Pinscher',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mink',
+    'scientific_name': 'Mustela lutreola or Neovison vison',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Minke Whale',
+    'scientific_name': 'Balaenoptera acutorostrata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mole',
+    'scientific_name': 'Talpidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mongoose',
+    'scientific_name': 'Helogale Parvula',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mongrel',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Monkey',
+    'scientific_name': 'Macaca Fascicularis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Moorhen',
+    'scientific_name': 'Gallinula',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Moose',
+    'scientific_name': 'Alces alces',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Morkie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Moscow Watchdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mountain Cur',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mountain Feist',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mountain Gorilla',
+    'scientific_name': 'Gorilla Berengei Berengei',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mountain Lion',
+    'scientific_name': 'Felis Concolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mouse',
+    'scientific_name': 'Mus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mudi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mule',
+    'scientific_name': 'Equus mulus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Mule Deer',
+    'scientific_name': 'Odocoileus hemionus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Muntjac',
+    'scientific_name': 'Muntiacus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Musk Deer',
+    'scientific_name': 'Moschus moschiferus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Muskox',
+    'scientific_name': 'Ovibos moschatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Muskrat',
+    'scientific_name': 'Ondatra zibethicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nabarlek',
+    'scientific_name': 'Petrogale concinna',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Naked Mole Rat',
+    'scientific_name': 'Heterocephalus glaber',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Narwhal',
+    'scientific_name': 'Monodon monoceros',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Neanderthal',
+    'scientific_name': 'Homo Sapiens Neanderthalensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Neapolitan Mastiff',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nebelung',
+    'scientific_name': 'Felis Catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Netherland Dwarf Rabbit',
+    'scientific_name': 'Oryctolagus cuniculus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Newfoundland',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Newfypoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nigerian Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nilgai',
+    'scientific_name': 'Boselaphus tragocamelus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norfolk Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'North American Black Bear',
+    'scientific_name': 'Ursus americanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Northern Fur Seal',
+    'scientific_name': 'Callorhinus ursinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Northern Inuit Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norwegian Buhund',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norwegian Elkhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norwegian Forest',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norwegian Lundehund',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Norwich Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nova Scotia Duck Tolling Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nubian Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Numbat',
+    'scientific_name': 'Myrmecobius fasciatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nutria',
+    'scientific_name': 'Myocastor coypus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Nyala',
+    'scientific_name': 'Tragelaphus angasii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ocelot',
+    'scientific_name': 'Leopardus pardalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Okapi',
+    'scientific_name': 'Okapia johnstoni',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Old English Sheepdog',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Olingo',
+    'scientific_name': 'Bassaricyon gabbii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Olive Baboon',
+    'scientific_name': 'Papio anubis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Onager',
+    'scientific_name': 'Equus hemionus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Opossum',
+    'scientific_name': 'Didelphis Virginiana',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Orangutan',
+    'scientific_name': 'Pongo pygmaeus, Pongo abelii, Pongo tapanuliensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Oribi',
+    'scientific_name': 'Ourebia ourebi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Otter',
+    'scientific_name': 'Mustelidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Otterhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ox',
+    'scientific_name': 'Bos taurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pademelon',
+    'scientific_name': 'Thylogale',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pangolin',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Panther',
+    'scientific_name': 'Panthera pardus, Panthera onca',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Papillon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Parson Russell Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Patagonian Cavy',
+    'scientific_name': 'Dolichotis patagonum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Patagonian Mara',
+    'scientific_name': 'Dolichotis patagonum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Patas Monkey',
+    'scientific_name': 'Erythrocebus patas',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Patterdale Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Peagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Peekapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pekingese',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pembroke Welsh Corgi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Père David’s Deer',
+    'scientific_name': 'Elaphurus davidianus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Perro De Presa Canario',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Persian',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Peruvian Inca Orchid',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Petit Basset Griffon Vendéen',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Petite Goldendoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pheasant',
+    'scientific_name': 'Phasianus Colchicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pied Tamarin',
+    'scientific_name': 'Saguinus bicolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pig',
+    'scientific_name': 'Sus scrofa scrofa',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pika',
+    'scientific_name': 'Ochotona Minor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pine Marten',
+    'scientific_name': 'Martes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pink Fairy Armadillo',
+    'scientific_name': 'Chlamyphorus truncatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pit Bull',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pitador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pitsky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Platypus',
+    'scientific_name': 'Ornithorhynchus anatinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pocket Beagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pocket Pitbull',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pointer',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Polar Bear',
+    'scientific_name': 'Ursus maritimus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Polish Lowland Sheepdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pomapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pomchi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pomeagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pomeranian',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pomsky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Poochon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Poodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Poogle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Porcupine',
+    'scientific_name': 'Erethizon Dorsaum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Possum',
+    'scientific_name': 'Phalangeriforme',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Potoroo',
+    'scientific_name': 'Potorous tridactylus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Prairie Dog',
+    'scientific_name': 'Cynomys',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Proboscis Monkey',
+    'scientific_name': 'Nasalis larvatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Procoptodon',
+    'scientific_name': '†Procoptodon',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pronghorn',
+    'scientific_name': 'Antilocapra americana',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pudelpointer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pug',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pugapoo',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Puggle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pugshire',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Puma',
+    'scientific_name': 'Felis concolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pumi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pygmy Hippopotamus',
+    'scientific_name': 'Choeropsis liberiensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pygmy Marmoset (Finger Monkey)',
+    'scientific_name': 'Callithrix pygmaea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pygora Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pyrador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Pyredoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Quagga',
+    'scientific_name': '†Equus quagga quagga',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Quokka',
+    'scientific_name': 'Setonix brachyurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Quoll',
+    'scientific_name': 'Dasyurus Viverrinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rabbit',
+    'scientific_name': 'Oryctolagus cuniculus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Raccoon',
+    'scientific_name': 'Procyon lotor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Raccoon Dog',
+    'scientific_name': 'Nyctereutes procyonoides',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ragamuffin',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Ragdoll',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Raggle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rat',
+    'scientific_name': 'Rattus rattus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rat Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red Deer',
+    'scientific_name': 'C. elaphus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red Fox',
+    'scientific_name': 'Vulpes vulpes',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red Panda',
+    'scientific_name': 'Ailurus fulgens',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red Squirrel',
+    'scientific_name': 'Tamiasciurus hudsonicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red Wolf',
+    'scientific_name': 'Canis lupus rufus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Red-handed Tamarin',
+    'scientific_name': 'Saguinus midas',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Redbone Coonhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Reindeer',
+    'scientific_name': 'Rangifer Tarandus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rhinoceros',
+    'scientific_name': 'Rhinocerotidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'River Otter',
+    'scientific_name': 'Lontra canadensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rock Hyrax',
+    'scientific_name': 'Procavia capensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rodents',
+    'scientific_name': 'Rodentia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Roe Deer',
+    'scientific_name': 'Capreolus capreolus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Roosevelt Elk',
+    'scientific_name': 'Cervus canadensis roosevelti',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rottsky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Rottweiler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Russell Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Russian Bear Dog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Russian Blue',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saanen Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saarloos Wolfdog',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saber-Toothed Tiger',
+    'scientific_name': 'Smilodon populator',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sable',
+    'scientific_name': 'Martes zibellina',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sable Black German Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sable Ferret',
+    'scientific_name': 'Mustela furo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saiga',
+    'scientific_name': 'Saiga tatarica',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saint Berdoodle',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saint Bernard',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saint Shepherd',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saluki',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sambar',
+    'scientific_name': 'Rusa unicolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Samoyed',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Saola',
+    'scientific_name': 'Pseudoryx nghetinhensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Savanna Goat',
+    'scientific_name': 'Capra hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Schipperke',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Schneagle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Schnoodle',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Scimitar-horned Oryx',
+    'scientific_name': 'Oryx Dammah',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Scottish Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sea Lion',
+    'scientific_name': 'Otariidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sea Otter',
+    'scientific_name': 'Enhydra Lutris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Seal',
+    'scientific_name': 'Phoca vitulina',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sealyham Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sei Whale',
+    'scientific_name': 'Balaenoptera borealis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Serval',
+    'scientific_name': 'Leptailurus serval',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sheep',
+    'scientific_name': 'Ovis aries',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sheepadoodle',
+    'scientific_name': 'Animalia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shepadoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shepkita',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shepweiler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shiba Inu',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shih Poo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shih Tzu',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shollie',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Shrew',
+    'scientific_name': 'Soricidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siamese',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberian',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberian Husky',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberian Ibex',
+    'scientific_name': 'Capra sibirica',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberian Retriever',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberian Tiger',
+    'scientific_name': 'Panthera Tigris Altaica',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Siberpoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sichuan Takin (Tibetan Takin)',
+    'scientific_name': 'Budorcas taxicolor tibetana',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Silky Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Silver Labrador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Skunk',
+    'scientific_name': 'Mephitidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Skye Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sloth',
+    'scientific_name': 'Choloepus Hoffmani',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Smooth Fox Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Snorkie',
+    'scientific_name': 'Canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Snow Leopard',
+    'scientific_name': 'Panthera uncia',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Snowshoe',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Snowshoe Hare',
+    'scientific_name': 'Lepus americanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Somali',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'South China Tiger',
+    'scientific_name': 'Panthera Tigris Amoyensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spalax',
+    'scientific_name': 'Spalax microphthalmus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spanador',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spanish Goat',
+    'scientific_name': 'Capra aegagrus hircus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spanish Mastiff',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spectacled Bear',
+    'scientific_name': 'Tremarctos Ornatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sperm Whale',
+    'scientific_name': 'Physeter macrocephalus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sphynx',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spider Monkey',
+    'scientific_name': 'Simia Paniscus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spinone Italiano',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Spotted Skunk',
+    'scientific_name': 'Spilogale',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Springbok',
+    'scientific_name': 'Antidorcas marsupialis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Springerdoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Squirrel',
+    'scientific_name': 'Sciuridae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Squirrel Monkey',
+    'scientific_name': 'Saimiri',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sri Lankan Elephant',
+    'scientific_name': 'Elephas Maximus Maximus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Stabyhoun',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Staffordshire Bull Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Standard Schnauzer',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Star-nosed mole',
+    'scientific_name': 'Condylura cristata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Steller’s Sea Cow',
+    'scientific_name': 'Hydrodamalis Gigas',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Stoat',
+    'scientific_name': 'Mustela Erminea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Striped Hyena',
+    'scientific_name': 'Hyaena hyaena',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sugar Glider',
+    'scientific_name': 'Petaurus breviceps',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sumatran Elephant',
+    'scientific_name': 'Elephas Maximus Sumatranus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sumatran Orangutan',
+    'scientific_name': 'Pongo abelii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sumatran Rhinoceros',
+    'scientific_name': 'Dicerorhinus Sumatrensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sumatran Tiger',
+    'scientific_name': 'Panthera Tigris Sumatrae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Sun Bear',
+    'scientific_name': 'Helarctos malayanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Swedish Vallhund',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Syrian Hamster',
+    'scientific_name': 'Mesocricetus auratus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Taco Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Takin',
+    'scientific_name': 'Budorcas taxicolor',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tamaskan',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tapanuli Orangutan',
+    'scientific_name': 'Pongo tapanuliensis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tapir',
+    'scientific_name': 'Tapirus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tarsier',
+    'scientific_name': 'Tarsius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tasmanian Devil',
+    'scientific_name': 'Sarcophilus harrisii',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tasmanian Tiger',
+    'scientific_name': '†Thylacinus cynocephalus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Teacup Miniature Horse',
+    'scientific_name': 'Equus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Teddy Bear Hamster',
+    'scientific_name': 'Mesocricetus auratus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Teddy Roosevelt Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tennessee Walking Horse',
+    'scientific_name': 'Equus ferus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tenrec',
+    'scientific_name': 'Tenrecidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tenterfield Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Texas Heeler',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Thai Ridgeback',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tibetan Fox',
+    'scientific_name': 'Vulpes ferrilata',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tibetan Mastiff',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tibetan Spaniel',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tibetan Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tiffany',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tiger',
+    'scientific_name': 'Panthera Tigris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Torkie',
+    'scientific_name': 'Canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Toy Fox Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Toy Poodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Transylvanian Hound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tree Kangaroo',
+    'scientific_name': 'Dendrolagus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Treeing Tennessee Brindle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Treeing Walker Coonhound',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Tuatara',
+    'scientific_name': 'Sphenodon Punctatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Turkish Angora',
+    'scientific_name': 'Felis catus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Uakari',
+    'scientific_name': 'Cacajao',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Uinta Ground Squirrel',
+    'scientific_name': 'Urocitellus armatus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Uintatherium',
+    'scientific_name': 'Uintatherium',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Unau (Linnaeus’s Two-Toed Sloth)',
+    'scientific_name': 'Choloepodidae didactylus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Utonagan',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vampire Bat',
+    'scientific_name': 'Desmodontinae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vaquita',
+    'scientific_name': 'Phocoena sinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vervet Monkey',
+    'scientific_name': 'Chlorocebus pygerythrus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vicuña',
+    'scientific_name': 'Lama vicugna',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vizsla',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Vole',
+    'scientific_name': 'Microtus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Volpino Italiano',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wallaby',
+    'scientific_name': 'Macropus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Walrus',
+    'scientific_name': 'Odobenus rosmarus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Warthog',
+    'scientific_name': 'Phacochoerus africanus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Water Buffalo',
+    'scientific_name': 'Bubalus bubalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Water Vole',
+    'scientific_name': 'Arvicola amphibius',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Waterbuck',
+    'scientific_name': 'Kobus ellipsiprymnus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Weasel',
+    'scientific_name': 'Mustela nivalis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Weimaraner',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Weimardoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Welsh Black Cattle',
+    'scientific_name': 'Bos taurus taurus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Welsh Corgi',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Welsh Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'West Highland Terrier',
+    'scientific_name': 'Canis Lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Western Gorilla',
+    'scientific_name': 'Gorilla Gorilla',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Western Lowland Gorilla',
+    'scientific_name': 'Gorilla gorilla gorilla',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Westiepoo',
+    'scientific_name': 'Canis familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wheaten Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Whippet',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'White Ferret / Albino Ferrets',
+    'scientific_name': 'Mustela putorius furo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'White Rhinoceros',
+    'scientific_name': 'Ceratotherium simum',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'White Tiger',
+    'scientific_name': 'Panthera tigris tigris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'White-Faced Capuchin',
+    'scientific_name': 'Cebus Capucinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'White-tail deer',
+    'scientific_name': 'Odocoileus virginianus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Whitetail Deer',
+    'scientific_name': '',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Whoodle',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wild Boar',
+    'scientific_name': 'Sus scrofa',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wildebeest',
+    'scientific_name': 'Connochaetes Taurinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wire Fox Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wirehaired Pointing Griffon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wolf',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wolverine',
+    'scientific_name': 'Gulo gulo',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wombat',
+    'scientific_name': 'Vombatus Ursinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Wood Bison',
+    'scientific_name': 'Bison bison athabascae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Woodrat',
+    'scientific_name': 'Neotoma cinerea',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Woolly Monkey',
+    'scientific_name': 'Lagothrix Lagotricha',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Woolly Rhinoceros',
+    'scientific_name': '†Coelodonta antiquitatis',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Xerus',
+    'scientific_name': 'Xerus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Xoloitzcuintli',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yak',
+    'scientific_name': 'Bos grunniens',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yakutian Laika',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yoranian',
+    'scientific_name': 'Canis lupus familiaris',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yorkie Bichon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yorkiepoo',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Yorkshire Terrier',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zebra',
+    'scientific_name': 'Equus zebra, Equus quagga, Equus grevyi',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zebu',
+    'scientific_name': 'Bos taurus indicus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zokor',
+    'scientific_name': 'Spalacidae',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zonkey',
+    'scientific_name': 'Equus zebra x Equus asinus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zorse',
+    'scientific_name': 'Equus zebra x Equus caballus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Zuchon',
+    'scientific_name': 'Canis lupus',
+    'class': 'mammals'
+  },
+  {
+    'common_name': 'Agama Lizard',
+    'scientific_name': 'Agama',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Aldabra Giant Tortoise',
+    'scientific_name': 'Geochelone gigantea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Amazon Tree Boa',
+    'scientific_name': 'Corallus hortulanus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'American Alligator',
+    'scientific_name': 'Alligator mississippiensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Anole Lizard',
+    'scientific_name': 'Anolis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Arabian Cobra',
+    'scientific_name': 'Naja arabica',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Argentine Black and White Tegu',
+    'scientific_name': 'Salvator merianae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Arizona Black Rattlesnake',
+    'scientific_name': 'Crotalus cerberus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Armadillo Lizard',
+    'scientific_name': 'Ouroborus cataphractus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Aruba Rattlesnake',
+    'scientific_name': 'Crotalus unicolor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Asian Vine Snake',
+    'scientific_name': 'Ahaetulla prasina',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Asian Water Monitor',
+    'scientific_name': 'Varanus salvator',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Asp',
+    'scientific_name': 'Vipera aspis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Australian Gecko',
+    'scientific_name': 'Squamata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Axanthic Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Baird’s Rat Snake',
+    'scientific_name': 'Pantherophis bairdi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Ball Python',
+    'scientific_name': 'P. regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Banana Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Banded Water Snake',
+    'scientific_name': 'Nerodia fasciata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Barinasuchus',
+    'scientific_name': 'Barinosuchus arveloi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Basilisk Lizard',
+    'scientific_name': 'Basiliscus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Bearded Dragon',
+    'scientific_name': 'Pogona Vitticeps',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Beauty rat snake',
+    'scientific_name': 'Orthriophis taeniura',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Black Mamba',
+    'scientific_name': 'D. polylepis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Black Pastel Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Black Rat Snake',
+    'scientific_name': 'Pantheropis obsoletus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Black Throat Monitor',
+    'scientific_name': 'Varanus albigularis microstictus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Black-headed python',
+    'scientific_name': 'Aspidites melanocephalus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Blind Snake',
+    'scientific_name': 'Typhlopidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Blood Python',
+    'scientific_name': 'Python brongersmai',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Blue Belly Lizard',
+    'scientific_name': 'Sceloporus occidentalis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Blue Iguana',
+    'scientific_name': 'Cyclura lewisi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Boas',
+    'scientific_name': 'Various',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Bolivian Anaconda',
+    'scientific_name': '',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Boomslang',
+    'scientific_name': 'Dispholidus typus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Box Turtle',
+    'scientific_name': 'Terrapene carolina',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Brahminy Blindsnake',
+    'scientific_name': 'Indotyphlops braminus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Brookesia Micra',
+    'scientific_name': 'Brookesia micra',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Brown Water Snake',
+    'scientific_name': 'Nerodia taxispilota',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Bullsnake',
+    'scientific_name': 'Pituophis catenifer sayi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Burmese Python',
+    'scientific_name': 'Python bivittatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Bush Viper',
+    'scientific_name': 'Atheris',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Bushmaster Snake',
+    'scientific_name': 'Lachesis sp.',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Caiman',
+    'scientific_name': 'Caiman crocodilus, Melanosuchus niger, Caiman yacare, Paleosuchus palpebrosus, Paleosuchus trigonatus, Caiman latirostris',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Caiman Lizard',
+    'scientific_name': 'Dracaena',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Carpet Python',
+    'scientific_name': 'Morelia spilota',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Carpet Viper',
+    'scientific_name': 'Echis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cascabel',
+    'scientific_name': 'Crotalus durissus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cat Snake',
+    'scientific_name': 'Colubridae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Central Ranges Taipan',
+    'scientific_name': 'Oxyuranus temporalis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Children’s python',
+    'scientific_name': 'Antaresia childreni',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Chinese Alligator',
+    'scientific_name': 'Alligator sinensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cinnamon Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Coachwhip Snake',
+    'scientific_name': 'Masticophis flagellum',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cobras',
+    'scientific_name': 'Elapidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Collett’s Snake',
+    'scientific_name': 'Pseudechis colletti',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Common European Adder',
+    'scientific_name': 'Vipera berus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Copperhead',
+    'scientific_name': 'Agkistrodon contortrix',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Coral Snake',
+    'scientific_name': 'Various',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Corn Snake',
+    'scientific_name': 'P. guttatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cottonmouth',
+    'scientific_name': 'Agkistrodon piscivorus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Crested Gecko',
+    'scientific_name': 'Correlophus ciliatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Crocodile',
+    'scientific_name': 'Crocodylus acutus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Crocodile Monitor',
+    'scientific_name': 'Varanus salvadorii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Crocodylomorph',
+    'scientific_name': 'Crocodylus porosus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Cuban Boa',
+    'scientific_name': 'Chilabothrus angulifer',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Death Adder',
+    'scientific_name': 'Acanthophis antarcticus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Desert Kingsnake',
+    'scientific_name': 'Lampropeltis splendida',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Desert Tortoise',
+    'scientific_name': 'Gopherus Agassizii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Draco Volans Lizard',
+    'scientific_name': 'Draco volans',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Dumeril’s Boa',
+    'scientific_name': 'Acrantophis dumerili',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Dwarf Boa',
+    'scientific_name': 'Various',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Dwarf Crocodile',
+    'scientific_name': 'Osteolaemus tetraspis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Earless Monitor Lizard',
+    'scientific_name': 'Lanthanotus borneensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Coral Snake',
+    'scientific_name': 'Micrurus fulvius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Diamondback Rattlesnake',
+    'scientific_name': 'C. adamanteus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Fence Lizard',
+    'scientific_name': 'Sceloporus undulatas',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Glass Lizard',
+    'scientific_name': 'Ophisaurus ventralis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Indigo Snake',
+    'scientific_name': 'Drymarchon couperi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Racer',
+    'scientific_name': 'Coluber constrictor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eastern Rat Snake',
+    'scientific_name': 'Pantherophis alleghaniensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Egyptian Cobra (Egyptian Asp)',
+    'scientific_name': 'Naja haje',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Elasmosaurus',
+    'scientific_name': '†Elasmosaurus platyurus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Emerald Tree Monitor',
+    'scientific_name': 'Varanus prasinus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Enchi Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Eyelash Viper',
+    'scientific_name': 'Bothriechis schlegelii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'False coral snake',
+    'scientific_name': 'Aniliidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Fer-de-lance Snake',
+    'scientific_name': 'B. asper, B. atrox, B. lanceolatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Firefly Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Flying Snake',
+    'scientific_name': 'Chrysopelea ornata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Fox Snakes',
+    'scientific_name': 'P. vulpinus and P. ramspotti',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Freshwater Crocodile',
+    'scientific_name': 'Crocodylus johnstoni',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Frilled Lizard',
+    'scientific_name': 'Chlamydosaurus kingii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gaboon Viper',
+    'scientific_name': 'Bitis gabonica',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Galapagos Tortoise',
+    'scientific_name': 'Chelonoidis nigra',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Garter Snake',
+    'scientific_name': 'Thamnophis sirtalis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gecko',
+    'scientific_name': 'Squamata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gharial',
+    'scientific_name': 'Gavialis gangeticus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gila Monster',
+    'scientific_name': 'Heloderma suspectum',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Glass Lizard',
+    'scientific_name': 'Ophisaurus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Golden Lancehead',
+    'scientific_name': 'B. insularis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gopher Snake',
+    'scientific_name': 'Pituophis catenifer',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Gopher Tortoise',
+    'scientific_name': 'Gopherus polyphemus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Grass Snake',
+    'scientific_name': 'Natrix natrix',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Great Plains Rat Snake',
+    'scientific_name': 'Pantheropis emoryi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Green Anaconda',
+    'scientific_name': '',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Green Anole',
+    'scientific_name': 'Anolis carolinensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Green Mamba',
+    'scientific_name': 'Dendroaspis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Green Rat Snake',
+    'scientific_name': 'Gonyosoma oxycephalum',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Green Tree Python',
+    'scientific_name': 'Morelia viridis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Ground Snake',
+    'scientific_name': 'Sonora semiannulata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Harlequin Coral Snake',
+    'scientific_name': 'Micrurus fulvius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Hellbender',
+    'scientific_name': 'Cryptobranchus alleganiensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Hognose snake',
+    'scientific_name': 'Squamata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Hook-Nosed Sea Snake',
+    'scientific_name': 'Enhydrina schistosa',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Horned Adder',
+    'scientific_name': 'Bitis caudalis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Horned Lizard',
+    'scientific_name': 'Phrynosoma',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Horned Viper',
+    'scientific_name': 'Cerastes cerastes',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Ichthyosaurus',
+    'scientific_name': 'Ichthyosaurus communis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Iguana',
+    'scientific_name': 'Iguanidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Indian Cobra',
+    'scientific_name': 'Naja naja',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Indian Star Tortoise',
+    'scientific_name': 'Geochelone elegans',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Indigo Snake',
+    'scientific_name': 'Drymarchon',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Jackson’s Chameleon',
+    'scientific_name': 'Trioceros jacksonii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Jamaican Boa',
+    'scientific_name': 'Chilabothrus subflavus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Japanese rat snake',
+    'scientific_name': 'Elaphe climacophora',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Keelback',
+    'scientific_name': 'Colubridae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'King Cobra',
+    'scientific_name': 'Ophiophagus hannah',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Kirtland’s Snake',
+    'scientific_name': 'Clonophis kirtlandii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Komodo Dragon',
+    'scientific_name': 'Varanus komodoensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Krait',
+    'scientific_name': 'Bungarus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Lazarus Lizard',
+    'scientific_name': 'Podarcis muralis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Leaf-Tailed Gecko',
+    'scientific_name': 'Uroplatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Leatherback Sea Turtle',
+    'scientific_name': 'Dermochelys coriacea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Lemon Blast Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Leopard Gecko',
+    'scientific_name': 'Eublepharis macularius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Leopard Lizard',
+    'scientific_name': 'Gambelia',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Leopard Tortoise',
+    'scientific_name': 'Stigmochelys pardalis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Lizard',
+    'scientific_name': 'Lacertidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Madagascar Tree Boa',
+    'scientific_name': 'Sanzinia madagascariensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mamba',
+    'scientific_name': 'Dendroaspis spp.',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mangrove Snake',
+    'scientific_name': 'Boiga dendrophila',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Marine Iguana',
+    'scientific_name': 'Amblyrhynchus cristatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Massasauga',
+    'scientific_name': 'Sistrurus catenatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Megalania',
+    'scientific_name': 'Varanus priscus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mexican Alligator Lizard',
+    'scientific_name': 'Abronia graminea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mexican Black Kingsnake',
+    'scientific_name': 'Lampropeltis getula nigrita',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mexican Mole Lizard',
+    'scientific_name': 'Bipes biporus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Midget Faded Rattlesnake',
+    'scientific_name': 'Crotalus concolor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Milk Snake',
+    'scientific_name': 'Lampropeltis triangulum',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mojave Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mojave Rattlesnake',
+    'scientific_name': 'Crotalus scutulatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Monitor Lizard',
+    'scientific_name': 'Varanus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Mozambique Spitting Cobra',
+    'scientific_name': 'Naja mossambica',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Night Snake',
+    'scientific_name': 'Hypsiglena torquata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Nile Crocodile',
+    'scientific_name': 'Crocodylus niloticus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Northern Alligator Lizard',
+    'scientific_name': 'Elgaria coerulea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Northern Water Snake',
+    'scientific_name': 'Nerodia sipedon',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Nose-Horned Viper',
+    'scientific_name': 'Vipera ammodytes',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Oenpelli python',
+    'scientific_name': 'Nyctophilopython oenpelliensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Olive Sea Snake',
+    'scientific_name': 'Aipysurus laevis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Ornate Box Turtle',
+    'scientific_name': 'Terrapene Ornata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Painted Turtle',
+    'scientific_name': 'Chrysemys picta',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Peringuey’s Adder',
+    'scientific_name': 'Bitis peringueyi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Philippine Cobra',
+    'scientific_name': 'Naja philippinensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Pied Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Pig-Nosed Turtle',
+    'scientific_name': 'carettochelys insculpta',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Pine Snake',
+    'scientific_name': '',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Pipe Snake',
+    'scientific_name': 'Squamata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Puff Adder',
+    'scientific_name': 'Bitis arietans',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Pygmy python',
+    'scientific_name': 'A. perthensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Queen Snake',
+    'scientific_name': 'Animalia',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Racer Snake',
+    'scientific_name': 'Coluber constrictor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Radiated Tortoise',
+    'scientific_name': 'Astrochelys radiata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rainbow Boa',
+    'scientific_name': 'Epicrates cenchria',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rat Snakes',
+    'scientific_name': 'various',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rattlesnake',
+    'scientific_name': 'Crotalus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Red Diamondback Rattlesnake',
+    'scientific_name': 'Crotalus ruber',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Red Tail Boa (common boa)',
+    'scientific_name': 'Boa constrictor constrictor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Red-Bellied Black Snake',
+    'scientific_name': 'Pseudechis porphyriacus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Red-Eared Slider',
+    'scientific_name': 'Trachemys scripta elegans',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Red-Footed Tortoise',
+    'scientific_name': 'Chelonoidis carbonarius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rhombic Egg-Eater Snake',
+    'scientific_name': 'Dasypeltis scabra',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Ribbon Snake',
+    'scientific_name': 'Thamnophis sauritus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'River Turtle',
+    'scientific_name': 'Testudines',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rock Python',
+    'scientific_name': 'Python sebae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rosy Boa',
+    'scientific_name': 'Lichanura trivirgata, Lichanura orcutti',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rough Green Snake',
+    'scientific_name': 'Opheodrys aestivus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Rubber Boa',
+    'scientific_name': 'Charina bottae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Russian Tortoise',
+    'scientific_name': 'Agrionemys horsfieldii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'San Francisco Garter Snake',
+    'scientific_name': 'Thamnophis sirtalis tetrataenia',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sand Lizard',
+    'scientific_name': 'Lacerta agilis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sand Viper',
+    'scientific_name': 'Cerastes viperus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Satanic Leaf-Tailed Gecko',
+    'scientific_name': 'Uroplatus phantasticus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Savannah Monitor',
+    'scientific_name': 'Varanus polydaedalus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Scaleless Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Scarlet Kingsnake',
+    'scientific_name': 'Lampropeltis elapsoides',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sea Snake',
+    'scientific_name': 'Hydrophiinae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sea Turtle',
+    'scientific_name': 'Chelonioidea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sharp-Tailed Snake',
+    'scientific_name': 'Contia tenuis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sidewinder',
+    'scientific_name': 'Crotalus cerastes',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Skink Lizard',
+    'scientific_name': 'Scincidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Slow Worm',
+    'scientific_name': 'Anguis fragilis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Smilosuchus',
+    'scientific_name': 'Smilosuchus gregorii',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Snake',
+    'scientific_name': 'Squamata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Snapping Turtle',
+    'scientific_name': 'Chelydridae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Snouted Cobra',
+    'scientific_name': 'Naja annulifera',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Southern Black Racer',
+    'scientific_name': 'Coluber constrictor',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Southern Hognose Snake',
+    'scientific_name': 'Heterodon simus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Southern Pacific Rattlesnake',
+    'scientific_name': 'Crotalus helleri',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Speckled Kingsnake',
+    'scientific_name': 'Lampropeltis holbrooki',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Spider Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Spider-Tailed Horned Viper',
+    'scientific_name': 'Pseudocerastes urarachnoides',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Spiny Hill Turtle',
+    'scientific_name': 'Heosemys spinosa',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Spitting Cobra',
+    'scientific_name': 'Elapidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Spotted python',
+    'scientific_name': 'Antaresia maculosa',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Stiletto Snake',
+    'scientific_name': 'Lamprophiidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Stupendemys',
+    'scientific_name': 'Stupendemys geographica',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Sulcata Tortoise',
+    'scientific_name': 'Centrochelys sulcata',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Super Pastel Ball Python',
+    'scientific_name': 'Python regius',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Taipan',
+    'scientific_name': 'Oxyuranus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Blind Snake',
+    'scientific_name': 'Rena dulcis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Coral Snake',
+    'scientific_name': 'Micrurus tener',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Indigo Snake',
+    'scientific_name': 'Drymarchon melanurus erebennus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Night Snake',
+    'scientific_name': 'Hypsiglena jani',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Rat Snake',
+    'scientific_name': 'Pantherophis obsoletus lindheimeri',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Texas Spiny Lizard',
+    'scientific_name': 'Sceloporus olivaceous',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Thorny Devil',
+    'scientific_name': 'Moloch horridus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Tiger Rattlesnake',
+    'scientific_name': 'Crotalus tigris',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Tiger snake',
+    'scientific_name': 'Notechis Scutatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Timber Rattlesnake (Canebrake Rattlesnake)',
+    'scientific_name': 'Crotalus horridus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Titanoboa',
+    'scientific_name': 'Titanoboa cerrejonensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Tortoise',
+    'scientific_name': 'Testudinidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Tree Snake',
+    'scientific_name': 'Boiga irregularis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Turtles',
+    'scientific_name': 'Testudines',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Twig Snake',
+    'scientific_name': 'Thelotornis capensis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Urutu Snake',
+    'scientific_name': 'Bothrops alternatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Vine Snake',
+    'scientific_name': 'Colubridae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Viper',
+    'scientific_name': 'Various',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Virgin Islands Dwarf Gecko',
+    'scientific_name': 'Sphaerodactylus parthenopion',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Water Dragon',
+    'scientific_name': 'Physignathus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Western Diamondback Rattlesnake',
+    'scientific_name': 'Crotalus atrox',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Western Hognose Snake',
+    'scientific_name': 'Heteredon nasicus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Western Rat Snake',
+    'scientific_name': 'Pantherophis obsoletus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Whiptail Lizard',
+    'scientific_name': 'Teiidae',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Woma Python',
+    'scientific_name': 'A. ramsayi',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Wood Turtle',
+    'scientific_name': 'Glyptemys insculpta',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Worm Snake',
+    'scientific_name': 'Carphophis amoenus, Carphophis vermis',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Yarara',
+    'scientific_name': 'Bothrops alternatus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Yellow Anaconda',
+    'scientific_name': 'E. notaeus',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Yellow Cobra',
+    'scientific_name': 'Naja nivea',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'Yellow Spotted Lizard',
+    'scientific_name': 'Lepidophyma flavimaculatum',
+    'class': 'reptiles'
+  },
+  {
+    'common_name': 'African Bullfrog',
+    'scientific_name': 'Pyxicephalus adspersus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'African Clawed Frog',
+    'scientific_name': 'Xenopus laevis',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'African Tree Toad',
+    'scientific_name': 'Nectophryne afra',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'American Toad',
+    'scientific_name': 'Anaxyrus americanus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Argentine Horned Frog',
+    'scientific_name': 'Ceratophrys Ornata',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Bullfrog',
+    'scientific_name': 'Lithobates catesbeianus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Burrowing Frog',
+    'scientific_name': 'Heleioporus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Caecilian',
+    'scientific_name': 'Apoda',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Common Frog',
+    'scientific_name': 'Rana temporaria',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Darwin’s Frog',
+    'scientific_name': 'Rhinoderma Darwinii',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Desert Rain Frog',
+    'scientific_name': 'Breviceps macrops',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Edible Frog',
+    'scientific_name': 'Pelophylax kl. esculentus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Fire Salamander',
+    'scientific_name': 'Salamandra',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Fire-Bellied Toad',
+    'scientific_name': 'Bombina',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Frog',
+    'scientific_name': 'Anura',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Giant Salamander',
+    'scientific_name': 'Cryptobranchidae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Glass Frog',
+    'scientific_name': 'Centrolenidae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Goliath Frog',
+    'scientific_name': 'Conraua goliath',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Gray Tree Frog',
+    'scientific_name': 'Hyla versicolor',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Green Frog',
+    'scientific_name': 'Lithobates clamitans',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Green Tree Frog',
+    'scientific_name': 'Anura',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Holy Cross Frog',
+    'scientific_name': 'Notaden bennettii',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Leopard Frog',
+    'scientific_name': 'Lithobates',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Mantella Frog',
+    'scientific_name': 'Mantella',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Marine Toad',
+    'scientific_name': 'Bufo Marinus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Marsh Frog',
+    'scientific_name': 'Pelophylax ridibundus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Monte Iberia Eleuth',
+    'scientific_name': 'Eleutherodactylus iberia',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Mudpuppy',
+    'scientific_name': 'Necturus maculosus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Natterjack',
+    'scientific_name': 'Epidalea calamita',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Newt',
+    'scientific_name': 'Salamandridae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Oak Toad',
+    'scientific_name': 'Anaxyrus quercicus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Olm',
+    'scientific_name': 'Proteus anguinus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Oregon Spotted Frog',
+    'scientific_name': 'Rana pretiosa',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Poison Dart Frog',
+    'scientific_name': 'Dendrobatidae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Pool Frog',
+    'scientific_name': 'Pelophylax lessonae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Red-Eyed Tree Frog',
+    'scientific_name': 'Agalychnis callidryas',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Salamander',
+    'scientific_name': 'Caudata',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Scrotum Frog',
+    'scientific_name': 'Telmatobius culeus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Sehuencas Water Frog',
+    'scientific_name': 'Telmatobius yuracare',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Spadefoot Toad',
+    'scientific_name': 'Mesobatrachia',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Striped Rocket Frog',
+    'scientific_name': 'Litoria nasuta',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Tiger Salamander',
+    'scientific_name': 'Ambystoma tigrinum',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Tree Frog',
+    'scientific_name': 'Hylidae',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Turtle Frog',
+    'scientific_name': 'Myobatrachus gouldii',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Wood Frog',
+    'scientific_name': 'Lithobates sylvaticus',
+    'class': 'amphibians'
+  },
+  {
+    'common_name': 'Wyoming Toad',
+    'scientific_name': 'Anaxyrus Baxteri',
+    'class': 'amphibians'
+  }
+]

--- a/tests/providers/test_animals.py
+++ b/tests/providers/test_animals.py
@@ -1,0 +1,50 @@
+import pytest
+from faker.providers.animals.constants import animals
+
+@pytest.fixture
+def animal_names():
+    return [animal['common_name'] for animal in animals]
+
+@pytest.fixture
+def animal_scientific_names():
+    return [animal['scientific_name'] for animal in animals]
+
+def test_animal(faker):
+    animal = faker.animal()
+    assert animal is not None
+
+def test_animal_name(faker,animal_names):
+    name = faker.animal_name()
+    assert name in animal_names
+
+
+def test_animal_name_scientific(faker,animal_scientific_names):
+    name_scientific = faker.animal_name_scientific()
+    assert name_scientific in animal_scientific_names
+
+
+def test_bird(faker):
+    animal = faker.bird()
+    assert animal['class'] == 'birds'
+
+
+def test_fish(faker):
+    animal = faker.fish()
+    assert animal['class'] == 'fish'
+
+
+def test_mammal(faker):
+    animal = faker.mammal()
+    assert animal['class'] == 'mammals'
+
+
+def test_reptile(faker):
+    animal = faker.reptile()
+    assert animal['class'] == 'reptiles'
+
+
+def test_amphibian(faker):
+    animal = faker.amphibian()
+    assert animal['class'] == 'amphibians'
+
+


### PR DESCRIPTION
### What does this change

Adds a new Animals provider that offers comprehensive and accurate animals data,covering an extensive range of species. It includes info like the common name and the scientific name. This data can be useful for applications requiring realistic representations of biological diversity, educational tools, wildlife databases, or any project that needs accurate animal species data.

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
