### PR TITLE
fix(pydecimal): allow Decimal type for min_value and max_value

### DIFF
--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -2666,8 +2666,8 @@ class Faker:
         left_digits: Optional[int] = ...,
         right_digits: Optional[int] = ...,
         positive: Optional[bool] = ...,
-        min_value: Union[float, int, None] = ...,
-        max_value: Union[float, int, None] = ...,
+        min_value: Union[float, int, Decimal, None] = ...,
+        max_value: Union[float, int, Decimal, None] = ...,
     ) -> Decimal: ...
     def pydict(
         self,

--- a/faker/typing.py
+++ b/faker/typing.py
@@ -2,6 +2,7 @@ import dataclasses
 
 from collections import OrderedDict as OrderedDictType
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 from typing import List, Literal, Sequence, TypeVar, Union
 
 
@@ -21,7 +22,7 @@ class CreditCard:
         self.security_code_length = security_code_length
 
 
-BasicNumber = Union[float, int]
+BasicNumber = Union[float, int, Decimal]
 CardType = TypeVar("CardType", "CreditCard", str)
 DateParseType = Union[date, datetime, timedelta, str, int]
 HueType = Union[str, float, int, Sequence[int]]


### PR DESCRIPTION
### What does this change

Allow `Decimal` type to be provided for `min_value` and `max_value` in type-safe manner.

### What was wrong

The type checkers `mypy` and `pyright` were complaining that the type `Decimal` is not supported by the function type declaration.

### How this fixes it

Add `Decimal` type to the allowed union

Fixes #2242, #2041

### Checklist

- [+] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [+] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [+] I have run `make lint`
