### PR TITLE
Fix last names from en_PK provider

### DIFF
--- a/faker/providers/person/en_PK/__init__.py
+++ b/faker/providers/person/en_PK/__init__.py
@@ -115,7 +115,6 @@ class Provider(PersonProvider):
         "Zewad",
         "Zimran",
         "Zuwayhir",
-        "Name",
         "Adil",
         "Aaaqil",
         "Aaban",
@@ -155,7 +154,6 @@ class Provider(PersonProvider):
         "Aayan",
         "Aazim",
         "Abaan",
-        "Name",
         "Baahir",
         "Baaizeed",
         "Baaqee",
@@ -195,7 +193,6 @@ class Provider(PersonProvider):
         "Bazam",
         "Bilaal",
         "Bilal",
-        "Name",
         "Dawud",
         "Daamin",
         "Daanish",
@@ -210,7 +207,6 @@ class Provider(PersonProvider):
         "Damurah",
         "Daniel",
         "Danish",
-        "Name",
         "Eesaa",
         "Ehan",
         "Ehsaas",
@@ -220,7 +216,6 @@ class Provider(PersonProvider):
         "El-Amin",
         "Emran",
         "Eshan",
-        "Name",
         "Ghaalib",
         "Ghaazi",
         "Ghaffaar",
@@ -254,7 +249,6 @@ class Provider(PersonProvider):
         "Gulfam",
         "Gulshan",
         "Gulzar",
-        "Name",
         "Izaaz",
         "Ibaad",
         "Ibn",
@@ -282,7 +276,6 @@ class Provider(PersonProvider):
         "Ikrimah",
         "Ikrimah",
         "Ilan",
-        "Name",
         "Jafar",
         "Jaabir",
         "Jaabir",
@@ -311,7 +304,6 @@ class Provider(PersonProvider):
         "Jamal",
         "Jameel",
         "Jameel",
-        "Name",
         "Kaamil",
         "Kaamil",
         "Kaamil",
@@ -347,7 +339,6 @@ class Provider(PersonProvider):
         "Kazim",
         "Keyaan",
         "Khaalid",
-        "Name",
         "Laeeq",
         "Labeeb",
         "Labeeb",
@@ -375,7 +366,6 @@ class Provider(PersonProvider):
         "Lutf",
         "Lutfi",
         "Lutfi",
-        "Name",
         "Maawiya",
         "Mad",
         "Mamun",
@@ -415,7 +405,6 @@ class Provider(PersonProvider):
         "Majdy",
         "Majeed",
         "Makeen",
-        "Name",
         "Nail",
         "Naail",
         "Naadir",
@@ -455,7 +444,6 @@ class Provider(PersonProvider):
         "Najeeb",
         "Najeeb",
         "Najeeb",
-        "Name",
         "Obaid",
         "Omair",
         "Omar",
@@ -465,11 +453,9 @@ class Provider(PersonProvider):
         "Osama",
         "Ossama",
         "Owais",
-        "Name",
         "Parsa",
         "Parvez",
         "Pervaiz",
-        "Name",
         "Qaadir",
         "Qaadir",
         "Qaasim",
@@ -507,7 +493,6 @@ class Provider(PersonProvider):
         "Qutaybah",
         "Qutb",
         "Qutub",
-        "Name",
         "Raed",
         "Raid",
         "Raaghib",
@@ -545,7 +530,6 @@ class Provider(PersonProvider):
         "Rahat",
         "Raheel",
         "Raheem",
-        "Name",
         "Sad",
         "Sadan",
         "Said",
@@ -585,7 +569,6 @@ class Provider(PersonProvider):
         "Sadan",
         "Sadaqat",
         "Sadeed",
-        "Name",
         "Taahaa",
         "Taahir",
         "Taahir",
@@ -623,7 +606,6 @@ class Provider(PersonProvider):
         "Talib",
         "Tamam",
         "Tamanna",
-        "Name",
         "Ubaadah",
         "Ubaadah",
         "Ubaadah",
@@ -656,7 +638,6 @@ class Provider(PersonProvider):
         "Umar",
         "Umar",
         "Umar",
-        "Name",
         "Waail",
         "Waail",
         "Waahid",
