### PR TITLE
Fix for #2223 No male names in randomized persons for sv_SE locale

### DIFF
--- a/faker/providers/person/sv_SE/__init__.py
+++ b/faker/providers/person/sv_SE/__init__.py
@@ -29,16 +29,16 @@ class Provider(PersonProvider):
     )
 
     formats_male = (
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}-{{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}-{{last_name}}",
     )
 
     formats = formats_female + formats_male


### PR DESCRIPTION
### What does this change

Enables randomized swedish names to include male first names

### What was wrong

The format_male variable used first_name_female

### How this fixes it

The format_male variable now uses first_name_male

Fixes #2223

### Checklist

- [X ] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [X] I have run `make lint`
