### PR TITLE
Implement localized UniqueProxy

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -305,6 +305,13 @@ class UniqueProxy:
     def clear(self) -> None:
         self._seen = {}
 
+    def __getitem__(self, locale: str) -> UniqueProxy:
+        locale_proxy = self._proxy[locale]
+        unique_proxy = UniqueProxy(locale_proxy)
+        unique_proxy._seen = self._seen
+        unique_proxy._sentinel = self._sentinel
+        return unique_proxy
+
     def __getattr__(self, name: str) -> Any:
         obj = getattr(self._proxy, name)
         if callable(obj):

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -75,3 +75,23 @@ class TestUniquenessClass:
 
         for i in range(10):
             fake.unique.pyset()
+
+    def test_unique_locale_access(self):
+        """Accessing locales through UniqueProxy with subscript notation
+        maintains global uniqueness across all locales."""
+
+        fake = Faker(["en_US", "fr_FR", "ja_JP"])
+        generated = set()
+
+        for i in range(5):
+            value = fake.unique["en_US"].random_int(min=1, max=10)
+            assert value not in generated
+            generated.add(value)
+
+        for i in range(5):
+            value = fake.unique["fr_FR"].random_int(min=1, max=10)
+            assert value not in generated
+            generated.add(value)
+
+        with pytest.raises(UniquenessException, match=r"Got duplicated values after [\d,]+ iterations."):
+            fake.unique["ja_JP"].random_int(min=1, max=10)


### PR DESCRIPTION
This fixes #2278. See the ticket for use case details.

### What does this change

`Faker(["en_US", "fr_FR"]).unique["fr_FR"]` is now valid.

### What was wrong

This was not implemented.

### How this fixes it

UniqueProxy.__getitem__ provides localized proxies that share the `_seen` states.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
