### PR TITLE
fix: correct leading zeros and add building number patterns for `DE_de` address provider 🐛

### DIFF
--- a/faker/providers/address/de_DE/__init__.py
+++ b/faker/providers/address/de_DE/__init__.py
@@ -13,7 +13,9 @@ class Provider(AddressProvider):
     street_address_formats = ("{{street_name}} {{building_number}}",)
     address_formats = ("{{street_address}}\n{{postcode}} {{city}}",)
 
-    building_number_formats = ("###", "##", "#", "#/#")
+    # NOTE: Zero itself can be a valid building number in rare cases e.g., Wilhelm-Wisser-Str. 0, Heidhörn
+    # see: https://www.uniserv.com/wissen/magazin/article/besonderheiten-von-zustelladressen/
+    building_number_formats = ("#", "%#", "%##", "%###", "%/%", "%#/%#", "%-%", "%#-%#")
 
     street_suffixes_long = (
         "Gasse",


### PR DESCRIPTION
### What does this change

This PR improves the building number generation for German addresses.  Previously, we generated multi-digit building numbers with leading 0s, which do not exist in Germany. This pr also adds more patterns to better cover German building numbers.

In detail:
- omit generating leading zeros, for multi-digit building numbers like `010`. Single zeros can be valid building number (see here: https://www.uniserv.com/wissen/magazin/article/besonderheiten-von-zustelladressen/)
- allow 4 digit building numbers, which appear quite frequently in larger cities e.g., Cologne (see here: https://www.faz.net/aktuell/gesellschaft/menschen/deutschlands-hoechste-hausnummer-bei-frau-hoechsten-ist-schluss-11741880.html)
- allow building number like `14-16`, if property spans across multiple lots. 

**MWE**

```python
from faker import Faker
fake = Faker('de_DE')
for _ in range(100):
    print(fake.building_number())

```

**before:**
```
0/2
...
053
...
5/0
...
0/0
```

**after:**

```
0
17
438
185
98
29-28
52-84
7
1-9
6
13-43
78-20
62
75-79
11/67
47-78
95
60
739
67/88
5531
...
```


### What was wrong

Pattern was wrong.

### How this fixes it

It fixes the pattern for German building numbers and adds more patterns to sample from. 

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
