### PR TITLE
Drop dateutil dependency

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -1,5 +1,6 @@
 import platform
 import re
+import zoneinfo
 
 from calendar import timegm
 from datetime import MAXYEAR
@@ -7,11 +8,9 @@ from datetime import date as dtdate
 from datetime import datetime
 from datetime import time as dttime
 from datetime import timedelta
+from datetime import timezone
 from datetime import tzinfo as TzInfo
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
-
-from dateutil import relativedelta
-from dateutil.tz import gettz, tzlocal, tzutc
 
 from faker.typing import Country, DateParseType
 
@@ -20,16 +19,20 @@ from .. import BaseProvider, ElementsType
 localized = True
 
 
+def _get_local_timezone():
+    datetime.now().astimezone().tzinfo
+
+
 def datetime_to_timestamp(dt: Union[dtdate, datetime]) -> int:
     if isinstance(dt, datetime) and getattr(dt, "tzinfo", None) is not None:
-        dt = dt.astimezone(tzutc())
+        dt = dt.astimezone(timezone.utc)
     return timegm(dt.timetuple())
 
 
 def timestamp_to_datetime(timestamp: Union[int, float], tzinfo: Optional[TzInfo]) -> datetime:
     if tzinfo is None:
-        pick = convert_timestamp_to_datetime(timestamp, tzlocal())
-        return pick.astimezone(tzutc()).replace(tzinfo=None)
+        pick = convert_timestamp_to_datetime(timestamp, _get_local_timezone())
+        return pick.astimezone(timezone.utc).replace(tzinfo=None)
     return convert_timestamp_to_datetime(timestamp, tzinfo)
 
 
@@ -2100,7 +2103,7 @@ class Provider(BaseProvider):
         if tzinfo is None:
             return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
         else:
-            return (datetime(1970, 1, 1, tzinfo=tzutc()) + timedelta(seconds=ts)).astimezone(tzinfo)
+            return (datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=ts)).astimezone(tzinfo)
 
     def date_between(self, start_date: DateParseType = "-30y", end_date: DateParseType = "today") -> dtdate:
         """
@@ -2202,9 +2205,9 @@ class Provider(BaseProvider):
         timestamp = self._rand_seconds(datetime_start_, datetime_end_)
         try:
             if tzinfo is None:
-                pick = convert_timestamp_to_datetime(timestamp, tzlocal())
+                pick = convert_timestamp_to_datetime(timestamp, _get_local_timezone())
                 try:
-                    pick = pick.astimezone(tzutc()).replace(tzinfo=None)
+                    pick = pick.astimezone(timezone.utc).replace(tzinfo=None)
                 except OSError:
                     pass
             else:
@@ -2336,8 +2339,11 @@ class Provider(BaseProvider):
         """
         now = datetime.now(tzinfo)
         this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        if this_month_start.month == 12:
+            next_month_start = this_month_start.replace(year=this_month_start.year + 1, month=1)
+        else:
+            next_month_start = this_month_start.replace(month=this_month_start.month + 1)
 
-        next_month_start = this_month_start + relativedelta.relativedelta(months=1)
         if before_now and after_now:
             return self.date_time_between_dates(this_month_start, next_month_start, tzinfo)
         elif not before_now and after_now:
@@ -2428,8 +2434,11 @@ class Provider(BaseProvider):
         """
         today = dtdate.today()
         this_month_start = today.replace(day=1)
+        if this_month_start.month == 12:
+            next_month_start = this_month_start.replace(year=this_month_start.year + 1, month=1)
+        else:
+            next_month_start = this_month_start.replace(month=this_month_start.month + 1)
 
-        next_month_start = this_month_start + relativedelta.relativedelta(months=1)
         if before_today and after_today:
             return self.date_between_dates(this_month_start, next_month_start)
         elif not before_today and after_today:
@@ -2540,7 +2549,7 @@ class Provider(BaseProvider):
 
         :sample:
         """
-        return gettz(self.timezone(*args, **kwargs))  # type: ignore
+        return zoneinfo.ZoneInfo(self.timezone(*args, **kwargs))  # type: ignore
 
     def date_of_birth(
         self,

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
     zip_safe=zip_safe,
     python_requires=">=3.8",
     install_requires=[
-        "python-dateutil>=2.4",
         "typing_extensions",
     ],
 )

--- a/tests/providers/test_date_time.py
+++ b/tests/providers/test_date_time.py
@@ -5,6 +5,7 @@ import re
 import sys
 import time
 import unittest
+import zoneinfo
 
 from datetime import date, datetime
 from datetime import time as datetime_time
@@ -167,10 +168,8 @@ class TestDateTime(unittest.TestCase):
         assert today == today_back
 
     def test_pytimezone(self):
-        import dateutil
-
         pytz = self.fake.pytimezone()
-        assert isinstance(pytz, dateutil.tz.tz.tzfile)
+        assert isinstance(pytz, zoneinfo.ZoneInfo)
 
     def test_pytimezone_usable(self):
         pytz = self.fake.pytimezone()


### PR DESCRIPTION
### What does this change

Removes dateutil.

### What was wrong

Nothing really. Dateutil is a bit less maintained and the use of it here can be done fairly easily with the standard library.

### How this fixes it

Fixes #2168 

Replaced usage of dateutil with stlib stuff. Changes should be covered by existing tests. Had to change one test that was referencing dateutil directly.

Could maybe argue this is backwards-incompatible if people are doing `isinstance` checks or otherwise doing something weird, but maybe that is going a bit far.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
