### PR TITLE
Fix: Ensure deterministic locale selection in multi-locale mode

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -183,10 +183,10 @@ class Faker:
         return factory
 
     def _select_factory_distribution(self, factories, weights):
-        return choices_distribution(factories, weights, random, length=1)[0]
+        return choices_distribution(factories, weights, self.factories[0].random, length=1)[0]
 
     def _select_factory_choice(self, factories):
-        return random.choice(factories)
+        return self._factories[0].random.choice(factories)
 
     def _map_provider_method(self, method_name: str) -> tuple[list[Factory], list[float] | None]:
         """


### PR DESCRIPTION
### What does this change

This PR fixes a bug where Faker instances initialized with multiple locales would produce non-deterministic output even when seeded. It ensures that the selection of which locale to use (e.g., picking between en_US or ru_RU) respects the instance seed.

### What was wrong

When Faker is acting as a proxy for multiple locales, it needs to randomly select a factory for each call. Previously, the methods _select_factory_distribution and _select_factory_choice used the global random module (via choices_distribution or random.choice).

Because seed_instance() only seeds the internal factory generators and not the global random module, the selection of the locale remained random and unseeded. This caused different outputs on subsequent runs despite using the same seed.

### How this fixes it

I modified faker/proxy.py to use self._factories[0].random instead of the global random module for locale selection.

Since seed_instance() iterates through self._factories and seeds every single one of them with the same value, accessing the random generator of the first factory (_factories[0]) provides a safe, seeded, and deterministic source of randomness. This fixes the determinism issue without needing to expose a random property on the Proxy class (which is explicitly forbidden by the current architecture).

Fixes #2283 

### Checklist

- [ X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [ X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ X] I have run `make lint`
