### PR TITLE
fix(pt_PT): prevent postal codes from starting with zero

### DIFF
--- a/faker/providers/address/pt_PT/__init__.py
+++ b/faker/providers/address/pt_PT/__init__.py
@@ -27,7 +27,7 @@ class Provider(AddressProvider):
 
     building_number_formats = ("S/N", "%", "%#", "%#", "%#", "%##")
 
-    postcode_formats = ("####-###",)
+    postcode_formats = ("%###-###",)
 
     cities = (
         "Abrantes",

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -1597,6 +1597,11 @@ class TestPtPt:
             assert isinstance(place_name, str)
             assert place_name in PtPtAddressProvider.places
 
+    def test_postcode(self, faker, num_samples):
+        for _ in range(num_samples):
+            postcode = faker.postcode()
+            assert re.fullmatch(r"[1-9]\d{3}-\d{3}", postcode)
+
 
 class TestEnPh:
     """Test en_PH address provider methods"""


### PR DESCRIPTION
### What does this change

Use `%` (non-zero digit) instead of `#` (any digit) for the first digit of pt_PT postal codes, and add a test to verify the format.

### What was wrong

The `postcode_formats` for `pt_PT` was `"####-###"`, which could generate postal codes starting with `0` (e.g., `0123-456`). Portuguese postal codes must start with a digit from 1 to 9. See [Wikipedia](https://en.wikipedia.org/wiki/Postal_codes_in_Portugal).

### How this fixes it

Changed `postcode_formats` from `("####-###",)` to `("%###-###",)`. The `%` placeholder generates a non-zero digit (1-9), ensuring valid Portuguese postal codes.

Fixes #2325

### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

GitHub Copilot was used to assist with this PR.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`