### PR TITLE
fix: setter for `first_names`

### DIFF
--- a/faker/providers/person/es_CL/__init__.py
+++ b/faker/providers/person/es_CL/__init__.py
@@ -1067,6 +1067,10 @@ class Provider(PersonProvider):
                     self._first_names[name] = weight / 2
         return self._first_names
 
+    @first_names.setter
+    def first_names(self, value):
+        self._first_names = value
+
     # 500 last names, weighted
     last_names = OrderedDict(
         [


### PR DESCRIPTION
### What does this change

Fix mypy error

### What was wrong

mypy caused an error:
```
faker/providers/person/es_CL/__init__.py:1057:5: error: Cannot override writeable attribute with read-only property  [override]
        def first_names(self):
        ^
Found 1 error in 1 file (checked 694 source files)
```

### How this fixes it

Create setter for `faker.providers.person.es_CL.Provider`

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
