### PR TITLE
Provide male names correctly. Fixes #2223

### DIFF
--- a/faker/providers/person/sv_SE/__init__.py
+++ b/faker/providers/person/sv_SE/__init__.py
@@ -29,16 +29,16 @@ class Provider(PersonProvider):
     )
 
     formats_male = (
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}",
-        "{{first_name_female}} {{last_name}} {{last_name}}",
-        "{{first_name_female}} {{last_name}}-{{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}",
+        "{{first_name_male}} {{last_name}} {{last_name}}",
+        "{{first_name_male}} {{last_name}}-{{last_name}}",
     )
 
     formats = formats_female + formats_male


### PR DESCRIPTION
### What does this change

Fixes the error in selecting female names instead of male names in generating persons.

### What was wrong

A previous commit used the wrong construct for creating male names.

### How this fixes it

Correct use of first_name_male instead of first_name_female in the formats_male construct. 
Fixes #2223 

### Checklist

- [X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [X] I have run `make lint`
