### PR TITLE
fix: prevent infinite RecursionError in pyfloat() for sub-integer ranges

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -264,7 +264,13 @@ class Provider(BaseProvider):
             min_value = max(min_value, 0)
 
         if min_value == max_value:
-            return self._safe_random_int(orig_min_value, orig_max_value, positive)
+            # Only retry if at least one bound was randomly chosen (None originally);
+            # when both bounds were explicitly supplied and still collapse to the same
+            # integer after adjustment, retrying would recurse infinitely with the same
+            # inputs.  Return the collapsed value directly in that case.
+            if orig_min_value is None or orig_max_value is None:
+                return self._safe_random_int(orig_min_value, orig_max_value, positive)
+            return int(min_value)
         else:
             min_value = int(min_value)
             max_value = int(max_value - 1)

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -519,6 +519,27 @@ class TestPyfloat(unittest.TestCase):
             self.assertLessEqual(result, 0.1)
             self.assertGreater(result, 0)
 
+    def test_pyfloat_min_neg_one_max_zero(self):
+        """
+        pyfloat(min_value=-1, max_value=0) previously caused an infinite
+        RecursionError inside _safe_random_int when both adjusted bounds
+        collapsed to the same integer (0).  Regression test.
+        """
+        for _ in range(20):
+            result = self.fake.pyfloat(min_value=-1, max_value=0)
+            self.assertGreaterEqual(result, -1)
+            self.assertLessEqual(result, 0)
+
+    def test_pyfloat_min_neg_max_zero_general(self):
+        """
+        Any range where both int-truncated bounds coincide (e.g. (-0.9, 0.1))
+        should not raise RecursionError.
+        """
+        for _ in range(20):
+            result = self.fake.pyfloat(min_value=-0.9, max_value=0.1)
+            self.assertGreaterEqual(result, -0.9)
+            self.assertLessEqual(result, 0.1)
+
 
 class TestPyint(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What

`pyfloat(min_value=-1, max_value=0)` (and any range where both bounds truncate to the same integer, such as `(-0.9, 0.1)`) raises an unbounded `RecursionError` at runtime.

## Root cause

`_safe_random_int` adjusts the caller-supplied bounds before selecting an integer.
For a range like `(-1, 0)` the adjustment shifts `min_value` from −1 to 0, leaving
both bounds equal to 0.  The method then recurses with the *original* arguments,
which produce the same collapsed bounds, which recurse again — indefinitely.

The recursive call was intended for the case where *one* bound was `None` (randomly
chosen), so that the retry would pick a different random value.  When *both* bounds
are explicit, retrying always gives the same result.

## Fix

One-line guard: only recurse when at least one original bound was `None`.
If both were explicitly supplied and collapse to the same integer, return that
integer directly and let the downstream clamping in `pyfloat` keep the result
within the requested range.

## Reproducer (before fix)

```python
from faker import Faker
Faker().pyfloat(min_value=-1, max_value=0)  # RecursionError
Faker().pyfloat(min_value=-0.9, max_value=0.1)  # RecursionError
```

## Related issues

Closes #2082, #1926, #1152 (all filed at different times for the same underlying bug, then closed as stale without a code fix).

---

This pull request was prepared with the assistance of AI, under my direction and review.