### PR TITLE
Add `ru_RU` SNILS generator

### DIFF
--- a/faker/providers/company/ru_RU/__init__.py
+++ b/faker/providers/company/ru_RU/__init__.py
@@ -12,6 +12,11 @@ def calculate_checksum(value: str) -> str:
     return str((check_sum % 11) % 10)
 
 
+def calculate_snils_checksum(numbers: str) -> str:
+    checksum = sum(int(v) * (9 - i) for i, v in enumerate(numbers)) % 101
+    return "%02d" % (checksum if checksum < 100 else 0)
+
+
 class Provider(CompanyProvider):
     formats = (
         "{{company_prefix}} «{{last_name}}»",
@@ -1168,3 +1173,10 @@ class Provider(CompanyProvider):
         tail: str = "%03d" % self.random_int(min=1, max=999)
 
         return region + inspection + reason + tail
+
+    def snils(self) -> str:
+        """
+        Returns SNILS number (ru. СНИЛС).
+        """
+        numbers: str = "%09d" % self.random_int(min=1, max=999999999)
+        return numbers + calculate_snils_checksum(numbers)

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -22,7 +22,7 @@ from faker.providers.company.pl_PL import company_vat_checksum, local_regon_chec
 from faker.providers.company.pt_BR import company_id_checksum
 from faker.providers.company.ro_RO import Provider as RoRoCompanyProvider
 from faker.providers.company.ru_RU import Provider as RuRuCompanyProvider
-from faker.providers.company.ru_RU import calculate_checksum
+from faker.providers.company.ru_RU import calculate_checksum, calculate_snils_checksum
 from faker.providers.company.th_TH import Provider as ThThCompanyProvider
 from faker.providers.company.tr_TR import Provider as TrTrCompanyProvider
 from faker.providers.company.vi_VN import Provider as ViVnCompanyProvider
@@ -363,6 +363,12 @@ class TestRuRu:
             bs_words = bs.split()
             assert isinstance(bs, str)
             assert bs_words[0] in RuRuCompanyProvider.bsWords[0]
+
+    def test_snils(self, faker, num_samples):
+        for _ in range(num_samples):
+            snils = faker.snils()
+            assert len(snils) == 11
+            assert snils[-2:] == calculate_snils_checksum(snils[:10])
 
 
 class TestItIt:


### PR DESCRIPTION
### What does this change
Resolves #2150.
Add `company.snils` function of locale `ru_RU`, and here is [the implementation](https://mimesis.name/master/_modules/mimesis/builtins/ru.html#RussiaSpecProvider.snils) in `mimesis`.
### Checklist
- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
