### PR TITLE
fix(en_IN): avoid shared state mutation in pincode_in_state

### DIFF
--- a/faker/providers/address/en_IN/__init__.py
+++ b/faker/providers/address/en_IN/__init__.py
@@ -533,7 +533,7 @@ class Provider(AddressProvider):
         if state_abbr in known_abbrs:
             codes = self.state_pincode
             if include_union_territories:
-                codes.update(self.union_territories_pincode)
+                codes = {**codes, **self.union_territories_pincode}
 
             pincode_range = self.random_element(codes[state_abbr])
 

--- a/tests/providers/test_address.py
+++ b/tests/providers/test_address.py
@@ -672,6 +672,15 @@ class TestEnIn:
             assert isinstance(pincode, int)
             assert len(str(pincode)) == 6
 
+    def test_pincode_in_state_does_not_mutate_state_pincode(self, faker):
+        """Test `state_pincode` remains unchanged when union territories are included"""
+
+        state_pincode_before = EnInAddressProvider.state_pincode.copy()
+
+        faker.pincode_in_state(include_union_territories=True)
+
+        assert EnInAddressProvider.state_pincode == state_pincode_before
+
     @pytest.mark.parametrize(
         "pincodes",
         [


### PR DESCRIPTION
Fixes shared state mutation in the en_IN address provider by avoiding in-place updates in `pincode_in_state(..., include_union_territories=True)`.

Adds regression test to ensure class-level `state_pincode` remains unchanged.

### Issue:

`pincode_in_state` assigned `codes = self.state_pincode` and then called `codes.update(self.union_territories_pincode)` when union territories were included.
Because `codes` referenced the class level dictionary, this permanently mutated shared provider state across calls and instances.

### Fix:

When union territories are requested, the method now builds a merged per-call dictionary:
`codes = {**codes, **self.union_territories_pincode}`

This preserves existing behavior for generated PIN codes while preventing mutation of `Provider.state_pincode`.

### Validation:

- `pytest tests/providers/test_address.py::TestEnIn::test_pincode_in_state_does_not_mutate_state_pincode -q`

Fixes #2365

### AI Assistance Disclosure (REQUIRED):
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Disclosure: GitHub Copilot (GPT-5.3 Codex) was used to help draft and implement code/test changes and PR text. All outputs were manually reviewed, edited, and validated with linting and real test execution.

### Checklist:

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`.

#### The validation screenshot of the tests run, locally on WSL:

<img width="2155" height="843" alt="image" src="https://github.com/user-attachments/assets/27b3fa3a-7032-4abd-9147-1abe8cd78a2d" />
