### PR TITLE
Fix ISBN13 generation for pt_BR locale (closes #2217)

### DIFF
--- a/faker/providers/isbn/pt_BR/__init__.py
+++ b/faker/providers/isbn/pt_BR/__init__.py
@@ -1,0 +1,73 @@
+# faker/providers/isbn/pt_BR/__init__.py
+from faker.providers.isbn import Provider as ISBNProvider
+import random
+
+class Provider(ISBNProvider):
+    """ISBN provider para locale pt_BR com grupos brasileiros oficiais."""
+    
+    BRAZILIAN_ISBN_GROUPS = [
+        {
+            'ean': '978', 'group': '65', 'name': 'Brasil (new allocation)',
+            'publisher_ranges': [(10, 99), (100, 999), (1000, 9999)]
+        },
+        {
+            'ean': '978', 'group': '85', 'name': 'Brasil (traditional)',
+            'publisher_ranges': [(10, 99), (100, 999), (1000, 9999)]
+        },
+        {
+            'ean': '979', 'group': '85', 'name': 'Brasil (extended)',
+            'publisher_ranges': [(10, 99), (100, 999), (1000, 9999)]
+        }
+    ]
+    
+    def isbn13(self, separator="-"):
+        """
+        Gera ISBN13 específico para o mercado brasileiro.
+        
+        Args:
+            separator (str): Separador entre os grupos do ISBN
+            
+        Returns:
+            str: ISBN13 com códigos de grupo brasileiros
+        """
+        group_info = random.choice(self.BRAZILIAN_ISBN_GROUPS)
+        ean = group_info['ean']
+        group = group_info['group']
+        
+        # Seleciona range de publisher aleatoriamente
+        pub_min, pub_max = random.choice(group_info['publisher_ranges'])
+        publisher = random.randint(pub_min, pub_max)
+        publisher_str = str(publisher)
+        
+        # Calcula comprimento do título baseado no espaço restante
+        title_length = 13 - len(ean) - len(group) - len(publisher_str) - 1
+        title = self.random_number(title_length)
+        
+        # Monta ISBN sem dígito verificador
+        isbn_without_check = f"{ean}{group}{publisher_str}{str(title).zfill(title_length)}"
+        
+        # Calcula dígito verificador
+        check_digit = self._calculate_isbn13_check_digit(isbn_without_check)
+        
+        # Retorna com ou sem separador
+        if separator:
+            return f"{ean}{separator}{group}{separator}{publisher_str}{separator}{str(title).zfill(title_length)}{separator}{check_digit}"
+        else:
+            return isbn_without_check + str(check_digit)
+    
+    def _calculate_isbn13_check_digit(self, isbn12):
+        """
+        Calcula o dígito verificador para ISBN-13.
+        
+        Args:
+            isbn12 (str): Primeiros 12 dígitos do ISBN
+            
+        Returns:
+            int: Dígito verificador
+        """
+        if len(isbn12) != 12:
+            raise ValueError("ISBN must have exactly 12 digits for check digit calculation")
+        
+        total = sum(int(digit) * (1 if i % 2 == 0 else 3) for i, digit in enumerate(isbn12))
+        remainder = total % 10
+        return 0 if remainder == 0 else 10 - remainder

--- a/test_provider.py
+++ b/test_provider.py
@@ -1,0 +1,16 @@
+import sys
+import os
+
+# Adiciona o caminho completo até a pasta que contém o pacote `faker/`
+sys.path.insert(0, os.path.abspath("."))  # ou "./faker" se você estiver fora do projeto
+
+from faker import Faker
+from faker.providers.isbn.pt_BR import Provider as BrazilianISBNProvider
+
+# Registra o provider
+fake = Faker('pt_BR')
+fake.add_provider(BrazilianISBNProvider)
+
+# Teste de geração
+for _ in range(5):
+    print(fake.isbn13())

--- a/tests/providers/test_isbn_pt_br.py
+++ b/tests/providers/test_isbn_pt_br.py
@@ -1,0 +1,47 @@
+import pytest
+from faker import Faker
+from faker.providers.isbn.pt_BR import Provider as PTBRISBNProvider
+
+class TestISBN13PTBR:
+    def setup_method(self):
+        self.fake = Faker('pt_BR')
+        self.fake.add_provider(PTBRISBNProvider)
+    
+    def test_isbn13_with_pt_br_locale_should_use_brazilian_group_codes(self):
+        """Testa se o ISBN13 com locale pt_BR usa códigos de grupo brasileiros."""
+        isbn = self.fake.isbn13()
+        brazilian_prefixes = ['978-65', '978-85', '979-85']
+        
+        assert any(isbn.startswith(prefix) for prefix in brazilian_prefixes), \
+            f"ISBN '{isbn}' deveria começar com código brasileiro"
+    
+    def test_isbn13_pt_br_multiple_group_codes(self):
+        """Testa se múltiplos códigos de grupo brasileiros são utilizados."""
+        isbns = [self.fake.isbn13() for _ in range(50)]
+        prefixes = ['-'.join(isbn.split('-')[:2]) for isbn in isbns]
+        unique_prefixes = set(prefixes)
+        
+        expected_prefixes = {'978-85', '978-65', '979-85'}
+        found_prefixes = unique_prefixes.intersection(expected_prefixes)
+        
+        assert len(found_prefixes) >= 2, \
+            f"Esperado pelo menos 2 prefixos brasileiros distintos"
+    
+    def test_isbn13_format_validation(self):
+        """Testa se o formato do ISBN está correto."""
+        isbn = self.fake.isbn13()
+        parts = isbn.split('-')
+        
+        assert len(parts) == 5, "ISBN deve ter 5 partes separadas por hífen"
+        assert all(part.isdigit() for part in parts), "Todas as partes devem ser numéricas"
+    
+    def test_isbn13_check_digit_validation(self):
+        """Testa se o dígito verificador está correto."""
+        isbn = self.fake.isbn13()
+        digits = ''.join(isbn.split('-'))
+        
+        # Validação do dígito verificador ISBN-13
+        total = sum(int(d) * (1 if i % 2 == 0 else 3) for i, d in enumerate(digits[:12]))
+        check_digit = (10 - (total % 10)) % 10
+        
+        assert int(digits[12]) == check_digit, "Dígito verificador inválido"


### PR DESCRIPTION
### What does this change

Adds a localized `isbn13()` implementation for the `pt_BR` locale, generating ISBNs using valid Brazilian group codes (`978-85`, `978-65`, and `979-85`). It includes a new provider at `faker.providers.isbn.pt_BR`.

### What was wrong

When using `Faker('pt_BR').isbn13()`, the returned ISBNs always include group codes like `978-0` or `978-1`, which correspond to English-speaking countries. This behavior disregards the configured locale and is inconsistent with expectations for Brazilian data.

### How this fixes it

This change introduces a custom provider for `pt_BR` that:
- Selects a Brazilian EAN and group code.
- Randomly generates publisher and title codes.
- Computes a valid ISBN-13 check digit.
- Returns the final ISBN using correct formatting.

This ensures that `Faker('pt_BR').isbn13()` produces culturally appropriate and structurally valid ISBNs for Brazil.

Fixes #2217
