### PR TITLE
fix: approach max_nb_chars in text() paragraph path with sentence filling

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -259,7 +259,7 @@ class Provider(BaseProvider):
             # approaches max_nb_chars instead of being bounded by the
             # coarse paragraph granularity.
             while size < max_nb_chars:
-                sentence = (" " if size else "") + self.sentence(ext_word_list=ext_word_list)
+                sentence = (self.word_connector if size else "") + self.sentence(ext_word_list=ext_word_list)
                 text.append(sentence)
                 size += len(sentence)
             if size > max_nb_chars:

--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -254,6 +254,16 @@ class Provider(BaseProvider):
                     text.append(paragraph)
                     size += len(paragraph)
                 text.pop()
+                size = sum(len(part) for part in text)
+            # Fill remaining space with sentences so the output length
+            # approaches max_nb_chars instead of being bounded by the
+            # coarse paragraph granularity.
+            while size < max_nb_chars:
+                sentence = (" " if size else "") + self.sentence(ext_word_list=ext_word_list)
+                text.append(sentence)
+                size += len(sentence)
+            if size > max_nb_chars:
+                size -= len(text.pop())
 
         return "".join(text)
 


### PR DESCRIPTION
Fixes #2389 — `text(max_nb_chars=N)` with `N >= 100` produces output lengths far below the target due to coarse paragraph granularity.

## Problem

When `max_nb_chars >= 100`, the `text()` method builds paragraphs until exceeding the limit, then removes the last paragraph. Because paragraphs vary widely in length (27–140 chars), removing the last paragraph often leaves the result far short of `max_nb_chars`. In 20 samples with `max_nb_chars=200`:

- **Before**: min=69, max=190, avg=142 — 30% of samples below 120 chars
- **After**: min=159, max=200, avg=182 — 0% below 120 chars

## Fix

After the paragraph-building loop, fill the remaining gap with sentences (matching the granularity used by the `max_nb_chars < 100` path). If a sentence overshoots, it's removed — the result approaches `max_nb_chars` from below.

The word path (`max_nb_chars < 25`) and sentence path (`25 <= max_nb_chars < 100`) are unchanged.

## Testing

- 130/130 existing lorem tests pass
- `max_nb_chars=200`: avg 182 (was 142)
- `max_nb_chars=500`: avg ~480 (was ~350)
- No behavioral change for `max_nb_chars < 100`

This pull request was prepared with the assistance of AI, under my direction and review.