### PR TITLE
Fix _get_local_timezone() missing return statement

### DIFF
--- a/faker/providers/date_time/__init__.py
+++ b/faker/providers/date_time/__init__.py
@@ -20,7 +20,7 @@ localized = True
 
 
 def _get_local_timezone():
-    datetime.now().astimezone().tzinfo
+    return datetime.now().astimezone().tzinfo
 
 
 def _get_next_month_start(dt: Union[dtdate, datetime]) -> Union[dtdate, datetime]:


### PR DESCRIPTION
## Summary

`_get_local_timezone()` computes the local timezone but doesn't return it — the `return` keyword is missing.

## The Bug

```python
def _get_local_timezone():
    datetime.now().astimezone().tzinfo  # <-- no return
```

This function always returns `None`. It's called by `timestamp_to_datetime()` and `date_time_ad()` to get the local timezone when no explicit `tzinfo` is provided. Because it returns `None`, `convert_timestamp_to_datetime()` receives `None` as the timezone, which can produce incorrect results for pre-1970 timestamps where the timezone path differs.

Quick verification:
```python
from faker.providers.date_time import _get_local_timezone
print(_get_local_timezone())  # None — should be a tzinfo object
```

## The Fix

Add the missing `return`:
```python
def _get_local_timezone():
    return datetime.now().astimezone().tzinfo
```
