### PR TITLE
Add major UK banks to en_GB bank provider

### DIFF
--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -6,3 +6,25 @@ class Provider(BankProvider):
 
     bban_format = "????##############"
     country_code = "GB"
+
+    # Major UK banks
+    banks = (
+        "Barclays",
+        "HSBC UK",
+        "Lloyds Bank",
+        "NatWest",
+        "Santander UK",
+        "Halifax",
+        "Bank of Scotland",
+        "Royal Bank of Scotland",
+        "Nationwide Building Society",
+        "TSB Bank",
+        "Virgin Money",
+        "Metro Bank",
+        "Monzo",
+        "Revolut",
+        "Starling Bank",
+        "Co-operative Bank",
+        "Yorkshire Bank",
+        "Clydesdale Bank",
+    )


### PR DESCRIPTION
### What does this change

Added a `banks` tuple to the en_GB bank provider containing 18 major UK banks, including both traditional banks (Barclays, HSBC UK, Lloyds Bank, NatWest, etc.) and modern digital banks (Monzo, Revolut, Starling Bank).

### What was wrong

The en_GB locale's bank provider was missing the `banks` attribute. When calling `fake.bank()` with locale `en_GB`, it raised an `AttributeError` because the provider didn't have the required `banks` tuple.

### How this fixes it

Added the missing `banks` tuple with a comprehensive list of UK banks to the `en_GB/__init__.py` file, enabling the `bank()` method to work correctly for the en_GB locale.

Fixes #2280

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)