### PR TITLE
Remove Collection[str] type from ElementTypes

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -17,7 +17,7 @@ _re_qm = re.compile(r"\?")
 _re_cir = re.compile(r"\^")
 
 T = TypeVar("T")
-ElementsType = Union[Collection[str], Collection[T], OrderedDictType[T, float]]
+ElementsType = Union[Collection[T], OrderedDictType[T, float]]
 
 
 class BaseProvider:
@@ -532,7 +532,7 @@ class BaseProvider:
         """
         return self.random_elements(elements, length, unique=False)
 
-    def random_element(self, elements: ElementsType[T] = ("a", "b", "c")) -> T:
+    def random_element(self, elements: ElementsType[T] = ("a", "b", "c")) -> T:  # type: ignore[assignment]
         """Generate a randomly sampled object from ``elements``.
 
         For information on the ``elements`` argument, please refer to


### PR DESCRIPTION
### What does this change

This removes `Collection[str]` type from `ElementsType` union type.

### What was wrong

`ElementsType` union type already has `Collection[T]` which can resolve to `Collection[str]` when type is `ElementsType[str]`. New mypy versions could not narrow `ElementsType` type when it was used as argument type.

### How this fixes it

Remove `Collection[str]` type from `ElementsType` union type and expect everyone to use `ElementsType[str]` when they want `Collection[str]`.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint` (I did not include changes to `faker/proxy.pyi` or changes to unrelated files.)