@@ -676,7 +657,6 @@ class Provider(PersonProvider):
         "Waheed",
         "Wahhaab",
         "Wahhaaj",
-        "Name",
         "Yaaseen",
         "Yafi",
         "Yaghnam",
@@ -697,7 +677,6 @@ class Provider(PersonProvider):
         "Yathrib",
         "Yawar",
         "Yawer",
-        "Name",
         "Zaafir",
         "Zaahid",
         "Zaahid",
@@ -721,304 +700,296 @@ class Provider(PersonProvider):
     )
 
     last_names = (
-        "Lajlaj"
-        "Aarif"
-        "Urrab"
-        "Tabassum"
-        "Ubadah"
-        "Daniel"
-        "Umaarah"
-        "Omair"
-        "Jalil"
-        "Aatiq"
-        "Karaamat"
-        "Lut"
-        "Karam"
-        "Aasif"
-        "Aadam"
-        "Mahbeer"
-        "Saalim"
-        "Ubayd"
-        "Naail"
-        "Mahfuz"
-        "Ghazzal"
-        "Aamir"
-        "Ubaydullah"
-        "Umaarah"
-        "Rabiah"
-        "Maawiya"
-        "Yasir"
-        "Raaghib"
-        "Daamin"
-        "Rabb"
-        "Bashaar"
-        "Taanish"
-        "Yafir"
-        "Baaree"
-        "Talib"
-        "Rafi"
-        "Luqman"
-        "Qaasim"
-        "Ubaidah"
-        "Saajid"
-        "Yaman"
-        "Ubaadah"
-        "Baaqir"
-        "Sadan"
-        "Zarar"
-        "Saafir"
-        "Zafar"
-        "Mahmoud"
-        "Zayyir"
-        "Ubay"
-        "Fidvi"
-        "Mahfuj"
-        "Awmar"
-        "Yawer"
-        "Ayaan"
-        "Taimur"
-        "Rabbani"
-        "Ayyubi"
-        "Waahid"
-        "Ijli"
-        "Baleegh"
-        "Bilaal"
-        "Radi"
-        "Ali"
-        "Tadeen"
-        "Souma"
-        "Layth"
-        "Kashif"
-        "Labeeb"
-        "Talhah"
-        "Sabir"
-        "Dabir"
-        "Yaghnam"
-        "Zackariya"
-        "Ibrahim"
-        "Rafeek"
-        "Qadeer"
-        "Luqmaan"
-        "Jahdari"
-        "Qabeel"
-        "Kaamil"
-        "Ilan"
-        "Omeir"
-        "Ubaid"
-        "Majd"
-        "Aadil"
-        "Ghafoor"
-        "Zahrun"
-        "Tabassum"
-        "Lutf"
-        "Aamir"
-        "Iftikhaar"
-        "Naeem"
-        "Ghauth"
-        "Eshan"
-        "Raid"
-        "Qasif"
-        "Ihsaan"
-        "Bambad"
-        "Aaaqil"
-        "Nabeel"
-        "Jamaal"
-        "Awj"
-        "Wahhaaj"
-        "Nabih"
-        "Jalaal"
-        "Yahyaa"
-        "Aalam"
-        "Ghayoor"
-        "Aarif"
-        "Tahir"
-        "Batal"
-        "Talha"
-        "Uhban"
-        "Aryan"
-        "Najam"
-        "Darain"
-        "Qusay"
-        "Vahar"
-        "Aabid"
-        "Ihtiram"
-        "Umar"
-        "Mahbub"
-        "Qaim"
-        "Name"
-        "Saajid"
-        "Owais"
-        "Maheen"
-        "Raashid"
-        "Limazah"
-        "Zaafir"
-        "Wadood"
-        "Aariz"
-        "Aalam"
-        "Ihab"
-        "Umair"
-        "Zahri"
-        "Aazim"
-        "Jad"
-        "Omar"
-        "Majeed"
-        "Qaseem"
-        "Rafay"
-        "Ghanee"
-        "Gulshan"
-        "Babar"
-        "Baasim"
-        "Ghunayn"
-        "Jaabir"
-        "Nadeem"
-        "Lahiah"
-        "Sair"
-        "Saaqib"
-        "Esfandyar"
-        "Zaheer"
-        "Sabil"
-        "Qutaybah"
-        "Azban"
-        "Zafrul"
-        "Awani"
-        "Tajammul"
-        "Auraq"
-        "Man"
-        "Name"
-        "Tafazal"
-        "Raed"
-        "Baseer"
-        "Quadir"
-        "Dawud"
-        "Talal"
-        "Sabah"
-        "Baashir"
-        "Damurah"
-        "Ibraaheem"
-        "Faizan"
-        "Zaakir"
-        "Ghutayf"
-        "Ehsaas"
-        "Sadeed"
-        "Mad"
-        "Jabir"
-        "Mourib"
-        "Aamil"
-        "Sabeeh"
-        "Bizhan"
-        "Barr"
-        "Basaam"
-        "Ghasaan"
-        "Nail"
-        "Kasim"
-        "Taaj"
-        "Omran"
-        "Madiyan"
-        "Taheem"
-        "Saad"
-        "Kamal"
-        "Raatib"
-        "Taj"
-        "Yadid"
-        "Basheerah"
-        "Aasim"
-        "Zahur"
-        "Saabir"
-        "Kasam"
-        "Naeem"
-        "Tawkeel"
-        "Ghannam"
-        "Tahmaseb"
-        "Awadil"
-        "Liyaaqat"
-        "Tahaw-wur"
-        "Tamanna"
-        "Zafir"
-        "Ghauth"
-        "Ubay"
-        "Zaahid"
-        "Awamil"
-        "Talat"
-        "Maalik"
-        "Name"
-        "Qadar"
-        "Waajid"
-        "Aamirah"
-        "Ayamin"
-        "Kamran"
-        "Kaleem"
-        "Wadi"
-        "Zaahid"
-        "Umar"
-        "Bashaarat"
-        "Saal"
-        "Najeeb"
-        "Kachela"
-        "Sabur"
-        "Buraid"
-        "Rabee"
-        "Najeeb"
-        "Yar"
-        "Umar"
-        "Ossama"
-        "Tahawwur"
-        "Zaahir"
-        "Raashid"
-        "Name"
-        "Tali"
-        "Batool"
-        "Umair"
-        "Ihsaan"
-        "Name"
-        "Majd Udeen"
-        "Kaamil"
-        "Raheel"
-        "Abaan"
-        "Rabah"
-        "Jameel"
-        "Gohar"
-        "Aabid"
-        "Zuwayhir"
-        "Name"
-        "Sadan"
-        "Idris"
-        "Qais"
-        "Sadaqat"
-        "Barraq"
-        "Ejlaal"
-        "Luay"
-        "Jahdami"
-        "Wafeeq"
-        "Wafa"
-        "Rabar"
-        "Aasif"
-        "Dakhil"
-        "Jalaal"
-        "Gulfam"
-        "Saahir"
-        "Name"
-        "Maroof"
-        "Baasit"
-        "Kabeer"
-        "Jameel"
-        "Latif"
-        "Badr Udeen"
-        "Qahtan"
-        "Liyaqat"
-        "Jabr"
-        "Kaleema"
-        "Fazli"
-        "Name"
-        "Huzaifa"
-        "Man"
-        "Rohaan"
-        "Ubadah"
-        "Saburah"
-        "Saariyah"
-        "Kaysan"
-        "Raakin"
-        "Sabiq"
-        "Saboor"
-        "Zahaar"
+        "Lajlaj",
+        "Aarif",
+        "Urrab",
+        "Tabassum",
+        "Ubadah",
+        "Daniel",
+        "Umaarah",
+        "Omair",
+        "Jalil",
+        "Aatiq",
+        "Karaamat",
+        "Lut",
+        "Karam",
+        "Aasif",
+        "Aadam",
+        "Mahbeer",
+        "Saalim",
+        "Ubayd",
+        "Naail",
+        "Mahfuz",
+        "Ghazzal",
+        "Aamir",
+        "Ubaydullah",
+        "Umaarah",
+        "Rabiah",
+        "Maawiya",
+        "Yasir",
+        "Raaghib",
+        "Daamin",
+        "Rabb",
+        "Bashaar",
+        "Taanish",
+        "Yafir",
+        "Baaree",
+        "Talib",
+        "Rafi",
+        "Luqman",
+        "Qaasim",
+        "Ubaidah",
+        "Saajid",
+        "Yaman",
+        "Ubaadah",
+        "Baaqir",
+        "Sadan",
+        "Zarar",
+        "Saafir",
+        "Zafar",
+        "Mahmoud",
+        "Zayyir",
+        "Ubay",
+        "Fidvi",
+        "Mahfuj",
+        "Awmar",
+        "Yawer",
+        "Ayaan",
+        "Taimur",
+        "Rabbani",
+        "Ayyubi",
+        "Waahid",
+        "Ijli",
+        "Baleegh",
+        "Bilaal",
+        "Radi",
+        "Ali",
+        "Tadeen",
+        "Souma",
+        "Layth",
+        "Kashif",
+        "Labeeb",
+        "Talhah",
+        "Sabir",
+        "Dabir",
+        "Yaghnam",
+        "Zackariya",
+        "Ibrahim",
+        "Rafeek",
+        "Qadeer",
+        "Luqmaan",
+        "Jahdari",
+        "Qabeel",
+        "Kaamil",
+        "Ilan",
+        "Omeir",
+        "Ubaid",
+        "Majd",
+        "Aadil",
+        "Ghafoor",
+        "Zahrun",
+        "Tabassum",
+        "Lutf",
+        "Aamir",
+        "Iftikhaar",
+        "Naeem",
+        "Ghauth",
+        "Eshan",
+        "Raid",
+        "Qasif",
+        "Ihsaan",
+        "Bambad",
+        "Aaaqil",
+        "Nabeel",
+        "Jamaal",
+        "Awj",
+        "Wahhaaj",
+        "Nabih",
+        "Jalaal",
+        "Yahyaa",
+        "Aalam",
+        "Ghayoor",
+        "Aarif",
+        "Tahir",
+        "Batal",
+        "Talha",
+        "Uhban",
+        "Aryan",
+        "Najam",
+        "Darain",
+        "Qusay",
+        "Vahar",
+        "Aabid",
+        "Ihtiram",
+        "Umar",
+        "Mahbub",
+        "Qaim",
+        "Saajid",
+        "Owais",
+        "Maheen",
+        "Raashid",
+        "Limazah",
+        "Zaafir",
+        "Wadood",
+        "Aariz",
+        "Aalam",
+        "Ihab",
+        "Umair",
+        "Zahri",
+        "Aazim",
+        "Jad",
+        "Omar",
+        "Majeed",
+        "Qaseem",
+        "Rafay",
+        "Ghanee",
+        "Gulshan",
+        "Babar",
+        "Baasim",
+        "Ghunayn",
+        "Jaabir",
+        "Nadeem",
+        "Lahiah",
+        "Sair",
+        "Saaqib",
+        "Esfandyar",
+        "Zaheer",
+        "Sabil",
+        "Qutaybah",
+        "Azban",
+        "Zafrul",
+        "Awani",
+        "Tajammul",
+        "Auraq",
+        "Man",
+        "Tafazal",
+        "Raed",
+        "Baseer",
+        "Quadir",
+        "Dawud",
+        "Talal",
+        "Sabah",
+        "Baashir",
+        "Damurah",
+        "Ibraaheem",
+        "Faizan",
+        "Zaakir",
+        "Ghutayf",
+        "Ehsaas",
+        "Sadeed",
+        "Mad",
+        "Jabir",
+        "Mourib",
+        "Aamil",
+        "Sabeeh",
+        "Bizhan",
+        "Barr",
+        "Basaam",
+        "Ghasaan",
+        "Nail",
+        "Kasim",
+        "Taaj",
+        "Omran",
+        "Madiyan",
+        "Taheem",
+        "Saad",
+        "Kamal",
+        "Raatib",
+        "Taj",
+        "Yadid",
+        "Basheerah",
+        "Aasim",
+        "Zahur",
+        "Saabir",
+        "Kasam",
+        "Naeem",
+        "Tawkeel",
+        "Ghannam",
+        "Tahmaseb",
+        "Awadil",
+        "Liyaaqat",
+        "Tahaw-wur",
+        "Tamanna",
+        "Zafir",
+        "Ghauth",
+        "Ubay",
+        "Zaahid",
+        "Awamil",
+        "Talat",
+        "Maalik",
+        "Qadar",
+        "Waajid",
+        "Aamirah",
+        "Ayamin",
+        "Kamran",
+        "Kaleem",
+        "Wadi",
+        "Zaahid",
+        "Umar",
+        "Bashaarat",
+        "Saal",
+        "Najeeb",
+        "Kachela",
+        "Sabur",
+        "Buraid",
+        "Rabee",
+        "Najeeb",
+        "Yar",
+        "Umar",
+        "Ossama",
+        "Tahawwur",
+        "Zaahir",
+        "Raashid",
+        "Tali",
+        "Batool",
+        "Umair",
+        "Ihsaan",
+        "Majd Udeen",
+        "Kaamil",
+        "Raheel",
+        "Abaan",
+        "Rabah",
+        "Jameel",
+        "Gohar",
+        "Aabid",
+        "Zuwayhir",
+        "Sadan",
+        "Idris",
+        "Qais",
+        "Sadaqat",
+        "Barraq",
+        "Ejlaal",
+        "Luay",
+        "Jahdami",
+        "Wafeeq",
+        "Wafa",
+        "Rabar",
+        "Aasif",
+        "Dakhil",
+        "Jalaal",
+        "Gulfam",
+        "Saahir",
+        "Maroof",
+        "Baasit",
+        "Kabeer",
+        "Jameel",
+        "Latif",
+        "Badr Udeen",
+        "Qahtan",
+        "Liyaqat",
+        "Jabr",
+        "Kaleema",
+        "Fazli",
+        "Huzaifa",
+        "Man",
+        "Rohaan",
+        "Ubadah",
+        "Saburah",
+        "Saariyah",
+        "Kaysan",
+        "Raakin",
+        "Sabiq",
+        "Saboor",
+        "Zahaar",
         "Jaabir"
     )

