### PR TITLE
fix: raise NotImplementedError in bank() for locales without banks data

### DIFF
--- a/faker/providers/bank/__init__.py
+++ b/faker/providers/bank/__init__.py
@@ -51,7 +51,7 @@ class Provider(BaseProvider):
     def bank(self) -> str:
         """Generate a bank name."""
         if not hasattr(self, "banks"):
-            raise AttributeError(
+            raise NotImplementedError(
                 f"The {self.__class__.__name__} provider does not have a 'banks' "
                 "attribute. Consider contributing to the project and "
                 " adding a 'banks' tuple to enable bank name generation."

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -64,13 +64,21 @@ class TestBaseBankProvider:
     """Test base bank provider"""
 
     def test_bank_not_implemented_error(self, faker):
-        """Test that bank() raises AttributeError when no banks attribute exists"""
+        """Test that bank() raises NotImplementedError when no banks attribute exists.
+
+        Raising NotImplementedError (instead of AttributeError) ensures that
+        hasattr(faker, 'bank') correctly returns True (the method exists) while
+        still clearly communicating that this locale has not implemented bank
+        name generation. Previously AttributeError was raised, which caused
+        hasattr() to return False-positive True yet crash on the call.
+        See: https://github.com/joke2k/faker/issues/2377
+        """
 
         provider = BankProvider(faker)
 
         assert not hasattr(provider, "banks")
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(NotImplementedError):
             provider.bank()
 
 


### PR DESCRIPTION
fixes #2377

bank() was raising AttributeError when the locale has no banks data. the problem is hasattr silently catches AttributeError so hasattr(faker, 'bank') returns True but then faker.bank() crashes which is pretty confusing.

changed it to NotImplementedError like fcurella suggested. also updated the existing test to match.