### PR TITLE
fix(factory): avoid mutating module-level PROVIDERS list

### DIFF
--- a/faker/factory.py
+++ b/faker/factory.py
@@ -47,7 +47,7 @@ class Factory:
         config["use_weighting"] = use_weighting
         providers = providers or PROVIDERS
 
-        providers += includes
+        providers = providers + includes
 
         faker = generator or Generator(**config)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -344,6 +344,18 @@ class FactoryTestCase(unittest.TestCase):
         with pytest.raises(ValueError):
             assert fake.pyfloat(min_value=9999, max_value=9999)
 
+    def test_includes_does_not_mutate_default_providers(self):
+        """Regression test for https://github.com/joke2k/faker/issues/2311.
+
+        Passing ``includes`` to ``Factory.create()`` must not permanently
+        append to the module-level ``PROVIDERS`` list.
+        """
+        from faker.config import PROVIDERS
+
+        original_length = len(PROVIDERS)
+        Factory.create(includes=["faker.providers.file"])
+        assert len(PROVIDERS) == original_length
+
     def test_instance_seed_chain(self):
         factory = Factory.create()
 


### PR DESCRIPTION
## Summary

- **Bug**: `Factory.create()` used `providers += includes` which mutates the module-level `PROVIDERS` list in-place. When no custom `providers` argument is passed, the local variable aliases the global `PROVIDERS`, so `+=` permanently appends `includes` to it. Every subsequent `Factory.create()` call then inherits previously included providers.
- **Fix**: Replace `providers += includes` with `providers = providers + includes` (line 50 in `faker/factory.py`), which creates a new list instead of mutating the original.
- **Test**: Added `test_includes_does_not_mutate_default_providers` regression test that verifies `PROVIDERS` length is unchanged after calling `Factory.create(includes=...)`.

Closes #2311

## Test plan

- [x] New regression test `test_includes_does_not_mutate_default_providers` passes
- [x] Full `tests/test_factory.py` suite passes (24 tests)
- [x] Linted with ruff — no issues