### PR TITLE
Add support for Zulu (zu_ZA) address provider and corresponding tests

### DIFF
--- a/faker/providers/address/zu_ZA/__init__.py
+++ b/faker/providers/address/zu_ZA/__init__.py
@@ -1,0 +1,185 @@
+from .. import Provider as AddressProvider
+
+
+class Provider(AddressProvider):
+    """
+    Address Provider for the zu_ZA locale (Zulu, South Africa).
+
+    Data sourced from:
+    - South African cities and towns: https://en.wikipedia.org/wiki/List_of_cities_and_towns_in_South_Africa
+    - South African postal codes: https://en.wikipedia.org/wiki/List_of_postal_codes_in_South_Africa
+    - Languages of South Africa: https://en.wikipedia.org/wiki/Languages_of_South_Africa
+    """
+
+    city_formats = ("{{city_name}}",)
+    building_number_formats = ("%#", "%##", "%###")
+    postcode_formats = ("%###",)  # Güncellendi: 4 haneli posta kodu için
+    section_formats = ("",)
+    street_address_formats = ("{{building_number}} {{street_name}} {{street_suffix}}",)
+    address_formats = ("{{street_address}}, {{city}}, {{postcode}}",)
+    secondary_address_formats = ("Flat #%#", "Unit #%#", "Suite #%#")
+
+    street_names = (
+        "Main",
+        "Church",
+        "President",
+        "Voortrekker",
+        "Nelson Mandela",
+        "Albertina Sisulu",
+        "Rivonia",
+        "Jan Smuts",
+        "Commissioner",
+        "Long",
+        "High",
+        "Short",
+        "Victoria",
+        "Queen",
+        "King",
+        "Oxford",
+        "George",
+        "William",
+        "York",
+        "Smith",
+        "Adelaide",
+        "Charles",
+        "Churchill",
+        "Cecil",
+        "Clarence",
+        "Edward",
+        "Elizabeth",
+        "Frere",
+        "Gandhi",
+        "Grey",
+        "James",
+        "Joseph",
+        "Milner",
+        "Napier",
+        "Paul Kruger",
+        "Prince",
+        "Somerset",
+        "Stanley",
+        "Thomas",
+        "Walter Sisulu",
+        "West",
+    )
+
+    street_suffixes = ("Umgwaqo", "Indlela", "Isitaladi", "Ithafa", "Indawo")
+
+    cities = (
+        "eGoli",
+        "eThekwini",
+        "iBhayi",
+        "iKapa",
+        "uMgungundlovu",
+        "Polokwane",
+        "Mbombela",
+        "Mahikeng",
+        "Kimberley",
+        "Bloemfontein",
+        "Rustenburg",
+        "Soweto",
+        "Benoni",
+        "Tembisa",
+        "Welkom",
+        "Vereeniging",
+        "Chatsworth",
+        "Uitenhage",
+        "Middelburg",
+        "Springs",
+        "Randfontein",
+        "Boksburg",
+        "Witbank",
+        "Klerksdorp",
+        "Bethlehem",
+        "George",
+        "Upington",
+        "Musina",
+        "Vanderbijlpark",
+        "Stellenbosch",
+        "Krugersdorp",
+        "Sasolburg",
+        "Centurion",
+        "Newcastle",
+        "Thohoyandou",
+        "Potchefstroom",
+        "Kathu",
+        "Paarl",
+    )
+
+    city_suffixes = ("",)
+
+    countries = (
+        "iNingizimu Afrika",
+        "Botswana",
+        "Lesotho",
+        "Namibia",
+        "Eswatini",
+        "Zimbabwe",
+        "Mozambique",
+        "Angola",
+        "Zambia",
+        "Malawi",
+        "Madagascar",
+        "Tanzania",
+        "Kenya",
+        "Nigeria",
+        "Ghana",
+        "Egypt",
+        "Morocco",
+        "Tunisia",
+        "Algeria",
+        "Ethiopia",
+        "Sudan",
+        "Somalia",
+        "Uganda",
+        "Cameroon",
+        "DR Congo",
+        "Rwanda",
+        "Burundi",
+        "Senegal",
+        "Mali",
+        "Ivory Coast",
+        "Niger",
+        "Chad",
+        "Mauritania",
+        "Eritrea",
+        "Djibouti",
+        "Cape Verde",
+        "Seychelles",
+        "Mauritius",
+        "Comoros",
+        "Gambia",
+        "Liberia",
+        "Sierra Leone",
+        "Benin",
+        "Togo",
+        "Equatorial Guinea",
+        "Gabon",
+        "Congo",
+        "Central African Republic",
+        "Sao Tome and Principe",
+        "Guinea",
+        "Guinea-Bissau",
+        "Burkina Faso",
+    )
+
+    def secondary_address(self) -> str:
+        return self.numerify(self.random_element(self.secondary_address_formats))
+
+    def building_number(self) -> str:
+        return self.numerify(self.random_element(self.building_number_formats))
+
+    def street_name(self) -> str:
+        return self.random_element(self.street_names)
+
+    def street_suffix(self) -> str:
+        return self.random_element(self.street_suffixes)
+
+    def city_name(self) -> str:
+        return self.random_element(self.cities)
+
+    def city_name_suffix(self) -> str:
+        return self.random_element(self.city_suffixes)
+
+    def section_number(self) -> str:
+        return self.numerify(self.random_element(self.section_formats))

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -56,6 +56,7 @@ from faker.providers.address.uk_UA import Provider as UkUaAddressProvider
 from faker.providers.address.vi_VN import Provider as ViVNAddressProvider
 from faker.providers.address.zh_CN import Provider as ZhCnAddressProvider
 from faker.providers.address.zh_TW import Provider as ZhTwAddressProvider
