### PR TITLE
feat: Add fake-security to list of community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -65,6 +65,9 @@ Here's a list of Providers written by the community:
 | Faker         | Recognition models        |                                  |
 |               | using Faker.              |                                  |
 +---------------+---------------------------+----------------------------------+
+| Security      | Fake data related to      | `faker-security`_                |
+|               | security e.g. CVSS, CVE   |                                  |
++-------------------------------------------------------------------------------
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -96,3 +99,4 @@ In order to be included, your provider must satisfy these requirements:
 .. _faker_wifi_essid: https://pypi.org/project/faker-wifi-essid/
 .. _optional_faker: https://pypi.org/project/optional_faker
 .. _presidio-evaluator: https://pypi.org/project/presidio-evaluator
+.. _faker-security: https://pypi.org/project/faker-security/


### PR DESCRIPTION
### What does this change

Adds `faker-security` to the list of community providers

This was actually released quite a while back, but I only noticed this community providers page today

### What was wrong

Nothing 

### How this fixes it

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
