### PR TITLE
Fix issue #2308 related to broken parameter grouping for -i

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,11 @@ Examples:
     Josiah Maggio;
     Gayla Schmitt;
 
+    $ faker -i faker_credit_score credit_score_full
+    Experian/Fair Isaac Risk Model V2SM
+    Experian
+    801
+
 How to create a Provider
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ When installed, you can invoke faker from the command-line:
     faker [-h] [--version] [-o output]
           [-l {bg_BG,cs_CZ,...,zh_CN,zh_TW}]
           [-r REPEAT] [-s SEP]
-          [-i {package.containing.custom_provider otherpkg.containing.custom_provider}]
+          [-i package.containing.custom_provider]
           [fake] [fake argument [fake argument ...]]
 
 Where:
@@ -206,9 +206,9 @@ Where:
 -  ``-s SEP``: will generate the specified separator after each
    generated output
 
--  ``-i {my.custom_provider other.custom_provider}`` list of additional custom
-   providers to use. Note that is the import path of the package containing
-   your Provider class, not the custom Provider class itself.
+-  ``-i package.containing.custom_provider`` additional custom provider to use. Note this
+   is the import path of the package containing your Provider class, not the
+   custom Provider class itself. Can be repeated to add multiple providers.
 
 -  ``fake``: is the name of the fake to generate an output for, such as
    ``name``, ``address``, or ``text``

--- a/faker/cli.py
+++ b/faker/cli.py
@@ -225,8 +225,7 @@ examples:
         parser.add_argument(
             "-i",
             "--include",
-            default=META_PROVIDERS_MODULES,
-            nargs="*",
+            action="append",
             help="list of additional custom providers to "
             "user, given as the import path of the module "
             "containing your Provider class (not the provider "
@@ -252,6 +251,8 @@ examples:
         )
 
         arguments = parser.parse_args(self.argv[1:])
+        if arguments.include is None:
+            arguments.include = META_PROVIDERS_MODULES
 
         if arguments.verbose:
             logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_cli_arg_parsing.py
+++ b/tests/test_cli_arg_parsing.py
@@ -1,0 +1,36 @@
+import unittest
+
+from unittest.mock import patch
+
+from faker.cli import Command
+
+
+class TestCLIArgParsing(unittest.TestCase):
+    def test_cli_include_argument_parsing(self):
+        """Test that the include flag correctly differentiates between a provider and the fake command."""
+        cmd = Command(["faker", "-i", "my.provider", "profile"])
+
+        with patch("faker.cli.Faker"), patch("faker.cli.print_doc") as mock_print_doc:
+            cmd.execute()
+
+            # Verify that 'my.provider' is treated as an include and 'profile' is not.
+            call_args = mock_print_doc.call_args
+            kwargs = call_args[1]
+            includes = kwargs.get("includes")
+
+            self.assertIn("my.provider", includes)
+            self.assertNotIn("profile", includes)
+
+    def test_cli_multiple_includes(self):
+        """Test that multiple include flags are correctly accumulated."""
+        cmd = Command(["faker", "-i", "p1", "-i", "p2", "profile"])
+
+        with patch("faker.cli.Faker"), patch("faker.cli.print_doc") as mock_print_doc:
+            cmd.execute()
+            kwargs = mock_print_doc.call_args[1]
+            includes = kwargs.get("includes")
+            self.assertEqual(includes, ["p1", "p2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this change

The documentation says that multiple community providers could be included in sequence:

```
faker [-h] [--version] [-o output]
      [-l {bg_BG,cs_CZ,...,zh_CN,zh_TW}]
      [-r REPEAT] [-s SEP]
      [-i {package.containing.custom_provider otherpkg.containing.custom_provider}]
      [fake] [fake argument [fake argument ...]]
```

This doesn't work when the user tries to import a community provider -- see Issue #2308.

### What was wrong

The problem was greedy grouping of parameters. Anything after `-i package.containing.custom_provider` was also being interpreted as a community provider, meaning `[fake] [fake argument [fake argument ...]]` could not be correctly parsed.

### How this fixes it

This change replaces `nargs="*"` with `action="append"`, allowing users to specify multiple community providers in this way:

`[-i package.containing.custom_provider]`

_Note this would be a breaking change for command line utilization of `-i` for multiple providers if it worked. Since it never worked, this shouldn't break for anyone._

Additional test included.

Fixes #2308 

### AI Utilization

I used Antigravity / Gemini 3 Pro to help with the change and tests.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
