### PR TITLE
Added pan() and gstin() generators to en_IN provider

### DIFF
--- a/faker/providers/ssn/en_IN/__init__.py
+++ b/faker/providers/ssn/en_IN/__init__.py
@@ -1,6 +1,29 @@
+import string
+
 from faker.utils import checksums
 
 from .. import Provider as BaseProvider
+
+GSTIN_CHECKSUM_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+GSTIN_CHECKSUM_BASE = len(GSTIN_CHECKSUM_ALPHABET)
+
+
+def calculate_gstin_checksum(gstin_without_checksum: str) -> str:
+    """Calculate checksum character for a 14-character GSTIN prefix."""
+
+    factor = 2
+    total = 0
+
+    for char in reversed(gstin_without_checksum):
+        code_point = GSTIN_CHECKSUM_ALPHABET.index(char)
+        addend = factor * code_point
+        factor = 1 if factor == 2 else 2
+        addend = (addend // GSTIN_CHECKSUM_BASE) + (addend % GSTIN_CHECKSUM_BASE)
+        total += addend
+
+    remainder = total % GSTIN_CHECKSUM_BASE
+    check_code_point = (GSTIN_CHECKSUM_BASE - remainder) % GSTIN_CHECKSUM_BASE
+    return GSTIN_CHECKSUM_ALPHABET[check_code_point]
 
 
 class Provider(BaseProvider):
@@ -9,6 +32,8 @@ class Provider(BaseProvider):
     """
 
     aadhaar_id_formats = ("%##########",)
+    pan_type_chars = tuple("CPHFATBLJG")
+    gstin_entity_code_chars = tuple("123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
     def aadhaar_id(self) -> str:
         """
@@ -24,3 +49,32 @@ class Provider(BaseProvider):
         aadhaar_number = f"{aadhaar_digits}{checksum}"
 
         return aadhaar_number
+
+    def pan(self) -> str:
+        """
+        Permanent Account Number (PAN) is a 10 character alphanumeric tax
+        identifier issued in India.
+        Details: https://en.wikipedia.org/wiki/Permanent_account_number
+        """
+
+        first_three = self.lexify("???", letters=string.ascii_uppercase)
+        pan_type = self.random_element(self.pan_type_chars)
+        holder_initial = self.random_uppercase_letter()
+        serial = self.numerify("####")
+        check_char = self.random_uppercase_letter()
+
+        return f"{first_three}{pan_type}{holder_initial}{serial}{check_char}"
+
+    def gstin(self) -> str:
+        """
+        Goods and Services Tax Identification Number (GSTIN) is a 15 character
+        identifier used in India for GST registration.
+        Details: https://en.wikipedia.org/wiki/Goods_and_Services_Tax_(India)
+        """
+
+        state_code = f"{self.random_int(min=1, max=38):02d}"
+        entity_code = self.random_element(self.gstin_entity_code_chars)
+        gstin_without_checksum = f"{state_code}{self.pan()}{entity_code}Z"
+        checksum = calculate_gstin_checksum(gstin_without_checksum)
+
+        return f"{gstin_without_checksum}{checksum}"

--- a/faker/proxy.pyi
+++ b/faker/proxy.pyi
@@ -3303,6 +3303,22 @@ class Faker:
         """
         ...
 
+    def gstin(self) -> str:
+        """
+        Goods and Services Tax Identification Number (GSTIN) is a 15 character
+        identifier used in India for GST registration.
+        Details: https://en.wikipedia.org/wiki/Goods_and_Services_Tax_(India)
+        """
+        ...
+
+    def pan(self) -> str:
+        """
+        Permanent Account Number (PAN) is a 10 character alphanumeric tax
+        identifier issued in India.
+        Details: https://en.wikipedia.org/wiki/Permanent_account_number
+        """
+        ...
+
     def building_prefix(self) -> str: ...
     def city_prefix_abbr(self) -> str: ...
     def city_state(self) -> str:

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -17,6 +17,7 @@ from validators.i18n.es import es_nif as is_nif
 from faker import Factory, Faker
 from faker.providers.ssn.el_GR import tin_checksum as gr_tin_checksum
 from faker.providers.ssn.en_CA import checksum as ca_checksum
+from faker.providers.ssn.en_IN import calculate_gstin_checksum
 from faker.providers.ssn.es_CL import rut_check_digit as cl_rut_checksum
 from faker.providers.ssn.es_CO import nit_check_digit
 from faker.providers.ssn.es_MX import curp_checksum as mx_curp_checksum
@@ -210,6 +211,8 @@ class TestEnIn(unittest.TestCase):
     def setUp(self):
         self.fake = Faker("en_IN")
         Faker.seed(0)
+        self.pan_pattern: Pattern = re.compile(r"^[A-Z]{5}[0-9]{4}[A-Z]$")
+        self.gstin_pattern: Pattern = re.compile(r"^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z][0-9A-Z]Z[0-9A-Z]$")
         test_samples = 10
         self.aadhaar_ids = [self.fake.aadhaar_id() for _ in range(test_samples)]
 
@@ -224,6 +227,35 @@ class TestEnIn(unittest.TestCase):
     def test_valid_luhn(self):
         for aadhaar_id in self.aadhaar_ids:
             assert luhn_checksum(aadhaar_id) == 0
+
+    def test_pan(self):
+        for _ in range(100):
+            pan = self.fake.pan()
+            assert self.pan_pattern.search(pan)
+
+    def test_gstin(self):
+        for _ in range(100):
+            gstin = self.fake.gstin()
+            assert self.gstin_pattern.search(gstin)
+
+    def test_gstin_checksum(self):
+        for _ in range(100):
+            gstin = self.fake.gstin()
+            assert calculate_gstin_checksum(gstin[:-1]) == gstin[-1]
+
+    def test_seeded_pan_and_gstin_are_reproducible(self):
+        Faker.seed(42)
+        fake_one = Faker("en_IN")
+        pan_one = fake_one.pan()
+        gstin_one = fake_one.gstin()
+
+        Faker.seed(42)
+        fake_two = Faker("en_IN")
+        pan_two = fake_two.pan()
+        gstin_two = fake_two.gstin()
+
+        assert pan_one == pan_two
+        assert gstin_one == gstin_two
 
 
 class TestEnPh(unittest.TestCase):


### PR DESCRIPTION
### What does this change:

Adds `pan()` and `gstin()` generators to the `en_IN` SSN provider.

- `pan()` now generates values matching `^[A-Z]{5}[0-9]{4}[A-Z]$`.
- `gstin()` now generates values matching `^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z][0-9A-Z]Z[0-9A-Z]$`.
- GSTIN checksum is generated using a base-36 checksum routine over the first 14 characters.
- Adds tests for PAN format, GSTIN format, GSTIN checksum validation, and deterministic output under seeding.

### What was wrong:

`en_IN` had `aadhaar_id()`, but did not provide `pan()` or `gstin()`, which are common IDs needed in India focused invoicing/compliance workflows.

### How this solves it:

- Extends `faker.providers.ssn.en_IN.Provider` with `pan()` and `gstin()` methods.
- Adds `calculate_gstin_checksum()` helper in `en_IN` provider for checksum correctness.
- Extends `TestEnIn` in `tests/providers/test_ssn.py` with repeated generation checks (`100` samples), checksum checks, and seeded reproducibility checks.
- Runs `make lint` (which updates stubs) so `faker/proxy.pyi` contains the new public methods.

Solves #2356

### AI Assistance Disclosure:
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: GitHub Copilot (GPT-5.3-Codex), used to draft and apply code/test changes and PR text. All generated code and tests were manually reviewed and validated locally.

### Checklist:

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`

The screenshot of the SSN provider test suite for validation (run inside WSL):

<img width="1866" height="583" alt="image" src="https://github.com/user-attachments/assets/3e0aa493-ef9d-493f-ae8c-c3e0be68844f" />

