### PR TITLE
Fix pt_PT postalcode format in address provider

### DIFF
--- a/faker/providers/address/pt_PT/__init__.py
+++ b/faker/providers/address/pt_PT/__init__.py
@@ -27,7 +27,7 @@ class Provider(AddressProvider):
 
     building_number_formats = ("S/N", "%", "%#", "%#", "%#", "%##")
 
-    postcode_formats = ("####-###",)
+    postcode_formats = ("%###-###",)
 
     cities = (
         "Abrantes",

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1596,7 +1596,12 @@ class TestPtPt:
             place_name = faker.place_name()
             assert isinstance(place_name, str)
             assert place_name in PtPtAddressProvider.places
-
+    
+    def test_formatted_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert isinstance(postcode, str)
+            assert re.fullmatch(r"^[1-9]\d{3}-\d{3}", postcode)
 
 class TestEnPh:
     """Test en_PH address provider methods"""


### PR DESCRIPTION
### What does this change

This change fix the postal code format in `pt_PT` Address Provider.

### What was wrong

Prior to this change, the format provided for the postal code in Portugal was generating random numbers starting with a wrong digit sometimes. The valid starting char string for Portuguese postal code should be always between 1 and 9 as provided [in this issue](https://github.com/joke2k/faker/issues/2325#issue-3959863746).

### How this fixes it

The changes fixes the `pt_PT` `postcode_formats` attribute in the `Provider` class to generate a valid postal code.

Fixes #...

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
