### PR TITLE
docs: Add AI Provider to community providers list

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -8,6 +8,10 @@ Here's a list of Providers written by the community:
 +---------------+---------------------------+----------------------------------+
 | Provider name | Description               | URL                              |
 +===============+===========================+==================================+
+| AI Provider   | Fake data for AI/ML       | `faker-ai-provider`_             |
+|               | models, companies, and    |                                  |
+|               | datasets.                 |                                  |
++---------------+---------------------------+----------------------------------+
 | Airtravel     | Airport names, airport    | `faker_airtravel`_               |
 |               | codes, and flights.       |                                  |
 +---------------+---------------------------+----------------------------------+
@@ -91,6 +95,7 @@ In order to be included, your provider must satisfy these requirements:
 .. _repo: https://github.com/joke2k/faker/
 .. _faker_pk: https://pypi.org/project/faker-pk/
 .. _OSI-Approved: https://opensource.org/licenses/alphabetical
+.. _faker-ai-provider: https://pypi.org/project/faker-ai-provider/
 .. _faker_airtravel: https://pypi.org/project/faker_airtravel/
 .. _faker_biology: https://pypi.org/project/faker_biology/
 .. _faker_credit_score: https://pypi.org/project/faker-credit-score/


### PR DESCRIPTION
### What does this change

Adds `faker-ai-provider` to the community providers list.

### Provider Details

- PyPI: https://pypi.org/project/faker-ai-provider/
- Repository: https://github.com/rodrigobnogueira/faker-ai-provider
- License: MIT (OSI-Approved)
- Tests: passing

### Features
- Data generation for AI/ML models, companies, and datasets
- 70+ correlated AI models (GPT, Claude, Gemini, LLaMA, etc.)
- Model architecture and capability simulation
- Realistic composite data generation (training runs, deployments)

### Compliance
- ✅ Has tests
- ✅ Published on PyPI
- ✅ MIT License
- ✅ No duplicate functionality
- ✅ No profanity
- ✅ No telemetry
