### PR TITLE
add_faker_pk_pypi_link

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -85,6 +85,7 @@ In order to be included, your provider must satisfy these requirements:
 * it must not contain any malicious nor any kind of telemetry code.
 
 .. _repo: https://github.com/joke2k/faker/
+.. _faker_pk: https://pypi.org/project/faker-pk/
 .. _OSI-Approved: https://opensource.org/licenses/alphabetical
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
 .. _faker_biology: https://pypi.org/project/faker_biology/


### PR DESCRIPTION
### What does this change

faker-pk, python library's link is added in docs/communityproviders.rst, which is compatible with faker with FakerPKProvider.

### What was wrong

the faker-pk, pakistani fake data generator library's link wasn't added in the providers.

### How this fixes it

added the project's pypi's link to the documentation

Fixes #...

### Checklist

- [ yes] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [ yes] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ yes] I have run `make lint`
