### PR TITLE
Fix UnicodeEncodeError in CLI docs on non-UTF consoles

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -20,6 +20,19 @@ __author__ = "joke2k"
 T = TypeVar("T")
 
 
+def _encode_for_output(value: str, output: TextIO) -> str:
+    encoding = getattr(output, "encoding", None)
+    if encoding is None:
+        return value
+
+    try:
+        value.encode(encoding)
+    except UnicodeEncodeError:
+        return value.encode(encoding, errors="backslashreplace").decode(encoding)
+
+    return value
+
+
 def print_provider(
     doc: Documentor,
     provider: BaseProvider,
@@ -33,7 +46,7 @@ def print_provider(
         excludes = []
 
     print(file=output)
-    print(f"### {doc.get_provider_name(provider)}", file=output)
+    print(_encode_for_output(f"### {doc.get_provider_name(provider)}", output), file=output)
     print(file=output)
 
     margin = max(30, doc.max_name_len + 2)
@@ -56,7 +69,8 @@ def print_provider(
         except UnicodeEncodeError:
             raise Exception(f"error on {signature!r} with value {example!r}")
         for left, right in itertools.zip_longest(signature_lines, lines, fillvalue=""):
-            print(f"\t{left:<{margin}}  {right}", file=output)
+            line = f"\t{left:<{margin}}  {right}"
+            print(_encode_for_output(line, output), file=output)
 
 
 def print_doc(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -26,6 +26,21 @@ class FactoryTestCase(unittest.TestCase):
         print_doc("faker.providers.person.it_IT", output=output)
         assert output.getvalue()
 
+    def test_print_provider_handles_non_utf_output(self):
+        from faker.cli import print_provider
+
+        doc = MagicMock()
+        doc.max_name_len = len("fake.emoji()")
+        doc.get_provider_name.return_value = "faker.providers.emoji"
+
+        output = io.TextIOWrapper(io.BytesIO(), encoding="cp950")
+        print_provider(doc, MagicMock(), {"fake.emoji()": "👩"}, output=output)
+        output.flush()
+
+        rendered = output.buffer.getvalue().decode("cp950")
+        assert "fake.emoji()" in rendered
+        assert "\\U0001f469" in rendered
+
     def test_command(self):
         from faker.cli import Command
 


### PR DESCRIPTION
## Changes done:

Fixes a CLI crash when printing provider docs to terminals using non-UTF encodings (for example cp950 on Windows).

### Problem Explaination:

`python -m faker` can raise `UnicodeEncodeError` while printing provider examples that include characters unsupported by the output encoding (such as emoji on cp950).
This happens in `print_provider()` when writing formatted documentation lines.

### Fix:

- Adds `_encode_for_output()` in `faker/cli.py` to safely encode output strings for the active stream encoding.
- Falls back to `backslashreplace` when characters are not encodable, so output remains printable and the CLI does not crash.
- Uses this safe encoding path for provider headings and example lines printed by `print_provider()`.
- Adds regression test `test_print_provider_handles_non_utf_output` to verify cp950 output no longer crashes and preserves escaped content.

Fixes #2361

### AI Assistance Disclosure (as REQUIRED):
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: GitHub Copilot (GPT-5.3-Codex), used for code drafting and test drafting. All changes were manually reviewed and validated by running tests.

### Checklist:

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst).
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst).
- [x] I have run `make lint`.

The screenshots of the tests run, for validation (ran on WSL):

<img width="1389" height="753" alt="image" src="https://github.com/user-attachments/assets/2b3e9029-8a63-478e-ba9b-4020b75f701a" />

