### PR TITLE
Docs: Add faker-healthcare-provider to community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -31,6 +31,10 @@ Here's a list of Providers written by the community:
 |               | fake-random data          |                                  |
 |               | generators.               |                                  |
 +---------------+---------------------------+----------------------------------+
+| Healthcare    | Multi-language medical    | `faker_healthcare`_              |
+|               | data: diseases, ICD-10,   |                                  |
+|               | medications, and more.    |                                  |
++---------------+---------------------------+----------------------------------+
 | Market Data   | Fake market data          |                                  |
 |               | identifiers (SEDOL, CUSIP,| `faker_marketdata`_              |
 |               | ISIN, etc.)               |                                  |
@@ -98,6 +102,7 @@ In order to be included, your provider must satisfy these requirements:
 .. _faker_education: https://pypi.org/project/faker_education/
 .. _faker-file: https://pypi.org/project/faker-file/
 .. _faker_geoscience: https://pypi.org/project/faker-geoscience/
+.. _faker_healthcare: https://pypi.org/project/faker-healthcare-provider/
 .. _faker_marketdata: https://pypi.org/project/faker-marketdata/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/


### PR DESCRIPTION
### What does this change

Adds `faker-healthcare-provider` to the community providers list.

### Provider Details
- **PyPI**: https://pypi.org/project/faker-healthcare-provider/
- **Repository**: https://github.com/rodrigobnogueira/faker-healthcare-provider
- **License**: MIT (OSI-Approved)
- **Tests**: passing

### Features
- 6 Languages: en_US, pt_BR, es_ES, zh_CN, fr_FR, de_DE
- 150+ diseases with correlated ICD-10 codes per locale
- Clinical correlations (disease ↔ symptoms ↔ medications)
- Hospital departments, procedures, insurance plans

### Compliance
- ✅ Has tests
- ✅ Published on PyPI
- ✅ MIT License
- ✅ No duplicate functionality
- ✅ No profanity
- ✅ No telemetry

## AI Disclosure

This provider was developed with AI assistance (GROK) for compiling disease/medication lists from WHO reference data. All medical data verified against standards.

## Checklist
- [x] Read CONTRIBUTING documentation
- [x] Read Coding style documentation
- [x] Ran `make lint` (docs-only change)
