### PR TITLE
fix: remove invalid word from ja_JP lorem provider

### DIFF
--- a/faker/providers/lorem/ja_JP/__init__.py
+++ b/faker/providers/lorem/ja_JP/__init__.py
@@ -213,7 +213,6 @@ class Provider(LoremProvider):
         "持つ",
         "持っていました",
         "あった",
-        "〜",
         "ない",
         "今",
         "今日",


### PR DESCRIPTION
### What does this change

I'm removing the `〜` character from the word list of the `ja_JP` lorem provider.

### What was wrong

As far as I can tell (I'm not a Japanese speaker and may be wrong) this is not a word. We hit this unexpectedly in one of our unit tests.


### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint`
