### PR TITLE
fix Belgium IBAN incorrect checksum #2165

### DIFF
--- a/faker/providers/bank/nl_BE/__init__.py
+++ b/faker/providers/bank/nl_BE/__init__.py
@@ -85,12 +85,12 @@ class Provider(BankProvider):
 
     def _calculate_mod97(self, account_number: str) -> str:
         """Calculate the mod 97 check digits for a given account number."""
-        check_digits = 97 - (int(account_number) % 97)
-        return str(check_digits).zfill(2)
+        remainder = int(account_number) % 97
+        return str(remainder).zfill(2) if remainder != 0 else 97
 
     def _calculate_iban_check_digits(self, bban: str) -> str:
         """Calculate the IBAN check digits using mod 97 algorithm."""
-        raw_iban = f"{self.country_code}00{bban}"
+        raw_iban = f"{bban}{self.country_code}00"
         numeric_iban = "".join(str(ord(char) - 55) if char.isalpha() else char for char in raw_iban)
         check_digits = 98 - (int(numeric_iban) % 97)
         return str(check_digits).zfill(2)

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -467,17 +467,16 @@ class TestNlBe:
             assert re.fullmatch(r"\d{12}", bban)
             account_number = bban[:-2]
             check_digits = int(bban[-2:])
-            assert (97 - (int(account_number) % 97)) == check_digits or check_digits == 97
+            assert (int(account_number) % 97) == check_digits or check_digits == 97
 
     def test_iban(self, faker, num_samples):
         for _ in range(num_samples):
             iban = faker.iban()
             assert iban[:2] == NlBeBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{12}", iban[2:])
-            bban = iban[4:]
-            account_number = bban[:-2]
-            check_digits = int(bban[-2:])
-            assert (97 - (int(account_number) % 97)) == check_digits or check_digits == 97
+            rearranged_iban = iban[4:] + iban[:4]
+            numeric_iban = "".join(str(ord(char) - 55) if char.isalpha() else char for char in rearranged_iban)
+            assert int(numeric_iban) % 97 == 1
 
     def test_swift8_use_dataset(self, faker, num_samples):
         for _ in range(num_samples):


### PR DESCRIPTION
Signed-off-by: xeirzo <>

### What does this change

This change adds a fix to the BBAN, IBAN checksum generation and validation by changing the generation formula, and rewriting the tests to be more precise.

### What was wrong

According to https://www.ibancalculator.com there is an issue with both the IBAN and BBAN checksum generation,
#### BBAN
 * calculation was done using : 97 - (account_number) % 97.
 * instead of : (account_number % 97) or 97 if previous calculation returns 0.
 
The calculator site verifies to true when using the later version,
moreover in https://www.ecbs.org/iban/belgium-bank-account-number.html there's an example of a valid BBAN that supports my claim.
Valid BBAN : 539007547034.
5390075470 is the account number and 34 is the resulting checksum, 
if we use 5390075470 % 97 we get 34.
If we use 97 - (5390075470 % 97) we get 63 which is not the example given above (539007547034),
which further proves the point.

#### IBAN:
The wiki elaborates on how to generate a checksum for the IBAN under Processing -> Algorithms.
in the previous version the mod calculation was done before converting chars to numbers and rearranging the IBAN which is incorrect, this version fixes this.
In addition the test for the IBAN didn't check if the resulting IBAN checksum is valid and only checked if the country code was added, and overall string structure.

### How this fixes it

By changing the method of calculation of the IBAN/BBAN checksums and making the tests cover the checksum generation it fixes the problem.

fixes #2165 which emerged from #2142

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
