### PR TITLE
Add hash functions overloads with no params

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -61,6 +61,9 @@ class Provider(BaseProvider):
         return os.urandom(length)
 
     @overload
+    def md5(self) -> str: ...
+
+    @overload
     def md5(self, raw_output: Literal[True]) -> bytes: ...
 
     @overload
@@ -81,6 +84,9 @@ class Provider(BaseProvider):
         return res.hexdigest()
 
     @overload
+    def sha1(self) -> str: ...
+
+    @overload
     def sha1(self, raw_output: Literal[True]) -> bytes: ...
 
     @overload
@@ -99,6 +105,9 @@ class Provider(BaseProvider):
         if raw_output:
             return res.digest()
         return res.hexdigest()
+
+    @overload
+    def sha256(self) -> str: ...
 
     @overload
     def sha256(self, raw_output: Literal[True]) -> bytes: ...

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -2203,6 +2203,19 @@ class Faker:
         ...
 
     @overload
+    def md5(self) -> str:
+        """
+        Generate a random MD5 hash.
+
+        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the MD5 hash
+        will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
+
+        :sample: raw_output=False
+        :sample: raw_output=True
+        """
+        ...
+
+    @overload
     def md5(self, raw_output: Literal[True]) -> bytes:
         """
         Generate a random MD5 hash.
@@ -2278,6 +2291,19 @@ class Faker:
         ...
 
     @overload
+    def sha1(self) -> str:
+        """
+        Generate a random SHA-1 hash.
+
+        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA-1 hash
+        will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
+
+        :sample: raw_output=False
+        :sample: raw_output=True
+        """
+        ...
+
+    @overload
     def sha1(self, raw_output: Literal[True]) -> bytes:
         """
         Generate a random SHA-1 hash.
@@ -2296,6 +2322,19 @@ class Faker:
         Generate a random SHA-1 hash.
 
         If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA-1 hash
+        will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
+
+        :sample: raw_output=False
+        :sample: raw_output=True
+        """
+        ...
+
+    @overload
+    def sha256(self) -> str:
+        """
+        Generate a random SHA-256 hash.
+
+        If ``raw_output`` is ``False`` (default), a hexadecimal string representation of the SHA-256 hash
         will be returned. If ``True``, a ``bytes`` object representation will be returned instead.
 
         :sample: raw_output=False


### PR DESCRIPTION
### What does this change

Added an extra over load to all sha functions that takes no param and return a string.

### What was wrong

The original functions all have a default `False`, which means it should be callable without a parameter, returning a string.

### How this fixes it

By providing the missing overload

Fixes #2184

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint` 

^ running make lint is changing things unrelated to this change
