### PR TITLE
Follow-up to #2287: Add requested tests

### DIFF
--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -183,10 +183,10 @@ class Faker:
         return factory
 
     def _select_factory_distribution(self, factories, weights):
-        return choices_distribution(factories, weights, random, length=1)[0]
+        return choices_distribution(factories, weights, self.factories[0].random, length=1)[0]
 
     def _select_factory_choice(self, factories):
-        return random.choice(factories)
+        return self._factories[0].random.choice(factories)
 
     def _map_provider_method(self, method_name: str) -> tuple[list[Factory], list[float] | None]:
         """

--- a/faker/proxy.py
+++ b/faker/proxy.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Pattern, Sequence, TypeVar
 from .config import DEFAULT_LOCALE
 from .exceptions import UniquenessException
 from .factory import Factory
-from .generator import Generator, random
+from .generator import Generator
 from .typing import SeedType
 from .utils.distribution import choices_distribution
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -437,6 +437,43 @@ class TestFakerProxyClass:
         attributes = dir(fake)
         assert attributes == expected
 
+    def test_select_factory_distribution_uses_instance_random(self):
+        from faker.utils.distribution import choices_distribution
+
+        locale = OrderedDict([("de_DE", 3), ("en_US", 2), ("ja_JP", 5)])
+        fake = Faker(locale)
+        fake.seed_instance(12345)
+
+        instance_random = fake._factories[0].random
+        with patch("faker.proxy.choices_distribution", wraps=choices_distribution) as mock_dist:
+            fake.name()
+            mock_dist.assert_called_once()
+            args = mock_dist.call_args[0]
+            assert args[2] is instance_random
+
+    def test_seed_instance_deterministic_multi_locale_no_weights(self):
+        fake = Faker(["en_US", "ja_JP", "de_DE"])
+        fake.seed_instance(12345)
+        first_run = [fake.name() for _ in range(20)]
+
+        fake2 = Faker(["en_US", "ja_JP", "de_DE"])
+        fake2.seed_instance(12345)
+        second_run = [fake2.name() for _ in range(20)]
+
+        assert first_run == second_run
+
+    def test_seed_instance_deterministic_multi_locale_with_weights(self):
+        locale = OrderedDict([("de_DE", 3), ("en_US", 2), ("ja_JP", 5)])
+        fake = Faker(locale)
+        fake.seed_instance(12345)
+        first_run = [fake.name() for _ in range(20)]
+
+        fake2 = Faker(locale)
+        fake2.seed_instance(12345)
+        second_run = [fake2.name() for _ in range(20)]
+
+        assert first_run == second_run
+
     def test_copy(self):
         fake = Faker("it_IT")
         fake2 = copy.deepcopy(fake)


### PR DESCRIPTION
Builds on #2287 by @just6660.
Adds the tests to compare the outputs for two runs using the same seed, for more than one locale defined.
Also, importing random is no longer needed so it was removed.