### PR TITLE
fix: update image placeholder service from placekitten to placekittens (fixes #2345)

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -213,7 +213,7 @@ class Provider(BaseProvider):
     image_placeholder_services: ElementsType[str] = (
         "https://picsum.photos/{width}/{height}",
         "https://dummyimage.com/{width}x{height}",
-        "https://placekitten.com/{width}/{height}",
+        "https://placekittens.com/{width}/{height}",
     )
 
     replacements: Tuple[Tuple[str, str], ...] = ()


### PR DESCRIPTION
### What does this change
Updates the image_placeholder_services list with the internet provider to use `placekittens.com`(with an "s")instead of the now defunct `placekitten.com`.

Brief summary of the changes.

### What was wrong
The original `placekitten.com` domain has been offline or unresponsive since mid-2024(as documented via the  Wayback Machine) This caused generated image placeholder URLs to fail when used in actual browser environments.

Description of the root cause of the issue.

### How this fixes it
It replaces the dead URL with `placekittens.com`, which currently serves kitten placeholders using the same width/height path parameters. Before this fix i performed a global search to ensure no other hardcoded references remained and verified that all 95 tests in `test/providers/test_internet.py` pass successfully.

Description of how the changes fix the issue.
Ran `pytest tests/providers/test_internet.py` pytest resulting in 95 passed tests.
Performed a global search to make sure no other instance of the old domain exist in the codebase.
I confirmed that `placekittens.com/{width}/{height}` returns valid images in the browser

Fixes #2345 

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [ x ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

**Disclosure**: I used Google Gemini to help guide me with the pytest features of the fix so as not to disturb any aspects of the codebase. The code changes were done by myself and the manually global checking.

### Checklist
- [ x ] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [ x ] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ x ] I have run `make lint`