+from faker.providers.address.zu_ZA import Provider as ZuZaAddressProvider
 
 
 class TestBaseProvider:
@@ -2564,3 +2565,48 @@ class TestPlPl:
             postalcode = faker.postalcode()
             match = re.findall(r"^^\d{2}-\d{3}$$", postalcode)
             assert match
+
+
+class TestZuZa:
+    """Test zu_ZA address provider methods"""
+
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            assert re.fullmatch(r"\d{4}", postcode)
+
+    def test_city_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_name = faker.city_name()
+            assert isinstance(city_name, str)
+            assert city_name in ZuZaAddressProvider.cities
+
+    def test_city_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            city_suffix = faker.city_suffix()
+            assert isinstance(city_suffix, str)
+            assert city_suffix in ZuZaAddressProvider.city_suffixes
+
+    def test_city(self, faker, num_samples):
+        for _ in range(num_samples):
+            city = faker.city()
+            assert isinstance(city, str)
+            assert city in ZuZaAddressProvider.cities
+
+    def test_country(self, faker, num_samples):
+        for _ in range(num_samples):
+            country = faker.country()
+            assert isinstance(country, str)
+            assert country in ZuZaAddressProvider.countries
+
+    def test_street_name(self, faker, num_samples):
+        for _ in range(num_samples):
+            street_name = faker.street_name()
+            assert isinstance(street_name, str)
+            assert street_name in ZuZaAddressProvider.street_names
+
+    def test_address(self, faker, num_samples):
+        for _ in range(num_samples):
+            address = faker.address()
+            assert isinstance(address, str)


### PR DESCRIPTION
### What does this change

Adds a new `AddressProvider` for the `zu_ZA` locale (Zulu, South Africa) to generate realistic fake addresses, including city names, street names, postal codes, and countries relevant to the region.

### What was wrong

The Faker library lacked support for the `zu_ZA` locale's address data, and the initial postal code format generated incorrect 5-digit codes, causing tests to fail.

### How this fixes it

Introduces accurate locale-specific data and corrects the postal code format to produce 4-digit codes matching South African standards, ensuring all tests pass.

Fixes #2105 

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
