### PR TITLE
Fix typing for uuid4()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,15 +159,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: '3.12'
     - name: Install dependencies
       run: |
-        python -m pip install mypy
-    - name: Static type checking with mypy
-      uses: liskin/gh-problem-matcher-wrap@v3
-      with:
-        linters: mypy
-        run: mypy --install-types --non-interactive --config mypy.ini faker
+        python -m pip install tox==3.27.1 setuptools
+    - name: Run tests
+      run: tox
+      env:
+        TOXENV: mypy
+        TEST_ALPINE: 1
 
   test_ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         python -m pip install tox==3.27.1 setuptools
@@ -167,7 +167,6 @@ jobs:
       run: tox
       env:
         TOXENV: mypy
-        TEST_ALPINE: 1
 
   test_ubuntu:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,7 @@ Making Changes
    the new branch with ``git checkout fix/master/my_contribution``.
    Please avoid working directly on the ``master`` branch.
 -  Make commits of logical units.
+-  Install the development requirements: ``python -m pip install -e .[dev]``
 -  Follow our `coding style`_. You can run ``make lint`` to format your code.
 -  Check for unnecessary whitespace with ``git diff --check`` before
    committing.

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,16 @@ mypy:
 	mypy --install-types --non-interactive --config mypy.ini faker
 
 black:
-	black --line-length 120 .
+	black .
 
 isort:
 	isort --atomic .
 
-generate-stubs: 
-	python3.10 generate_stubs.py
+generate-stubs:
+	python3.11 generate_stubs.py
+	black faker/proxy.pyi
+	isort faker/proxy.pyi
+
 
 lint: generate-stubs isort black mypy flake8
 

--- a/docs/coding_style.rst
+++ b/docs/coding_style.rst
@@ -5,7 +5,7 @@ We use the black code style with a line length of 120 characters and trailing co
 
 You can format the code with::
 
-    black --line-length 120
+    black .
 
 Please include `type hints`_ for every provider method you write. An overview of generic types is included below.
 

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -9,7 +9,7 @@ import tarfile
 import uuid
 import zipfile
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, overload
 
 from typing_extensions import TypeAlias
 
@@ -103,6 +103,18 @@ class Provider(BaseProvider):
         if raw_output:
             return res.digest()
         return res.hexdigest()
