### PR TITLE
feat: add banks list for en_GB locale

### DIFF
--- a/faker/providers/bank/en_GB/__init__.py
+++ b/faker/providers/bank/en_GB/__init__.py
@@ -2,7 +2,49 @@ from .. import Provider as BankProvider
 
 
 class Provider(BankProvider):
-    """Implement bank provider for ``en_GB`` locale."""
+    """Implement bank provider for ``en_GB`` locale.
+
+    Banks list sourced from:
+    https://en.wikipedia.org/wiki/List_of_banks_in_the_United_Kingdom
+    https://en.wikipedia.org/wiki/Banking_in_the_United_Kingdom
+    Last checked: 2026-04-10
+    """
 
     bban_format = "????##############"
     country_code = "GB"
+    banks = (
+        "Al Rayan Bank",
+        "Aldermore Bank",
+        "Atom Bank",
+        "Bank of Ireland UK",
+        "Bank of London and The Middle East",
+        "Bank of Scotland",
+        "Barclays Bank",
+        "Chase UK",
+        "Clydesdale Bank",
+        "Co-operative Bank",
+        "Gatehouse Bank",
+        "Halifax",
+        "Handelsbanken",
+        "HSBC UK",
+        "Investec Bank",
+        "Kroo Bank",
+        "Lloyds Bank",
+        "Metro Bank",
+        "Monzo Bank",
+        "Nationwide Building Society",
+        "NatWest",
+        "OakNorth Bank",
+        "Revolut Bank",
+        "Royal Bank of Scotland",
+        "Santander UK",
+        "Shawbrook Bank",
+        "Starling Bank",
+        "Tandem Bank",
+        "TSB Bank",
+        "Ulster Bank",
+        "Virgin Money",
+        "Yorkshire Bank",
+        "Zempler Bank",
+        "Zopa Bank",
+    )

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -142,6 +142,12 @@ class TestElGr:
 class TestEnGb:
     """Test en_GB bank provider"""
 
+    def test_bank(self, faker, num_samples):
+        for _ in range(num_samples):
+            bank = faker.bank()
+            assert isinstance(bank, str)
+            assert bank in EnGbBankProvider.banks
+
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):
             assert re.fullmatch(r"[A-Z]{4}\d{14}", faker.bban())


### PR DESCRIPTION
### What does this change
Adds a `banks` tuple to the `en_GB` bank provider, enabling the `bank()` method to return realistic UK bank names. Also adds a `test_bank` test to the `TestEnGb` class in `tests/providers/test_bank.py`.

### What was wrong
The `en_GB` bank provider was missing the `banks` attribute, causing `bank()` to raise `AttributeError` despite being documented as supported for this locale.

### How this fixes it
Added a `banks` tuple containing major UK retail banks, challenger banks, and Islamic banks. Sources:
- https://en.wikipedia.org/wiki/List_of_banks_in_the_United_Kingdom
- https://en.wikipedia.org/wiki/Banking_in_the_United_Kingdom

Fixes #2280

### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

*Claude (Anthropic) was used to assist with compiling the initial bank list. The list was cross-referenced against Wikipedia sources and verified manually.*

### Checklist
- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`