### PR TITLE
Fix IndexError in choices_distribution when uniform() returns 1.0

### DIFF
--- a/faker/utils/distribution.py
+++ b/faker/utils/distribution.py
@@ -47,6 +47,7 @@ def choices_distribution_unique(
         cdf2 = [i / normal for i in cdf]
         uniform_sample = random_sample(random=random)
         idx = bisect.bisect_right(cdf2, uniform_sample)
+        idx = min(idx, len(items) - 1)
         item = items[idx]
         choices.append(item)
         probabilities.pop(idx)
@@ -83,6 +84,7 @@ def choices_distribution(
         for _ in range(length):
             uniform_sample = random_sample(random=random)
             idx = bisect.bisect_right(cdf2, uniform_sample)
+            idx = min(idx, len(a) - 1)
             item = a[idx]
             choices.append(item)
         return choices


### PR DESCRIPTION
## Summary

`choices_distribution_unique` (and the fallback path of `choices_distribution`) can crash with `IndexError` when `random.uniform(0, 1.0)` returns exactly `1.0`.

## The Bug

`random.uniform(0, 1.0)` can return `1.0` — from the Python docs: "The end-point value b may or may not be included" and the implementation note says `a + (b-a) * random()` can return `b`.

When this happens, `bisect.bisect_right(cdf2, 1.0)` returns `len(cdf2)` because the last CDF element is always `1.0` and `bisect_right` places equal values to the right. This index is one past the end:

```python
uniform_sample = random_sample(random=random)  # can be 1.0
idx = bisect.bisect_right(cdf2, uniform_sample)  # returns len(cdf2)
item = items[idx]  # IndexError!
```

```python
from faker.utils.distribution import choices_distribution_unique
from unittest.mock import MagicMock
from random import Random

mock_random = MagicMock(spec=Random)
mock_random.uniform.return_value = 1.0

choices_distribution_unique(["a", "b"], [0.5, 0.5], random=mock_random, length=1)
# IndexError: list index out of range
```

This is intermittent in production — `uniform()` returning exactly `1.0` is rare but will happen given enough calls.

## The Fix

Clamp the index to the valid range:
```python
idx = bisect.bisect_right(cdf2, uniform_sample)
idx = min(idx, len(items) - 1)
```

Applied to both `choices_distribution_unique` and the fallback path of `choices_distribution`.