+
+    @overload
+    def uuid4(self) -> str: ...
+
+    @overload
+    def uuid4(self, cast_to: None) -> uuid.UUID: ...
+
+    @overload
+    def uuid4(self, cast_to: Callable[[uuid.UUID], str]) -> str: ...
+
+    @overload
+    def uuid4(self, cast_to: Callable[[uuid.UUID], bytes]) -> bytes: ...
 
     def uuid4(
         self,

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -2337,16 +2337,49 @@ class Faker:
         ...
 
     @overload
-    def uuid4(self) -> str: ...
+    def uuid4(self) -> str:
+        """
+        Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
+
+        By default, ``cast_to`` is set to ``str``.
+
+        May be called with ``cast_to=None`` to return a full-fledged ``UUID``.
+
+        :sample:
+        :sample: cast_to=None
+        """
+        ...
+
     @overload
-    def uuid4(self, cast_to: None) -> UUID: ...
+    def uuid4(self, cast_to: None) -> UUID:
+        """
+        Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
+
+        By default, ``cast_to`` is set to ``str``.
+
+        May be called with ``cast_to=None`` to return a full-fledged ``UUID``.
+
+        :sample:
+        :sample: cast_to=None
+        """
+        ...
+
     @overload
-    def uuid4(self, cast_to: Callable[[UUID], str]) -> str: ...
+    def uuid4(self, cast_to: Callable[[UUID], str]) -> str:
+        """
+        Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
+
+        By default, ``cast_to`` is set to ``str``.
+
+        May be called with ``cast_to=None`` to return a full-fledged ``UUID``.
+
+        :sample:
+        :sample: cast_to=None
+        """
+        ...
+
     @overload
-    def uuid4(self, cast_to: Callable[[UUID], bytes]) -> bytes: ...
-    def uuid4(
-        self, cast_to: Union[Callable[[UUID], str], Callable[[UUID], bytes], None] = ...
-    ) -> Union[bytes, str, UUID]:
+    def uuid4(self, cast_to: Callable[[UUID], bytes]) -> bytes:
         """
         Generate a random UUID4 object and cast it to another type if specified using a callable ``cast_to``.
 

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -23,6 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 from uuid import UUID
 
@@ -2335,6 +2336,14 @@ class Faker:
         """
         ...
 
+    @overload
+    def uuid4(self) -> str: ...
+    @overload
+    def uuid4(self, cast_to: None) -> UUID: ...
+    @overload
+    def uuid4(self, cast_to: Callable[[UUID], str]) -> str: ...
+    @overload
+    def uuid4(self, cast_to: Callable[[UUID], bytes]) -> bytes: ...
     def uuid4(
         self, cast_to: Union[Callable[[UUID], str], Callable[[UUID], bytes], None] = ...
     ) -> Union[bytes, str, UUID]:

--- a/generate_stubs.py
+++ b/generate_stubs.py
@@ -3,7 +3,7 @@ import pathlib
 import re
 
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, get_type_hints
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, get_overloads, get_type_hints
 
 import faker.proxy
 
@@ -18,7 +18,7 @@ MODULES_TO_FULLY_QUALIFY = ["datetime"]
 imports: Dict[str, Optional[Set[str]]] = defaultdict(lambda: None)
 imports["collections"] = {"OrderedDict"}
 imports["json"] = {"encoder"}
-imports["typing"] = {"Callable", "Collection", "TypeVar"}
+imports["typing"] = {"Callable", "Collection", "TypeVar", "overload"}
 imports["uuid"] = {"UUID"}
 imports["enum"] = {"Enum"}
 imports["faker.typing"] = {"*"}
@@ -90,6 +90,80 @@ def get_member_functions_and_variables(cls: object, include_mangled: bool = Fals
     return UniqueMemberFunctionsAndVariables(cls, funcs, vars)
 
 
+def get_signatures_for_func(func_value, func_name, locale, is_overload: bool = False):
+    """Return the signatures for the given function, recursing as necessary to handle overloads."""
+    signatures = []
+
+    if not is_overload:
+        try:
+            overloads = get_overloads(func_value)
+        except Exception as e:
+            raise TypeError(f"Can't parse overloads for {func_name}{sig}.") from e
+
+        for overload in overloads:
+            signatures.extend(get_signatures_for_func(overload, func_name, locale, is_overload=True))
+
+    sig = inspect.signature(func_value)
+    try:
+        hints = get_type_hints(func_value)
+    except Exception as e:
+        raise TypeError(f"Can't parse {func_name}{sig}.") from e
+    ret_annot_module = getattr(sig.return_annotation, "__module__", None)
+    if sig.return_annotation not in [
+        None,
+        inspect.Signature.empty,
+        prov_cls.__name__,
+    ] and ret_annot_module not in [
+        None,
+        *BUILTIN_MODULES_TO_IGNORE,
+    ]:
+        module, member = get_module_and_member_to_import(sig.return_annotation, locale)
+        if module not in [None, "types"]:
+            if imports[module] is None:
+                imports[module] = set() if member is None else {member}
+            elif member is not None:
+                imports[module].add(member)
+
+    new_parms = []
+    for key, parm_val in sig.parameters.items():
+        new_parm = parm_val
+        annotation = hints.get(key, new_parm.annotation)
+        if parm_val.default is not inspect.Parameter.empty:
+            new_parm = parm_val.replace(default=...)
+        if annotation is not inspect.Parameter.empty and annotation.__module__ not in BUILTIN_MODULES_TO_IGNORE:
+            module, member = get_module_and_member_to_import(annotation, locale)
+            if module not in [None, "types"]:
+                if imports[module] is None:
+                    imports[module] = set() if member is None else {member}
+                elif member is not None:
+                    imports[module].add(member)
+        new_parms.append(new_parm)
+
+    sig = sig.replace(parameters=new_parms)
+    sig_str = str(sig).replace("Ellipsis", "...").replace("NoneType", "None").replace("~", "")
+    for module in imports.keys():
+        if module in MODULES_TO_FULLY_QUALIFY:
+            continue
+        sig_str = sig_str.replace(f"{module}.", "")
+
+    decorator = ""
+    if is_overload:
+        decorator += "@overload\n"
+    if list(sig.parameters)[0] == "cls":
+        decorator += "@classmethod\n"
+    elif list(sig.parameters)[0] != "self":
+        decorator += "@staticmethod\n"
+    comment = inspect.getdoc(func_value)
+    signatures.append(
+        (
+            f"{decorator}def {func_name}{sig_str}: ...",
+            None if comment == "" else comment,
+            False,
+        )
+    )
+    return signatures
+
+
 classes_and_locales_to_use_for_stub: List[Tuple[object, str]] = []
 for locale in AVAILABLE_LOCALES:
     for provider in PROVIDERS:
@@ -115,54 +189,7 @@ signatures_with_comments: List[Tuple[str, str, bool]] = []
 
 for mbr_funcs_and_vars, locale in all_members:
     for func_name, func_value in mbr_funcs_and_vars.funcs.items():
-        sig = inspect.signature(func_value)
-        try:
-            hints = get_type_hints(func_value)
-        except Exception as e:
-            raise TypeError(f"Can't parse {func_name}{sig}.") from e
-        ret_annot_module = getattr(sig.return_annotation, "__module__", None)
-        if sig.return_annotation not in [None, inspect.Signature.empty, prov_cls.__name__] and ret_annot_module not in [
-            None,
-            *BUILTIN_MODULES_TO_IGNORE,
-        ]:
-            module, member = get_module_and_member_to_import(sig.return_annotation, locale)
-            if module is not None:
-                if imports[module] is None:
-                    imports[module] = set() if member is None else {member}
-                elif member is not None:
-                    imports[module].add(member)
-
-        new_parms = []
-        for key, parm_val in sig.parameters.items():
-            new_parm = parm_val
-            annotation = hints.get(key, new_parm.annotation)
-            if parm_val.default is not inspect.Parameter.empty:
-                new_parm = parm_val.replace(default=...)
-            if annotation is not inspect.Parameter.empty and annotation.__module__ not in BUILTIN_MODULES_TO_IGNORE:
-                module, member = get_module_and_member_to_import(annotation, locale)
-                if module is not None:
-                    if imports[module] is None:
-                        imports[module] = set() if member is None else {member}
-                    elif member is not None:
-                        imports[module].add(member)
-            new_parms.append(new_parm)
-
-        sig = sig.replace(parameters=new_parms)
-        sig_str = str(sig).replace("Ellipsis", "...").replace("NoneType", "None").replace("~", "")
-        for module in imports.keys():
-            if module in MODULES_TO_FULLY_QUALIFY:
-                continue
-            sig_str = sig_str.replace(f"{module}.", "")
-
-        decorator = ""
-        if list(sig.parameters)[0] == "cls":
-            decorator = "@classmethod\n"
-        elif list(sig.parameters)[0] != "self":
-            decorator = "@staticmethod\n"
-        comment = inspect.getdoc(func_value)
-        signatures_with_comments.append(
-            (f"{decorator}def {func_name}{sig_str}: ...", None if comment == "" else comment, False)
-        )
+        signatures_with_comments.extend(get_signatures_for_func(func_value, func_name, locale))
 
 signatures_with_comments_as_str = []
 for sig, comment, is_preceding_comment in signatures_with_comments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extra_test = [
 extra_flake8 = ["flake8>=4.0.0", "flake8-comprehensions"]
 extra_check_manifest = ["check-manifest"]
 extra_isort = ["isort"]
-extra_mypy = ["mypy==0.910"]
+extra_mypy = ["mypy==1.14.1"]
 extra_black = ["black==24.4.0"]
 extra_doc8 = ["doc8"]
 extra_dev = list(

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,26 @@ try:
 except AttributeError:
     zip_safe = False
 
+extra_test = [
+    "coverage>=5.2",
+    "freezegun",
+    "pytest>=6.0.1",
+    "ukpostcodeparser>=1.1.1",
+    "validators>=0.13.0",
+    "sphinx>=2.4,<3.0",
+    "Pillow",
+    "xmltodict",
+]
+extra_flake8 = ["flake8>=4.0.0", "flake8-comprehensions"]
+extra_check_manifest = ["check-manifest"]
+extra_isort = ["isort"]
+extra_mypy = ["mypy==0.910"]
+extra_black = ["black==24.4.0"]
+extra_doc8 = ["doc8"]
+extra_dev = list(
+    set(extra_test + extra_flake8 + extra_check_manifest + extra_isort + extra_mypy + extra_black + extra_doc8)
+)
+
 setup(
     name="Faker",
     version=VERSION,
@@ -73,4 +93,14 @@ setup(
         "python-dateutil>=2.4",
         "typing_extensions",
     ],
+    extras_require={
+        "test": extra_test,
+        "flake8": extra_flake8,
+        "check-manifest": extra_check_manifest,
+        "isort": extra_isort,
+        "mypy": extra_mypy,
+        "black": extra_black,
+        "doc8": extra_doc8,
+        "dev": extra_dev,
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,7 @@ envlist=py{38,39,310,311,312,313,py3},alpine,flake8,checkmanifest,isort,mypy,doc
 skip_missing_interpreters = true
 
 [testenv]
-deps =
-    coverage>=5.2
-    freezegun
-    pytest>=6.0.1
-    ukpostcodeparser>=1.1.1
-    validators>=0.13.0
-    sphinx>=2.4,<3.0
-    Pillow
-    xmltodict
+extras = test
 commands =
     coverage run --source=faker -m pytest {posargs}
     coverage run --source=faker -a -m pytest --exclusive-faker-session tests/pytest/session_overrides {posargs}
@@ -19,39 +11,34 @@ commands =
 
 [testenv:flake8]
 basepython = python
-deps =
-    flake8>=4.0.0
-    flake8-comprehensions
+extras = flake8
 commands =
     flake8 --extend-ignore=E203 faker tests
 
 [testenv:checkmanifest]
 basepython = python
-deps =
-    check-manifest
+extras = check-manifest
 commands =
     check-manifest
 
 [testenv:isort]
-deps =
-    isort
+extras = isort
 commands =
     {envpython} -m isort --check-only --diff .
 
 [testenv:mypy]
 basepython = python
-deps =
-    mypy==0.910
+extras = mypy
 commands =
-    mypy --install-types --non-interactive --config mypy.ini faker
+    {envpython} -m mypy --install-types --non-interactive --config mypy.ini faker
 
 [testenv:black]
-deps = black==24.4.0
+extras = black
 commands =
-    {envpython} -m black --check --line-length 120 .
+    {envpython} -m black --check .
 
 [testenv:doc8]
-deps = doc8
+extras = doc8
 commands =
     {envpython} -m doc8
 


### PR DESCRIPTION
### What does this change

* Adds proper type support for `uuid4()`, so that static type checkers understand the return type based on the inputs

### What was wrong

* Working with Faker in an environment using a static type checker such as MyPy / Pyright is frustrating when using `uuid4()`, because these tools rightly point out that the return type is one of `UUID | str | bytes`

### How this fixes it

* This adds overload typing so that the output is deterministic

### Checklist

- [X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [X] I have run `make lint`
