### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/faker/cli.py
+++ b/faker/cli.py
@@ -63,7 +63,7 @@ def print_provider(
             )
         except UnicodeDecodeError:
             # The example is actually made of bytes.
-            # We could coerce to bytes, but that would fail anyway when we wiil
+            # We could coerce to bytes, but that would fail anyway when we will
             # try to `print` the line.
             lines = ["<bytes>"]
         except UnicodeEncodeError:

--- a/faker/providers/automotive/en_US/__init__.py
+++ b/faker/providers/automotive/en_US/__init__.py
@@ -27,7 +27,7 @@ class Provider(AutomotiveProvider):
         # Colarado
         "###-???",
         "???-###",
-        # Conneticut
+        # Connecticut
         "###-???",
         # Delaware
         "######",
@@ -113,7 +113,7 @@ class Provider(AutomotiveProvider):
         "###-????",
         # North Dakota
         "### ???",
-        # Nothern Mariana Islands
+        # Northern Mariana Islands
         "??? ###",
         # Ohio
         "??? ####",

--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -584,7 +584,7 @@ class Provider(BaseProvider):
                 :returns: Flat list of IPv4 networks after exclusion.
                           If exclude fails because networks do not
                           overlap, a single element list with the
-                          orignal network is returned. If it overlaps,
+                          original network is returned. If it overlaps,
                           even partially, the network is excluded.
                 """
                 try:

--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -49,7 +49,7 @@ class Provider(BaseProvider):
     def binary(self, length: int = (1 * 1024 * 1024)) -> bytes:
         """Generate a random binary blob of ``length`` bytes.
 
-        If this faker instance has been seeded, performance will be signficiantly reduced, to conform
+        If this faker instance has been seeded, performance will be significantly reduced, to conform
         to the seeding.
 
         :sample: length=64

--- a/faker/providers/passport/en_US/__init__.py
+++ b/faker/providers/passport/en_US/__init__.py
@@ -53,7 +53,7 @@ class Provider(PassportProvider):
             issue_date = self.generator.date_time_between(
                 today - timedelta(days=expiry_years * 365 - 1), birthday + timedelta(days=16 * 365 - 1)
             )
-            # all people over 21 must have been over 16 when they recieved passport or it will be expired otherwise
+            # all people over 21 must have been over 16 when they received passport or it will be expired otherwise
             if age >= 21:
                 issue_date = self.generator.date_time_between(today - timedelta(days=expiry_years * 365 - 1), today)
                 expiry_years = 10
@@ -81,7 +81,7 @@ class Provider(PassportProvider):
         return gender
 
     def passport_full(self) -> str:
-        """Generates a formatted sting with US Passport information"""
+        """Generates a formatted string with US Passport information"""
         dob = self.passport_dob()
         birth_date, issue_date, expiry_date = self.passport_dates(dob)
         gender_g = self.passport_gender()


### PR DESCRIPTION
### What does this change

Fixes seven spelling mistakes in code comments and docstrings. No functional changes.

| File | Fix |
| --- | --- |
| `faker/cli.py` | `wiil` → `will` |
| `faker/providers/internet/__init__.py` | `orignal` → `original` |
| `faker/providers/misc/__init__.py` | `signficiantly` → `significantly` (`binary()` docstring) |
| `faker/providers/passport/en_US/__init__.py` | `recieved` → `received`, `sting` → `string` (`passport_full()` docstring) |
| `faker/providers/automotive/en_US/__init__.py` | `Conneticut` → `Connecticut`, `Nothern` → `Northern` |

### What was wrong

Minor misspellings. The `misc.binary()` and `passport_full()` ones are in public method docstrings, so they also surface in the generated `proxy.pyi` stubs and the API docs.

### How this fixes it

Corrects the spelling only. Each candidate was checked to be a genuine English typo in a comment or docstring — not localized data, currency codes, place names, or surnames (for example `Soure`, a real city in Brazil, was deliberately left untouched).

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

`codespell` was used to surface candidate misspellings, and an AI assistant (Claude) helped review the candidates and draft this description. Every change was then verified by hand. Checks run on the modified files: `flake8 --extend-ignore=E203` (clean), `black --check --line-length 120` (clean), `isort --check` (clean), and a quick smoke test of the affected providers (`passport_full()`, `license_plate()`, `binary()`).

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [ ] I have run `make lint` — ran `flake8`, `black --line-length 120`, and `isort` on the changed files individually (all clean). I did not run the full target, which also regenerates the type stubs and requires Python 3.11; the two docstring fixes will propagate to `proxy.pyi` on the next `make generate-stubs`.
