### PR TITLE
Docs: Add faker-ecommerce-provider to community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -21,6 +21,9 @@ Here's a list of Providers written by the community:
 | Datasets      | Build providers based     | `faker-datasets`_                |
 |               | on datasets               |                                  |
 +---------------+---------------------------+----------------------------------+
+| Ecommerce     | Fake data for e-commerce  | `faker-ecommerce-provider`_      |
+|               | e.g. products, orders     |                                  |
++---------------+---------------------------+----------------------------------+
 | Education     | Public school name and    | `faker_education`_               |
 |               | info for testing purposes |                                  |
 +---------------+---------------------------+----------------------------------+


### PR DESCRIPTION
### What does this change

Adds `faker-ecommerce-provider` to the community providers list.

### Provider Details

- PyPI: https://pypi.org/project/faker-ecommerce-provider/
- Repository: https://github.com/rodrigobnogueira/faker-ecommerce-provider
- License: MIT (OSI-Approved)
- Tests: passing

### Features
- Product names, categories, and descriptions
- E-commerce specific data generation
- SKU and barcode generation
- Price and discount generation

### Compliance
- ✅ Has tests
- ✅ Published on PyPI
- ✅ MIT License
- ✅ No duplicate functionality
- ✅ No profanity
- ✅ No telemetry