### PR TITLE
Resolve address number output issue and refactor road_formats for clarity

### DIFF
--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -527,6 +527,44 @@ class Provider(AddressProvider):
         """
         return self.random_element(self.road_suffixes)
 
+    def building_number(self) -> str:
+        """
+        :returns: A random building number
+
+        Generates building number(건물 번호). There are 3 types of building number with current ROK addressing system.
+            (1) 19: A typical format. Only marks one building.
+            (2) 지하11: The building entrance is underground.
+            (3) 132-1: Several buildings are distinguished with sub-building-number(가지 번호).
+
+        Generating probability is arbitrarily.
+
+        :example: 19, 지하11, 143-1
+        """
+        if self.random_int() % 9 < 1:
+            return self.building_number_underground()
+        elif self.random_int() % 9 < 4:
+            return self.building_number_segregated()
+        else:
+            return self.generator.random.randint(1, 999)
+
+    def building_number_underground(self) -> str:
+        """
+        :returns: A random building number with undergrond entrances
+
+        :example: 지하11
+        """
+        return "지하%d" % (self.generator.random.randint(1,999))
+
+    def building_number_segregated(self) -> str:
+        """
+        :returns: A random building number distinguished with sub-building-number(가지 번호)
+
+        :example: 143-1
+        """
+        main_building_number = self.generator.random.randint(1, 999)
+        sub_building_number = self.generator.random.randint(1, 99)
+        return "%d-%d" % (main_building_number, sub_building_number)
+
     def metropolitan_city(self) -> str:
         """
         :example: 서울특별시

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -545,7 +545,7 @@ class Provider(AddressProvider):
         elif self.random_int() % 9 < 4:
             return self.building_number_segregated()
         else:
-            return self.generator.random.randint(1, 999)
+            return "%d" % self.generator.random.randint(1, 999)
 
     def building_number_underground(self) -> str:
         """

--- a/faker/providers/address/ko_KR/__init__.py
+++ b/faker/providers/address/ko_KR/__init__.py
@@ -454,12 +454,8 @@ class Provider(AddressProvider):
         "{{building_name}} {{building_dong}}동 ###호",
     )
     road_formats = (
-        "{{road_name}}{{road_suffix}} ###",
-        "{{road_name}}{{road_suffix}} 지하###",
-        "{{road_name}}{{road_suffix}} ###-##",
-        "{{road_name}}{{road_number}}{{road_suffix}} ###",
-        "{{road_name}}{{road_number}}{{road_suffix}} 지하###",
-        "{{road_name}}{{road_number}}{{road_suffix}} ###-##",
+        "{{road_name}}{{road_suffix}} {{building_number}}",
+        "{{road_name}}{{road_number}}{{road_suffix}} {{building_number}}",
     )
     road_address_formats = (
         "{{metropolitan_city}} {{borough}} {{road}}",

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1309,16 +1309,21 @@ class TestKoKr:
         for _ in range(num_samples):
             building_number = faker.building_number()
             assert isinstance(building_number, str)
+            assert '#' not in building_number
 
     def test_building_number_underground(self, faker, num_samples):
         for _ in range(num_samples):
             building_number = faker.building_number_underground()
             assert isinstance(building_number, str)
+            assert '#' not in building_number
+            assert building_number[:2] == '지하'
 
     def test_building_number_segregated(self, faker, num_samples):
         for _ in range(num_samples):
             building_number = faker.building_number_segregated()
             assert isinstance(building_number, str)
+            assert '#' not in building_number
+            assert '-' in building_number
 
     def test_building_suffix(self, faker, num_samples):
         for _ in range(num_samples):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1305,6 +1305,21 @@ class TestKoKr:
             building_name = faker.building_name()
             assert isinstance(building_name, str)
 
+    def test_building_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number()
+            assert isinstance(building_number, (str, int))
+
+    def test_building_number_underground(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number_underground()
+            assert isinstance(building_number, str)
+
+    def test_building_number_segregated(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number_segregated()
+            assert isinstance(building_number, str)
+
     def test_building_suffix(self, faker, num_samples):
         for _ in range(num_samples):
             building_suffix = faker.building_suffix()
@@ -1320,21 +1335,6 @@ class TestKoKr:
         for _ in range(num_samples):
             road_address = faker.road_address()
             assert isinstance(road_address, str)
-
-    def test_building_number(self, faker, num_samples):
-        for _ in range(num_samples):
-            building_number = faker.building_number()
-            assert isinstance(building_number, (str, int))
-
-    def test_building_number_underground(self, faker, num_samples):
-        for _ in range(num_samples):
-            building_number = faker.building_number_underground()
-            assert isinstance(building_number, str)
-
-    def test_building_number_segregated(self, faker, num_samples):
-        for _ in range(num_samples):
-            building_number = faker.building_number_segregated()
-            assert isinstance(building_number, str)
 
 
 class TestNeNp:

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1308,7 +1308,7 @@ class TestKoKr:
     def test_building_number(self, faker, num_samples):
         for _ in range(num_samples):
             building_number = faker.building_number()
-            assert isinstance(building_number, (str, int))
+            assert isinstance(building_number, str)
 
     def test_building_number_underground(self, faker, num_samples):
         for _ in range(num_samples):

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1321,6 +1321,21 @@ class TestKoKr:
             road_address = faker.road_address()
             assert isinstance(road_address, str)
 
+    def test_building_number(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number()
+            assert isinstance(building_number, (str, int))
+
+    def test_building_number_underground(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number_underground()
+            assert isinstance(building_number, str)
+
+    def test_building_number_segregated(self, faker, num_samples):
+        for _ in range(num_samples):
+            building_number = faker.building_number_segregated()
+            assert isinstance(building_number, str)
+
 
 class TestNeNp:
     """Test ne_NP address provider methods"""


### PR DESCRIPTION
# What does this change
This change addresses the issue in the previous implementation (#2133), where `#` was mistakenly printed instead of the actual address numbers. Additionally, the `road_formats` structure has been simplified by incorporating `{{building_number}}` directly for more concise formatting.

# What was wrong
The original code had a formatting error where `#` was printed instead of the intended numeric address numbers. This caused unexpected outputs in the feature responsible for generating ROK (🇰🇷) road addresses (도로명 주소), leading to inaccuracies.

# How this fixes it
The building_number method now correctly handles the generation of building numbers. It produces a standard building number or, with a certain probability, generates variations such as underground entrances using `building_number_underground()` or `includes sub-building numbers via building_number_segregated()`. This probability was determined arbitrarily, as there are no official government statistics available for this data.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
