### PR TITLE
Add support for unique complex value types Fixes #1817

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ black:
 isort:
 	isort --atomic .
 
-generate-stubs: 
+generate-stubs:
 	python3.11 generate_stubs.py
 
 lint: generate-stubs isort black mypy flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ coverage>=5.2
 doc8>=1.1.1
 flake8-comprehensions
 flake8>=4.0.0
-freezegun>=15.1
+freezegun>=1.5.1
 isort>=5.13.2
 mypy-extensions>=1.0.0
 mypy>=1.15.0

--- a/faker/providers/profile/__init__.py
+++ b/faker/providers/profile/__init__.py
@@ -16,7 +16,7 @@ class Provider(BaseProvider):
 
     def simple_profile(self, sex: Optional[SexLiteral] = None) -> Dict[str, Union[str, date, SexLiteral]]:
         """
-        Generates a basic profile with personal informations
+        Generates a basic profile with personal information
         """
         sex_ = self.random_element(["F", "M"]) if sex is None else sex
         if sex_ == "F":

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -2633,7 +2633,7 @@ class Faker:
         self, sex: Optional[Literal["M", "F", "X"]] = ...
     ) -> Dict[str, Union[str, datetime.date, Literal["M", "F", "X"]]]:
         """
-        Generates a basic profile with personal informations
+        Generates a basic profile with personal information
         """
         ...
 

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -60,3 +60,18 @@ class TestUniquenessClass:
 
         with pytest.raises(TypeError, match="Accessing non-functions through .unique is not supported."):
             fake.unique.locales
+
+    def test_complex_return_types_is_supported(self):
+        """The unique decorator supports complex return types
+        like the ones used in the profile provider."""
+
+        fake = Faker()
+
+        for i in range(10):
+            fake.unique.pydict()
+
+        for i in range(10):
+            fake.unique.pylist()
+
+        for i in range(10):
+            fake.unique.pyset()


### PR DESCRIPTION
### What does this change

The changes modify the UniqueProxy class to handle unhashable return types (e.g., dictionaries) by introducing a _make_hashable method. This ensures that the uniqueness logic can work with complex return types without requiring changes to the profile method or other providers.

### What was wrong

The root cause of the issue was that the unique proxy attempted to store unhashable types (like dictionaries) in a se
t for uniqueness checks. Since dictionaries are mutable and unhashable, this caused a TypeError: unhashable type: 'dict'.

### How this fixes it

The _make_hashable method converts unhashable types (e.g., dictionaries, lists, sets) into hashable representations (e.g., tuples, frozensets). This allows the UniqueProxy to store and compare these values in a set, ensuring uniqueness without modifying the return types of the providers.

Fixes #1817

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
