### PR TITLE
fix: implement bank name provider and used a def function for en_GB l…

### DIFF
--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -3,6 +3,31 @@ from .. import Provider as BankProvider
 
 class Provider(BankProvider):
     """Implement bank provider for ``en_GB`` locale."""
-
+    
+    # UK IBANS start with GB, 2 check digits, a 4 char bank code, 
+    # a 6 digit sort code, and a 8 digit account number.
     bban_format = "????##############"
     country_code = "GB"
+
+    # Major UK Banks
+    # Last verified February 2026. According to Google.
+    banks = (
+        "Barclays",
+        "HSBC",
+        "Lloyds Bank",
+        "Metro Bank",
+        "Monzo Bank",
+        "Natwest",
+        "Santander UK",
+        "Nationwide Building Society",
+        "Royal Bank of Scotland",
+        "Standard Chartered",
+        "Starling Bank",
+        "TSB Bank",
+    )
+
+    def bank(self):
+        """Generate a bank name."""
+
+        # Randomly select and return one bank name from the BANKS tuple above.
+        return self.random_element(self.banks)


### PR DESCRIPTION
…ocale

### What does this change
Implemented the bank() method for the en_GB locale and added a standardised list of major UK Banks.

### What was wrong
The en_GB locale claimed to support the bank() method (as seen in the bban_format) however the provider was missing banks data tuple and the corresponding method, leading to missing or incorrect data generation.

Description of the root cause of the issue.

### How this fixes it
1. Added a banks tuple containing major UK Banks(HSBC, Barclays, etc)
2. Implemented the bank() method to return a random element from that list.
3. Added inline comments for clarity purposes.

Description of how the changes fix the issue.

Fixes #2280

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
- note - Used Claude and Google Gemini to help research the missing provider structure and verify the UK banking formatting.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x ] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`

I've been using Faker extensively in my own projects—most recently for a Invoice Fraud Detection Service https://github.com/reory/Invoice-Fraud-Detector-Service  
where I used it to generate synthetic invoice data. I noticed the en_GB bank provider was missing while working on UK-specific datasets, so I'm happy to give back to a library that has been so helpful for my junior backend development work!

Thanks for maintaining such a great tool.