### PR TITLE
Add Faker Galactic Provider

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -110,4 +110,4 @@ In order to be included, your provider must satisfy these requirements:
 .. _presidio-evaluator: https://pypi.org/project/presidio-evaluator
 .. _faker-security: https://pypi.org/project/faker-security/
 .. _faker_researcher_ids: https://pypi.org/project/faker-researcher-ids/
-.. _faker-galactic_: https://pypi.org/project/faker-galactic/
+.. _faker-galactic: https://pypi.org/project/faker-galactic/


### PR DESCRIPTION
### What does this change

Adds a new community provider, SciFiProvider. This provider allows users to generate fake information from popular sci-fi universes.  

https://github.com/jasonleibowitz/faker-galactic/tree/master

### How this fixes it

Nothing was wrong, adding new community package to documentation

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