--- a/faker/providers/person/en_PK/__init__.py
+++ b/faker/providers/person/en_PK/__init__.py
@@ -991,5 +991,5 @@ class Provider(PersonProvider):
         "Sabiq",
         "Saboor",
         "Zahaar",
-        "Jaabir"
+        "Jaabir",
     )

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -434,6 +434,7 @@ class TestEnPk(unittest.TestCase):
     def test_last_name(self):
         """Test if the last name is from the predefined list."""
         last_name = self.fake.last_name()
+        self.assertGreater(len(last_name), 1, "Last name should have more than 1 character.")
         self.assertIn(last_name, EnPKprovider.last_names)
 
     def test_full_name(self):

--- a/tests/providers/test_person.py
+++ b/tests/providers/test_person.py
@@ -449,8 +449,20 @@ class TestEnPk(unittest.TestCase):
         name = self.fake.name()
         name_parts = name.split()
         self.assertGreaterEqual(len(name_parts), 2, "Full name should have at least a first and last name.")
-        self.assertIn(name_parts[0], EnPKprovider.first_names)
-        self.assertIn(name_parts[-1], EnPKprovider.last_names)
+        if len(name_parts) == 2:
+            self.assertIn(name_parts[0], EnPKprovider.first_names)
+            self.assertIn(name_parts[-1], EnPKprovider.last_names)
+        elif len(name_parts) == 4:
+            self.assertIn(name_parts[:2], EnPKprovider.first_names)
+            self.assertIn(name_parts[2:], EnPKprovider.last_names)
+        elif len(name_parts) == 3:
+            assert (
+                " ".join(name_parts[:2]) in EnPKprovider.first_names
+                and " ".join(name_parts[2]) in EnPKprovider.last_names
+            ) or (
+                " ".join(name_parts[:1]) in EnPKprovider.first_names
+                and " ".join(name_parts[1:]) in EnPKprovider.last_names
+            ), "Either first two name parts should be in first names, or last two should be in last names."
 
 
 class TestEnUS(unittest.TestCase):


### PR DESCRIPTION
### What does this change

Corrects the last names list in `en_PK` from one long, concatenated string to an actual tuple of names

### What was wrong

All last names from en_PK provider were returned as individual characters
Addresses #2189

### How this fixes it

Adds commas between names
Fixes #2189

**Note**: This is my first PR to an open-source repository, so please let me know if I've done something wrong or if there are best practices that I've neglected.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
