### PR TITLE
Fix unnatural Korean company names in ko_KR locale

### DIFF
--- a/faker/providers/company/ko_KR/__init__.py
+++ b/faker/providers/company/ko_KR/__init__.py
@@ -2,11 +2,14 @@ from .. import Provider as CompanyProvider
 
 
 class Provider(CompanyProvider):
+    """
+    Provider for company names for ko_KR locale
+    """
+
     formats = (
-        "{{company_suffix}} {{last_name}}{{last_name}}{{last_name}}",
-        "{{company_suffix}} {{last_name}}",
-        "{{last_name}}{{last_name}}",
-        "{{last_name}}{{last_name}}{{last_name}}",
+        "{{company_suffix}} {{company_name_word}}{{brand_suffix}}",
+        "{{company_suffix}} {{company_name_word}}{{company_name_word}}{{brand_suffix}}",
+        "{{company_suffix}} {{company_name_word}}",
     )
 
     catch_phrase_words = (
@@ -370,3 +373,98 @@ class Provider(CompanyProvider):
     )
 
     company_suffixes = ("(주)", "주식회사", "(유)", "유한회사")
+
+    company_name_words = (
+        "가람",
+        "가야",
+        "가온",
+        "겨레",
+        "고구려",
+        "고려",
+        "국민",
+        "글로벌",
+        "글로벌",
+        "나루",
+        "네오",
+        "넥스트",
+        "다올",
+        "라온",
+        "마루",
+        "마음",
+        "모두",
+        "미래",
+        "발해",
+        "백제",
+        "보람",
+        "브레인",
+        "비전",
+        "스타",
+        "시너지",
+        "신라",
+        "씨앤씨",
+        "아름",
+        "에코",
+        "우리",
+        "원더",
+        "월드",
+        "윈드",
+        "유니온",
+        "이노",
+        "인포",
+        "제나",
+        "조선",
+        "종합",
+        "중앙",
+        "첨단",
+        "코리아",
+        "코어",
+        "푸른",
+        "하나",
+        "한가람",
+        "한강",
+        "한빛",
+    )
+
+    brand_suffixes = (
+        "개발",
+        "개발공사",
+        "그룹",
+        "금고",
+        "기술",
+        "기획",
+        "네트워크",
+        "네트웍스",
+        "랩스",
+        "바이오",
+        "반도체",
+        "보안",
+        "뷰티",
+        "상사",
+        "센터",
+        "소프트",
+        "솔루션",
+        "시스템",
+        "시스템즈",
+        "신문",
+        "에너지",
+        "에이아이",
+        "엔지니어링",
+        "연구소",
+        "유통",
+        "은행",
+        "자동차",
+        "전자",
+        "정보통신",
+        "제조",
+        "출판",
+        "코스메틱",
+        "테크",
+        "플랫폼",
+        "항공",
+    )
+
+    def company_name_word(self) -> str:
+        return self.random_element(self.company_name_words)
+
+    def brand_suffix(self) -> str:
+        return self.random_element(self.brand_suffixes)

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -20,13 +20,18 @@ from faker.providers.company.ja_JP import Provider as JaJpCompanyProvider
 from faker.providers.company.nl_BE import Provider as NlBeCompanyProvider
 from faker.providers.company.nl_NL import Provider as NlNlCompanyProvider
 from faker.providers.company.pl_PL import Provider as PlPlCompanyProvider
-from faker.providers.company.pl_PL import company_vat_checksum, local_regon_checksum, regon_checksum
+from faker.providers.company.pl_PL import (
+    company_vat_checksum,
+    local_regon_checksum,
+    regon_checksum,
+)
 from faker.providers.company.pt_BR import company_id_checksum
 from faker.providers.company.ro_RO import Provider as RoRoCompanyProvider
 from faker.providers.company.ru_RU import Provider as RuRuCompanyProvider
 from faker.providers.company.ru_RU import calculate_checksum, calculate_snils_checksum
 from faker.providers.company.th_TH import Provider as ThThCompanyProvider
 from faker.providers.company.tr_TR import Provider as TrTrCompanyProvider
+from faker.providers.company.ko_KR import Provider as KoKrCompanyProvider
 from faker.providers.company.vi_VN import Provider as ViVnCompanyProvider
 from faker.utils.checksums import luhn_checksum
 
@@ -541,6 +546,27 @@ class TestViVn:
             suffix = faker.company_suffix()
             assert isinstance(suffix, str)
             assert suffix in ViVnCompanyProvider.company_suffixes
+
+    def test_company(self, faker, num_samples):
+        for _ in range(num_samples):
+            company = faker.company()
+            assert isinstance(company, str)
+
+
+class TestKoKr:
+    """Test ko_KR company provider methods"""
+
+    def test_company_name_word(self, faker, num_samples):
+        for _ in range(num_samples):
+            word = faker.company_name_word()
+            assert isinstance(word, str)
+            assert word in KoKrCompanyProvider.company_name_words
+
+    def test_company_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            suffix = faker.company_suffix()
+            assert isinstance(suffix, str)
+            assert suffix in KoKrCompanyProvider.company_suffixes
 
     def test_company(self, faker, num_samples):
         for _ in range(num_samples):

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -17,6 +17,7 @@ from faker.providers.company.hu_HU import Provider as HuHuCompanyProvider
 from faker.providers.company.hy_AM import Provider as HyAmCompanyProvider
 from faker.providers.company.it_IT import Provider as ItItCompanyProvider
 from faker.providers.company.ja_JP import Provider as JaJpCompanyProvider
+from faker.providers.company.ko_KR import Provider as KoKrCompanyProvider
 from faker.providers.company.nl_BE import Provider as NlBeCompanyProvider
 from faker.providers.company.nl_NL import Provider as NlNlCompanyProvider
 from faker.providers.company.pl_PL import Provider as PlPlCompanyProvider
@@ -31,7 +32,6 @@ from faker.providers.company.ru_RU import Provider as RuRuCompanyProvider
 from faker.providers.company.ru_RU import calculate_checksum, calculate_snils_checksum
 from faker.providers.company.th_TH import Provider as ThThCompanyProvider
 from faker.providers.company.tr_TR import Provider as TrTrCompanyProvider
-from faker.providers.company.ko_KR import Provider as KoKrCompanyProvider
 from faker.providers.company.vi_VN import Provider as ViVnCompanyProvider
 from faker.utils.checksums import luhn_checksum
 


### PR DESCRIPTION
### What does this change

This improves the realism of company names generated for the ko_KR locale.
Replaces last_name-based company name formats with more natural Korean naming patterns
Adds company_name_words (e.g., "미래", "한빛", "코리아") and company_name_suffixes (e.g., "테크", "소프트") for constructing company names

### What was wrong

The original Korean company names were generated using combinations of Korean last names (e.g., `{{last_name}}{{last_name}}`), which resulted in highly unnatural outputs like: `(주) 김박김`
Such combinations do not reflect how real Korean company names are structured.

### How this fixes it
By introducing a curated list of real-sounding company name roots and suffixes, and updating the formats accordingly, the generated company names now resemble realistic Korean business names.
Examples after this change: `(주) 미래소프트`, `주식회사 브레인랩스`, `유한회사 코리아시스템`
Fixes #2229

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
