### PR TITLE
docs: extend patterns understood by bothify📃

### DIFF
--- a/faker/providers/__init__.py
+++ b/faker/providers/__init__.py
@@ -646,6 +646,10 @@ class BaseProvider:
         """Generate a string with each placeholder in ``text`` replaced according to the following rules:
 
         - Number signs ('#') are replaced with a random digit (0 to 9).
+        - Percent signs ('%') are replaced with a random non-zero digit (1 to 9).
+        - Dollar signs ('$') are replaced with a random digit above two (2 to 9).
+        - Exclamation marks ('!') are replaced with a random digit or an empty string.
+        - At symbols ('@') are replaced with a random non-zero digit or an empty string.
         - Question marks ('?') are replaced with a random character from ``letters``.
 
         By default, ``letters`` contains all ASCII letters, uppercase and lowercase.
@@ -657,6 +661,7 @@ class BaseProvider:
         :sample: letters='ABCDE'
         :sample: text='Product Number: ????-########'
         :sample: text='Product Number: ????-########', letters='ABCDE'
+        :sample: text='Order: ##??-$'
         """
         return self.lexify(self.numerify(text), letters=letters)
 

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -45,6 +45,10 @@ class Faker:
         Generate a string with each placeholder in ``text`` replaced according to the following rules:
 
         - Number signs ('#') are replaced with a random digit (0 to 9).
+        - Percent signs ('%') are replaced with a random non-zero digit (1 to 9).
+        - Dollar signs ('$') are replaced with a random digit above two (2 to 9).
+        - Exclamation marks ('!') are replaced with a random digit or an empty string.
+        - At symbols ('@') are replaced with a random non-zero digit or an empty string.
         - Question marks ('?') are replaced with a random character from ``letters``.
 
         By default, ``letters`` contains all ASCII letters, uppercase and lowercase.
@@ -56,6 +60,7 @@ class Faker:
         :sample: letters='ABCDE'
         :sample: text='Product Number: ????-########'
         :sample: text='Product Number: ????-########', letters='ABCDE'
+        :sample: text='Order: ##??-$'
         """
         ...
 


### PR DESCRIPTION
### What does this change

This PR extends the documentation for `bothify()`. Previously, the docs only documented the placeholders `#` for numerics. Which gave the impression, that the scope of `bothify()` is limited compared to `numerify()`. However, all patterns of `numerify()` are possible.

### What was wrong

Docs for `numerify()` and `bothify()` were just out-of-sync.

### How this fixes it

Docs now show all valid patterns and samples have been extended.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
