### PR TITLE
Fix korean road address

### DIFF
--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -454,8 +454,12 @@ class Provider(AddressProvider):
         "{{building_name}} {{building_dong}}동 ###호",
     )
     road_formats = (
-        "{{road_name}}{{road_suffix}}",
-        "{{road_name}}{{road_number}}{{road_suffix}}",
+        "{{road_name}}{{road_suffix}} ###",
+        "{{road_name}}{{road_suffix}} 지하###",
+        "{{road_name}}{{road_suffix}} ###-##",
+        "{{road_name}}{{road_number}}{{road_suffix}} ###",
+        "{{road_name}}{{road_number}}{{road_suffix}} 지하###",
+        "{{road_name}}{{road_number}}{{road_suffix}} ###-##",
     )
     road_address_formats = (
         "{{metropolitan_city}} {{borough}} {{road}}",

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1316,6 +1316,11 @@ class TestKoKr:
             building_dong = faker.building_dong()
             assert isinstance(building_dong, str)
 
+    def test_road_address(self, faker, num_samples):
+        for _ in range(num_samples):
+            road_address = faker.road_address()
+            assert isinstance(road_address, str)
+
 
 class TestNeNp:
     """Test ne_NP address provider methods"""


### PR DESCRIPTION
### What does this change

Adds building-number(건물 번호) to a road address in 'ko_KR' locale. Without building-numbers, faker-generated addresses do not reflect real addressing system in Republic of Korea(South korea). 

**before:**
address form: `"{{road_name}}{{road_suffix}}"`
대전광역시 강서구 석촌호수거리

**after:** 
*below shows one of possible outputs*

- **대전광역시 강서구 석촌호수거리 110** (Basic building number format)
- **대전광역시 강서구 석촌호수거리 지하110** (The building's main entrance is underground)
- **대전광역시 강서구 석촌호수거리 110-31** (The building is cramped together, distinguished by sub-building number; exact format is (*main-building-number*)-(*sub-building-number*))

(FYI, 석촌호수거리 is a road name.)
 
Change above also applies to the other form of an address, which is defined as : `"{{road_name}}{{road_number}}{{road_suffix}}"`.  

### What was wrong

The original source code did not include any logic to generate building numbers. Although it is explained on comments written on source code.

### How this fixes it

Added additional strings to describe building numbers. 

Fixes #2132 

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
