### PR TITLE
Add major Swiss banks to de_CH bank provider

### DIFF
--- a/faker/providers/bank/de_CH/__init__.py
+++ b/faker/providers/bank/de_CH/__init__.py
@@ -6,3 +6,19 @@ class Provider(BankProvider):
 
     bban_format = "#################"
     country_code = "CH"
+
+    # Major Swiss banks - Source: https://de.wikipedia.org/wiki/Schweizer_Bankwesen
+    banks = (
+        "UBS",
+        "Credit Suisse",
+        "Raiffeisen Schweiz",
+        "Zürcher Kantonalbank",
+        "PostFinance",
+        "Julius Bär",
+        "Banque Cantonale Vaudoise",
+        "Migros Bank",
+        "Basler Kantonalbank",
+        "Luzerner Kantonalbank",
+        "Union Bancaire Privée",
+        "Vontobel",
+    )

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -409,6 +409,11 @@ class TestDeCh:
             assert iban[:2] == DeChBankProvider.country_code
             assert re.fullmatch(r"\d{19}", iban[2:])
 
+    def test_bank(self, faker, num_samples):
+        for _ in range(num_samples):
+            bank = faker.bank()
+            assert bank in DeChBankProvider.banks
+
 
 class TestFrCh(TestDeCh):
     """Test fr_CH bank provider"""


### PR DESCRIPTION
### What does this change

Added a tuple of 12 major Swiss banks to the de_CH bank provider. Containing major banks as listed by [Wikipedia](https://de.wikipedia.org/wiki/Schweizer_Bankwesen)

### What was wrong

Calling `Faker("de_CH").bank()` raised an `AttributeError` because Faker is missing that specific dataset for the given locale.

### How this fixes it

Added the missing tuple to the `de_CH` locale so Faker can provide a bank name when running in `de_CH` locale.
Also added an additional test to check for the new tuple of banks.

### Checklist

- [X] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [X] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [X] I have run `make lint`
