### PR TITLE
Fix deepcopy proxy bindings for unique and optional helpers

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -141,12 +141,14 @@ class Faker:
     def __deepcopy__(self, memodict):
         cls = self.__class__
         result = cls.__new__(cls)
-        result._locales = copy.deepcopy(self._locales)
-        result._factories = copy.deepcopy(self._factories)
-        result._factory_map = copy.deepcopy(self._factory_map)
-        result._weights = copy.deepcopy(self._weights)
-        result._unique_proxy = UniqueProxy(self)
+        memodict[id(self)] = result
+        result._locales = copy.deepcopy(self._locales, memodict)
+        result._factory_map = copy.deepcopy(self._factory_map, memodict)
+        result._factories = list(result._factory_map.values())
+        result._weights = copy.deepcopy(self._weights, memodict)
+        result._unique_proxy = UniqueProxy(result)
         result._unique_proxy._seen = {k: {result._unique_proxy._sentinel} for k in self._unique_proxy._seen.keys()}
+        result._optional_proxy = OptionalProxy(result)
         return result
 
     def __setstate__(self, state: Any) -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -442,6 +442,39 @@ class TestFakerProxyClass:
         fake2 = copy.deepcopy(fake)
         assert fake.locales == fake2.locales
         assert fake.locales is not fake2.locales
+        assert fake2.factories[0] is fake2._factory_map["it_IT"]
+
+    def test_copy_rebinds_single_locale_proxies(self):
+        fake = Faker("en_US")
+        fake2 = copy.deepcopy(fake)
+
+        assert fake2.unique._proxy is fake2
+        assert fake2.optional._proxy is fake2
+        assert fake2.factories[0] is fake2._factory_map["en_US"]
+        assert fake2.optional.name(prob=1.0)
+
+    def test_copy_rebinds_multiple_locale_proxies(self):
+        fake = Faker(["en_US", "ja_JP"])
+        fake2 = copy.deepcopy(fake)
+
+        assert fake2.unique._proxy is fake2
+        assert fake2.optional._proxy is fake2
+        assert fake2.factories[0] is fake2["en_US"]
+        assert fake2.factories[1] is fake2["ja_JP"]
+        assert fake2.optional.name(prob=1.0)
+
+    def test_copy_unique_uses_copied_proxy_state(self):
+        source = Faker("en_US")
+        source.seed_instance(999)
+        clone_a = copy.deepcopy(source)
+        clone_b = copy.deepcopy(source)
+
+        clone_a.seed_instance(200)
+        clone_b.seed_instance(200)
+
+        assert clone_a.unique._proxy is clone_a
+        assert clone_b.unique._proxy is clone_b
+        assert clone_a.unique.name() == clone_b.unique.name()
 
     def test_pickle(self):
         fake = Faker()


### PR DESCRIPTION
## Summary

`copy.deepcopy(Faker(...))` currently leaves proxy helpers in a broken state:

- `optional` is not rebuilt for the copied instance, so `deepcopy(Faker()).optional.name()` raises an `AttributeError`
- `unique` is rebuilt against the original `Faker` instance instead of the copied one
- `_factories` and `_factory_map` can also drift apart inside the copied object because they are deep-copied independently

This patch rebuilds the copied proxy helpers against the copied `Faker` instance and reconstructs `_factories` from the copied `_factory_map`.

## Reproduction

Before this patch:

```python
import copy
from faker import Faker

copy.deepcopy(Faker()).optional.name()
# AttributeError: 'Generator' object has no attribute 'optional'
```

## AI Using

I used an AI coding assistant to help inspect the bug, draft the fix, and draft the PR text. I verified the bug locally, implemented the change myself in this branch, and validated the relevant tests locally.
