### PR TITLE
**Title:** Add `currency` Provider to `en_GH` Locale  

### DIFF
--- a/faker/providers/currency/en_GH/__init__.py
+++ b/faker/providers/currency/en_GH/__init__.py
@@ -1,0 +1,8 @@
+from .. import Provider as CurrencyProvider
+
+
+class Provider(CurrencyProvider):
+    price_formats = ["#.##", "%#.##", "%##.##", "%,###.##", "%#,###.##"]
+
+    def pricetag(self) -> str:
+        return "GH₵\N{NO-BREAK SPACE}" + self.numerify(self.random_element(self.price_formats))

--- a/tests/providers/test_currency.py
+++ b/tests/providers/test_currency.py
@@ -294,6 +294,23 @@ class TestEnCa:
             assert isinstance(pricetag, str)
 
 
+class TestEnGH:
+    """Test en_GH currency provider"""
+
+    num_samples = 100
+
+    @classmethod
+    def setup_class(cls):
+        from faker.providers.currency.en_GH import Provider as EnGHCurrencyProvider
+
+        cls.provider = EnGHCurrencyProvider
+
+    def test_pricetag(self, faker, num_samples):
+        for _ in range(num_samples):
+            pricetag = faker.pricetag()
+            assert isinstance(pricetag, str)
+
+
 class TestEsEs:
     """Test es_ES currency provider"""
 


### PR DESCRIPTION

### What does this change  
This change adds a `currency` provider to the `en_GH` locale, enabling the generation of Ghanaian currency-related data.  

### What was wrong  
The `en_GH` locale was missing a `currency` provider, preventing users from generating Ghanaian currency formats (e.g., GHS, GH₵).  

### How this fixes it  
The new provider includes support for the Ghanaian Cedi (`GHS`), along with its symbol (`GH₵`), ensuring consistency with other locales.  

Fixes #2195 

### Checklist  
- [ ] I have read the documentation about [[CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)  
- [ ] I have read the documentation about [[Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)  
- [ ] I have run `make lint`
