### PR TITLE
docs: fix three outdated links in README credits section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -473,15 +473,15 @@ Credits
 
 .. _FZaninotto: https://github.com/fzaninotto
 .. _PHP Faker: https://github.com/fzaninotto/Faker
-.. _Perl Faker: http://search.cpan.org/~jasonk/Data-Faker-0.07/
+.. _Perl Faker: https://metacpan.org/dist/Data-Faker
 .. _Ruby Faker: https://github.com/stympy/faker
 .. _Distribute: https://pypi.org/project/distribute/
-.. _Buildout: http://www.buildout.org/
+.. _Buildout: https://www.buildout.org/
 .. _modern-package-template: https://pypi.org/project/modern-package-template/
 .. _extended docs: https://faker.readthedocs.io/en/stable/
 .. _bundled providers: https://faker.readthedocs.io/en/stable/providers.html
 .. _community providers: https://faker.readthedocs.io/en/stable/communityproviders.html
-.. _pytest fixture docs: https://faker.readthedocs.io/en/master/pytest-fixtures.html
+.. _pytest fixture docs: https://faker.readthedocs.io/en/stable/pytest-fixtures.html
 .. _LICENSE: https://github.com/joke2k/faker/blob/master/LICENSE.txt
 .. _CONTRIBUTING: https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst
 .. _Factory Boy: https://github.com/FactoryBoy/factory_boy


### PR DESCRIPTION
## What

Fixes three outdated links in the credits section of `README.rst`:

1. **`Perl Faker` link**: `http://search.cpan.org/~jasonk/Data-Faker-0.07/` → `https://metacpan.org/dist/Data-Faker`
   - `search.cpan.org` was retired and now redirects to MetaCPAN. The correct, stable URL is on `metacpan.org`.

2. **`Buildout` link**: `http://www.buildout.org/` → `https://www.buildout.org/`
   - Simple HTTP → HTTPS upgrade.

3. **`pytest fixture docs` link**: `https://faker.readthedocs.io/en/master/pytest-fixtures.html` → `https://faker.readthedocs.io/en/stable/pytest-fixtures.html`
   - All other ReadTheDocs links in the file use `/en/stable/`; this one inconsistently used `/en/master/`.

## Why

`search.cpan.org` was decommissioned and the old URL no longer reliably reaches the Perl Faker module page. The other two are minor consistency/security improvements.

## How verified

- Confirmed `https://metacpan.org/dist/Data-Faker` resolves to the Data-Faker module page (version 0.10).
- `https://faker.readthedocs.io/en/stable/pytest-fixtures.html` is an existing valid page.
- No code changes; only doc link updates.

---

*Note: this PR was prepared with AI assistance (Claude). The changes have been reviewed and verified to be accurate.*