### PR TITLE
Add Password Provider

### DIFF
--- a/faker/providers/password/__init__.py
+++ b/faker/providers/password/__init__.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .. import BaseProvider
+
+AMBIGUOUS = set("O0oIl1|`'\"")
+SYMBOLS = "!@#$%^&*()-_=+[]{};:,.?/"
+
+
+class Provider(BaseProvider):
+    """Strong password generator"""
+
+    def strong_password(
+        self,
+        *,
+        length: int = 16,
+        min_upper: int = 1,
+        min_lower: int = 1,
+        min_digits: int = 1,
+        min_symbols: int = 1,
+        allow_ambiguous: bool = False,
+    ) -> str:
+        """Generate a strong password base on policy provided
+        Parameters:
+        - length : Total length of the generated password
+        - min_upper : Minimum number of uppercase letters
+        - min_lower : Minimum number of lowercase letters
+        - min_digits : Minimum number of digits
+        - min_symbols : Minimum number of symbols (from a curated set)
+        - allow_ambiguous : If False, characters that are commonly confused (e.g., 'O', '0', 'l', '1', '|') are excluded
+        """
+        min = [min_upper, min_lower, min_digits, min_symbols]
+        if any(m < 0 for m in min):
+            raise ValueError("Minimum counts must be non-negative")
+        required = sum(min)
+        if required > length:
+            raise ValueError(f"length ({length}) is less than the sum of minimums ({required})")
+
+        # Build character pools
+        uppercase = [c for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+        lowercase = [c for c in "abcdefghijklmnopqrstuvwxyz"]
+        digits = [c for c in "0123456789"]
+        symbols = list(SYMBOLS)
+
+        if not allow_ambiguous:
+
+            def filter(pool: Iterable[str]) -> List[str]:
+                return [c for c in pool if c not in AMBIGUOUS]
+
+            uppercase = filter(uppercase)
+            lowercase = filter(lowercase)
+            digits = filter(digits)
+
+        # Guarantee minimum requirements
+        password_chars: List[str] = []
+        password_chars.extend(self.random_choices(uppercase, length=min_upper))
+        password_chars.extend(self.random_choices(lowercase, length=min_lower))
+        password_chars.extend(self.random_choices(digits, length=min_digits))
+        password_chars.extend(self.random_choices(symbols, length=min_symbols))
+
+        # Fill remaining characters from the union pool
+        characters_pool = uppercase + lowercase + digits + symbols
+        remaining = length - len(password_chars)
+        if remaining > 0:
+            password_chars.extend(self.random_choices(characters_pool, length=remaining))
+
+        # Shuffle
+        rng = getattr(self.generator, "random", None)
+        if rng is None:
+            import random as _random
+
+            rng = _random
+        rng.shuffle(password_chars)
+
+        return "".join(password_chars)

--- a/faker/providers/password/en_US/__init__.py
+++ b/faker/providers/password/en_US/__init__.py
@@ -1,0 +1,5 @@
+from .. import Provider as PasswordProvider
+
+
+class Provider(PasswordProvider):
+    pass

--- a/tests/providers/test_password.py
+++ b/tests/providers/test_password.py
@@ -1,0 +1,97 @@
+import string
+
+import pytest
+
+from faker import Faker
+from faker.providers.password import Provider as PasswordProvider
+
+SYMBOLS = set("!@#$%^&*()-_=+[]{};:,.?/")
+AMBIGUOUS = set("O0oIl1|`'\"")
+
+
+def make_fake(seed=0):
+    fake = Faker()
+    fake.add_provider(PasswordProvider)
+    fake.seed_instance(seed)
+    return fake
+
+
+def counts_by_class(password: str):
+    up = sum(1 for c in password if c in string.ascii_uppercase)
+    low = sum(1 for c in password if c in string.ascii_lowercase)
+    dig = sum(1 for c in password if c in string.digits)
+    sym = sum(1 for c in password if c in SYMBOLS)
+    return up, low, dig, sym
+
+
+def test_basic_constraints():
+    """Ensures password meets length and all minimum counts."""
+    fake = make_fake(42)
+    password = fake.strong_password(length=20, min_upper=2, min_lower=3, min_digits=4, min_symbols=5)
+    assert len(password) == 20
+    up, low, dig, sym = counts_by_class(password)
+    assert up >= 2 and low >= 3 and dig >= 4 and sym >= 5
+
+
+def test_no_ambiguous_by_default():
+    """Verifies ambiguous characters are excluded by default."""
+    fake = make_fake(1)
+    password = fake.strong_password(length=64)
+    # Should exclude ambiguous characters unless allow_ambiguous=True
+    assert not (set(password) & AMBIGUOUS)
+
+
+def test_minimums_cannot_exceed_length():
+    """Confirms error when sum of minimums exceeds total length."""
+    fake = make_fake(0)
+    with pytest.raises(ValueError):
+        fake.strong_password(length=3, min_upper=1, min_lower=1, min_digits=1, min_symbols=1)
+
+
+def test_minimums_must_be_nonnegative():
+    """Confirms error when any minimum is negative."""
+    fake = make_fake(0)
+    with pytest.raises(ValueError):
+        fake.strong_password(length=10, min_upper=-1)
+
+
+def test_reproducible_with_seed():
+    """Checks deterministic output when using the same seed."""
+    f1 = make_fake(123)
+    f2 = make_fake(123)
+    password1 = f1.strong_password()
+    password2 = f2.strong_password()
+    assert password1 == password2
+
+
+def test_exact_sum_of_minimums_only():
+    """When length == sum(minimums), output must be exactly the required counts."""
+    fake = make_fake(77)
+    password = fake.strong_password(length=10, min_upper=2, min_lower=3, min_digits=4, min_symbols=1)
+    assert len(password) == 10
+    assert counts_by_class(password) == (2, 3, 4, 1)
+
+
+def test_zero_symbol_requirement_is_allowed():
+    """Ensure no symbols appear when min_symbols=0 and length == sum of others."""
+    fake = make_fake(78)
+    password = fake.strong_password(length=12, min_upper=4, min_lower=4, min_digits=4, min_symbols=0)
+    up, low, dig, sym = counts_by_class(password)
+    assert len(password) == 12
+    assert sym == 0
+
+
+def test_only_digits_when_min_digits_equals_length():
+    """If digits minimum equals length, password should be all digits (with ambiguous digits excluded by default)."""
+    fake = make_fake(79)
+    password = fake.strong_password(length=8, min_upper=0, min_lower=0, min_digits=8, min_symbols=0)
+    assert len(password) == 8
+    # Ambiguous digits 0 and 1 should be excluded by default
+    assert set(password).issubset(set("23456789"))
+
+
+def test_no_whitespace_anywhere():
+    """Ensures no whitespace characters."""
+    fake = make_fake(80)
+    password = fake.strong_password(length=48)
+    assert not any(char.isspace() for char in password)


### PR DESCRIPTION
### What does this change

This pull request adds a new feature to the Faker library: a strong password generator. It introduces a new provider, `faker/providers/password`, with a `strong_password` method. The new method allows users to generate passwords that meet specific security policies, which is useful for testing common real-world login and signup scenarios.

### What was wrong

Nothing was wrong. The Faker library previously did not have a provider for generating passwords that meet customizable security policies.

### How this fixes it

This PR resolves the issue by implementing a new `strong_password` method with flexible parameters. Users can now specify the total `length` of the password and a minimum number of `min_upper, min_lower, min_digits, and min_symbols`. The method also includes an `allow_ambiguous` flag to exclude commonly confused characters by default. Comprehensive unit tests have been included to ensure the functionality is correct and all specified constraints are met.

Fixes #2240 

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
