### PR TITLE
Changed the function for generating vin, now the last 4 characters are digits

### DIFF
--- a/faker/providers/automotive/__init__.py
+++ b/faker/providers/automotive/__init__.py
@@ -55,7 +55,7 @@ class Provider(BaseProvider):
         """Generate vin number."""
         vin_chars = "1234567890ABCDEFGHJKLMNPRSTUVWXYZ"  # I, O, Q are restricted
         front_part = self.bothify("????????", letters=vin_chars)
-        rear_part = self.bothify("????????", letters=vin_chars)
+        rear_part = self.bothify("????####", letters=vin_chars)
         front_part_weight = calculate_vin_str_weight(front_part, [8, 7, 6, 5, 4, 3, 2, 10])
         rear_part_weight = calculate_vin_str_weight(rear_part, [9, 8, 7, 6, 5, 4, 3, 2])
         checksum = (front_part_weight + rear_part_weight) % 11

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -1,4 +1,5 @@
 import re
+import string
 
 from typing import Pattern
 
@@ -38,6 +39,8 @@ class _SimpleAutomotiveTestMixin:
             checksum = (front_part_weight + rear_part_weight) % 11
             checksum_str = "X" if checksum == 10 else str(checksum)
             assert vin_number[8] == checksum_str
+            for char in vin_number[13:]:
+                assert char in string.digits
 
 
 class TestArBh(_SimpleAutomotiveTestMixin):


### PR DESCRIPTION
### What does this change

VIN must ends with 4 digits, https://www.studocu.com/es-ar/document/universidad-nacional-de-misiones/legislacion-y-ejercicio-profesional/iso-3779-2009-vin-decoder/70130592 in 4.4

```
The VIS shall be the third and final section of the VIN and shall consist of eight characters, the last four being numerical. 
```

### What was wrong

Before this change VIN can ends with ascii letters.

### How this fixes it

change args in `bothify` function call

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
