### PR TITLE
fix: prevent mutation of global PROVIDERS list in Factory.create

### DIFF
--- a/faker/factory.py
+++ b/faker/factory.py
@@ -47,7 +47,7 @@ class Factory:
         config["use_weighting"] = use_weighting
         providers = providers or PROVIDERS
 
-        providers += includes
+        providers = providers + includes
 
         faker = generator or Generator(**config)
 


### PR DESCRIPTION
### What does this change

Changed the way providers and includes are combined in Factory.create to ensure the original list is not modified

### What was wrong

The code was using the in-place addition operator (+=) on the providers list. When providers defaulted to the global PROVIDERS constant, this operator mutated the global list itself. This caused side effects where  subsequent Faker instances would unexpectedly contain providers from previous instances 

### How this fixes it
Replaced the in-place operator += with the concatenation operator +. This creates a new list for the local scope of the function, leaving the global PROVIDERS constant intact and preventing unintended side effects.

Fixes #2311 

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint`
