### PR TITLE
Nl nl ssn issue #2253

### DIFF
--- a/faker/providers/ssn/nl_NL/__init__.py
+++ b/faker/providers/ssn/nl_NL/__init__.py
@@ -21,10 +21,10 @@ class Provider(SsnProvider):
 
         while True:
             # create an array of first 8 elements initialized randomly
-            digits = self.generator.random.choices(range(10), 8)
-            # discard if not 8 or 9 digits long
-            if digits[0] == 0 and digits[1] == 0:
-                continue
+            digits = self.generator.random.choices(range(10), k=8)
+            # discard generated digits combination if not 8 or 9 digits long
+            if digits[0] == 0 and digits[1] == 0:  # too short
+                continue                           # try again 
             # sum those 8 digits according to (part of) the "11-proef"
             s = _checksum(digits)
             # determine the last digit to make it qualify the test


### PR DESCRIPTION
### What does this change

Fix [issue #2253](https://github.com/joke2k/faker/issues/2253) on `ssn()` in 'nl_NL' provider.

### What was wrong

Generated `ssn()` values had unique leading 8 digits, which is *not* a BSN (Dutch ssn) requirement.
As a consequence the range (number of possible values) was limited to 10! / 2! * 9 / 10.

### How this fixes it

Replace `random.sample()` by `random.choices()` and `continue` in case `digits[:2] == [0, 0]` in `ssn()` code.
Now the range is 10 ** 8 * 99 / 100 * 9 / 10, and I generated 20 million unique BSN's without issue (other than 2.6 million collisions).

### Checklist

- [X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint`
(I didn't install locally)