### PR TITLE
Add Scientific Provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -68,6 +68,10 @@ Here's a list of Providers written by the community:
 | Security      | Fake data related to      | `faker-security`_                |
 |               | security e.g. CVSS, CVE   |                                  |
 +---------------+---------------------------+----------------------------------+
+| Scientific    | Fake author identifiers   | `faker_researcher_ids`_          |
+|               | for scientific databases  |                                  |
+|               | (Scopus, ORCID etc.)      |
++---------------+---------------------------+----------------------------------+
 
 If you want to add your own provider to this list, please submit a Pull Request to our `repo`_.
 
@@ -100,3 +104,4 @@ In order to be included, your provider must satisfy these requirements:
 .. _optional_faker: https://pypi.org/project/optional_faker
 .. _presidio-evaluator: https://pypi.org/project/presidio-evaluator
 .. _faker-security: https://pypi.org/project/faker-security/
+.. _faker_researcher_ids: https://pypi.org/project/faker-researcher-ids/


### PR DESCRIPTION
### What does this change

This pull request introduces a new community provider, `ScientificProvider`, with methods which allows users to generate fake author identifiers used in scientific databases and publication tracking systems like Scopus, ORCID etc.

### What was wrong

The Faker library previously did not have a provider with such functionality.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
