### PR TITLE
Add Automotive providers for ko_KR locale

### DIFF
--- a/faker/providers/automotive/ko_KR/__init__.py
+++ b/faker/providers/automotive/ko_KR/__init__.py
@@ -1,0 +1,26 @@
+from .. import Provider as AutomotiveProvider
+
+class Provider(AutomotiveProvider):
+    """
+    Implement automotive provider for ``ko_KR`` locale.
+    """
+
+    license_formats = (
+        '##?####',
+        '###?####',
+    )
+
+    letter_codes = (
+        "가", "나", "다", "라", "마",
+        "거", "너", "더", "러", "머",
+        "버", "서", "어", "저",
+        "고", "노", "도", "로", "모",
+        "보", "소", "오", "조",
+        "구", "누", "두", "루", "무",
+        "부", "수", "우", "주",
+    )
+
+    def license_plate(self) -> str:
+        pattern = self.random_element(self.license_formats)
+        letters = ''.join(self.letter_codes)
+        return self.numerify(self.lexify(pattern, letters=letters))

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -396,3 +396,9 @@ class TestUkUa(_SimpleAutomotiveTestMixin):
 
     def test_region_code(self, faker):
         assert "14" == faker.plate_region_code(region_name="Lviv")
+
+
+class TestKoKr(_SimpleAutomotiveTestMixin):
+    license_plate_pattern: Pattern = re.compile(
+        r"^\d{2,3}[가나다라마거너더러머버서어저고노도로모보소오조구누두루무부수우주]\d{4}$"
+    )


### PR DESCRIPTION
### What does this change

this pull request adds a new license_plate provider specifically for the ko_KR locale. It introduces the license_plate() method to generate vehicle license plates that conform to modern South Korean formats.
(e.g., 12가234 or 123너879).

### What was wrong

The Faker library currently lacks the functionality to generate vehicle license plates specific to South Korea.

### How this fixes it

This change introduces a new ko_KR automotive provider at faker/providers/automotive/ko_KR/__init__.py. It includes the license_plate() method with a list of licence_plate_formats that reflect common South Korean license plate patterns (e.g., ##가####, ###더####). This allows for realistic and locale-accurate data generation.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
