### PR TITLE
Fix duplicate phone number prefix 145 in zh_CN locale

### DIFF
--- a/faker/providers/phone_number/zh_CN/__init__.py
+++ b/faker/providers/phone_number/zh_CN/__init__.py
@@ -27,7 +27,6 @@ class Provider(PhoneNumberProvider):
         156,
         185,
         186,
-        145,
         133,
         153,
         180,


### PR DESCRIPTION
## Summary

The `zh_CN` phone number provider has a duplicate entry for prefix `145` in its `phonenumber_prefixes` list.

## The Bug

The list contains 30 entries but only 29 unique prefixes - `145` appears twice. This means:
- Prefix `145` is generated approximately 2x more often than other prefixes
- The distribution is slightly skewed

## The Fix

Remove the duplicate `145` entry from the list.

## Before

```python
phonenumber_prefixes = [
    ..., 156, 185, 186, 145, 133, 153, 180, 181, 189,
]
# 30 entries, 29 unique
```

## After

```python
phonenumber_prefixes = [
    ..., 156, 185, 186, 133, 153, 180, 181, 189,
]
# 29 entries, 29 unique
```