### PR TITLE
Add major GR banks to el_GR bank provider

### DIFF
--- a/faker/providers/bank/el_GR/__init__.py
+++ b/faker/providers/bank/el_GR/__init__.py
@@ -6,3 +6,23 @@ class Provider(BankProvider):
 
     bban_format = "#######################"
     country_code = "GR"
+
+    # Major GR banks (with a head office in Greece)
+    # Source:
+    # - https://www.bankofgreece.gr/en/main-tasks/supervision/supervised-institutions
+    # Last verified: January 2026
+    banks = (
+        "Aegean Baltic Bank",
+        "Alpha Bank",        
+        "Credia Bank",
+        "Eurobank",
+        "Optima Bank",
+        "SNAPPI",
+        "Vivabank",   
+        "Εθνική Τράπεζα",
+        "Συνεταιριστική Τράπεζα Θεσσαλίας",
+        "Συνεταιριστική Τράπεζα Καρδίτσας",
+        "Συνεταιριστική Τράπεζα Χανίων",
+        "Τράπεζα Ηπείρου",
+        "Τράπεζα Πειραιώς",
+    )

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -440,6 +440,11 @@ class TestThTh:
 class TestElGr:
     """Test el_GR bank provider"""
 
+    def test_bank(self, faker, num_samples):
+        for _ in range(num_samples):
+            bank = faker.bank()
+            assert bank in ElGrBankProvider.banks
+            
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):
             assert re.fullmatch(r"\d{23}", faker.bban())


### PR DESCRIPTION
### What does this change

Added a banks tuple to the el_GR bank provider containing 13 GR banks, including systemic banks (e.g. Alpha Bank) and cooperative banks (e.g. Cooperative Bank of Chania). I only added banks that have a head office in Greece, and not branches of foreign-based banks. The information is sourced from the Bank of Greece ([english](https://www.bankofgreece.gr/en/main-tasks/supervision/supervised-institutions), [greek](https://www.bankofgreece.gr/kiries-leitourgies/epopteia/epopteyomena-idrymata)).

### What was wrong

Previously, a call to the `bank()` method when using the `el_GR` locale would raise an `attributeError`, because the provider did not have a `banks` tuple.

### How this fixes it

Added the missing `banks` tuple to the `el_GR/__init__.py` file, enabling the `bank()` method to work correctly.

Fixes #2305

### A few comments

This is my first contribution to open source. I apologise if I missed a contributing standard. The linter technology is new to me, and to my understanding I cannot run `make linter`, because I use a Windows machine. I used gen-AI (see section below) to run a list of "equal" commands based on `Makefile`. If I can do anything else please let me know.

### AI usage

I should clarify that I used gen-AI (specifically Google Gemini) to:
- correct my PR message so that I use proper technical terminology.
- run style checks on my code.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint`
