### PR TITLE
feat: adds city geodata for Uzbekistan

### DIFF
--- a/faker/providers/geo/uz_UZ/__init__.py
+++ b/faker/providers/geo/uz_UZ/__init__.py
@@ -1,0 +1,22 @@
+from .. import Provider as GeoProvider
+
+
+class Provider(GeoProvider):
+    # Source: https://time-in.ru/coordinates/uzbekistan
+    land_coords = (
+        ("41.26465", "69.21627", "Toshkent", "UZ", "Asia/Tashkent"),
+        ("39.65417", "66.95972", "Samarqand", "UZ", "Asia/Tashkent"),
+        ("39.77472", "64.42861", "Buxoro", "UZ", "Asia/Tashkent"),
+        ("41.37833", "60.36389", "Xiva", "UZ", "Asia/Tashkent"),
+        ("39.05778", "66.83444", "Shahrisabz", "UZ", "Asia/Tashkent"),
+        ("43.76833", "59.02028", "Mo‘ynoq", "UZ", "Asia/Tashkent"),
+        ("37.22417", "67.27833", "Termiz", "UZ", "Asia/Tashkent"),
+        ("42.45306", "59.61444", "Nukus", "UZ", "Asia/Tashkent"),
+        ("41.00000", "71.66667", "Namangan", "UZ", "Asia/Tashkent"),
+        ("40.78333", "72.35000", "Andijon", "UZ", "Asia/Tashkent"),
+        ("40.38333", "71.78333", "Farg‘ona", "UZ", "Asia/Tashkent"),
+        ("38.86000", "65.79722", "Qarshi", "UZ", "Asia/Tashkent"),
+        ("40.08333", "65.37917", "Navoiy", "UZ", "Asia/Tashkent"),
+        ("40.53139", "70.94250", "Qo‘qon", "UZ", "Asia/Tashkent"),
+        ("41.55333", "60.63194", "Urganch", "UZ", "Asia/Tashkent"),
+    )


### PR DESCRIPTION
### What does this change

This commit adds a list of cities in Uzbekistan (locale `uz_UZ`) to the dataset, including their latitude, longitude, city name (in Uzbek), country code, and time zone.

### What was wrong

The dataset `geo/uz_UZ` lacked geographical information about cities in Uzbekistan, which limited its utility for mocking data involving this region.

### How this fixes it

The commit introduces a formatted list of cities in Uzbekistan, filling the gap and providing accurate geodata for enhanced usability.


### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
