### PR TITLE
fix: pyfloat TypeError when combining positive=True with max_value

### DIFF
--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -309,6 +309,15 @@ class TestPyfloat(unittest.TestCase):
     def test_float_min_and_max_value_with_same_whole(self):
         self.fake.pyfloat(min_value=2.3, max_value=2.5)
 
+    def test_pyfloat_positive_with_small_max_value(self):
+        def mock_random_number(self, digits=None, fix_len=False):
+            return 5
+
+        with patch("faker.providers.BaseProvider.random_number", mock_random_number):
+            result = self.fake.pyfloat(positive=True, max_value=0.1)
+            self.assertLessEqual(result, 0.1)
+            self.assertGreater(result, 0)
+
 
 class TestPyDict(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When calling pyfloat(positive=True, max_value=0.1), a TypeError was raised because the boundary adjustment code assumed both min_value and max_value were set when computing variance.

### What does this change

- Use effective_min=0 when positive=True and min_value is not set
- Handle cases where only one of min_value/max_value is provided
- Add test for the specific bug scenario

### What was wrong

This occurred because the boundary adjustment code assumed both `min_value` and `max_value` were set when computing variance.

### How this fixes it

- Fixed boundary adjustment logic
- Added test test_pyfloat_positive_with_small_max_value

Fixes #2300

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
