### PR TITLE
Fix type annotations for Python 3.14

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -9,6 +9,7 @@ import tarfile
 import uuid
 import zipfile
 
+from json import JSONEncoder
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Type, Union, overload
 
 from faker.exceptions import UnsupportedFeature
@@ -536,7 +537,7 @@ class Provider(BaseProvider):
         data_columns: Optional[List] = None,
         num_rows: int = 10,
         indent: Optional[int] = None,
-        cls: Optional[Type[json.JSONEncoder]] = None,
+        cls: Optional[Type[JSONEncoder]] = None,
     ) -> bytes:
         """
         Generate random JSON structure and return as bytes.
@@ -551,7 +552,7 @@ class Provider(BaseProvider):
         data_columns: Optional[List] = None,
         num_rows: int = 10,
         indent: Optional[int] = None,
-        cls: Optional[Type[json.JSONEncoder]] = None,
+        cls: Optional[Type[JSONEncoder]] = None,
     ) -> str:
         """
         Generate random JSON structure values.


### PR DESCRIPTION

### What does this change

Fix type annotations for `Provider.json()` in Python 3.14.0b1.

### What was wrong

`json` is resolved to the `json()` method itself rather than the `json` module, resulting in:

```pytb
    def json(
        self,
        data_columns: Optional[List] = None,
        num_rows: int = 10,
        indent: Optional[int] = None,
>       cls: Optional[Type[json.JSONEncoder]] = None,
    ) -> str:
E   AttributeError: 'function' object has no attribute 'JSONEncoder'
```

### How this fixes it

Import `JSONEncoder` directly instead, so we can reference it without `json.`.

Fixes #2212

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
