### PR TITLE
fix(de_DE): compute valid ISO 7064 Mod 11,10 check digit for vat_id (#2399)

### DIFF
--- a/faker/providers/ssn/de_DE/__init__.py
+++ b/faker/providers/ssn/de_DE/__init__.py
@@ -48,14 +48,26 @@ class Provider(BaseProvider):
         # get the check digit by summing up the digit sums and calculating the modulo of 10
         return str(sum(digit_sums) % 10)
 
+    def __get_vat_checkdigit(self, digits: str) -> str:
+        # ISO 7064 Mod 11,10 check digit for the German USt-IdNr.
+        product = 10
+        for digit in digits:
+            digit_sum = (int(digit) + product) % 10
+            if digit_sum == 0:
+                digit_sum = 10
+            product = (2 * digit_sum) % 11
+        return str((11 - product) % 10)
+
     def vat_id(self) -> str:
         """
         http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
 
-        :return: A random German VAT ID
+        :return: A random German VAT ID with a valid ISO 7064 Mod 11,10 check digit
         """
-
-        return self.bothify(self.random_element(self.vat_id_formats))
+        # The USt-IdNr is 9 digits: the first must be non-zero and the last is
+        # an ISO 7064 Mod 11,10 check digit over the preceding 8 digits.
+        base = str(self.random_digit_not_null()) + self.numerify("#######")
+        return "DE" + base + self.__get_vat_checkdigit(base)
 
     def rvnr(self, birthdate: Optional[date] = None) -> str:
         """

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -141,7 +141,14 @@ class TestDeDe(unittest.TestCase):
 
     def test_vat_id(self):
         for _ in range(100):
-            assert re.search(r"^DE\d{9}$", self.fake.vat_id())
+            vat_id = self.fake.vat_id()
+            assert re.fullmatch(r"DE[1-9]\d{8}", vat_id)
+            # the last digit is an ISO 7064 Mod 11,10 check digit over the first 8
+            product = 10
+            for digit in vat_id[2:10]:
+                digit_sum = (int(digit) + product) % 10 or 10
+                product = (2 * digit_sum) % 11
+            assert vat_id[10] == str((11 - product) % 10)
 
     def test_rvnr(self):
         for _ in range(100):


### PR DESCRIPTION
## Problem

`Faker('de_DE').vat_id()` returns `DE` + 9 **random** digits. The German USt-IdNr's last digit is an **ISO 7064 Mod 11,10** check digit, so the generated numbers fail validation ~90% of the time (see #2399).

```python
from faker import Faker
from stdnum.de import vat
f = Faker('de_DE')
sum(vat.is_valid(f.vat_id()) for _ in range(1000))   # ~90 / 1000 before this change
```

## Fix

Compute the ISO 7064 Mod 11,10 check digit over the first 8 digits and force a non-zero first digit (the spec — and `python-stdnum` — reject a leading `0`). After this change the same loop returns **1000 / 1000**, verified against `python-stdnum` (2000/2000 over a larger sample locally).

This mirrors the approach used for the Belgian VAT mod-97 check referenced in the issue (#2037, #864).

## Test

Strengthens the existing `TestDeDe.test_vat_id` to verify the check digit (the old assertion `^DE\d{9}$` matched the buggy random output too), recomputing the ISO 7064 Mod 11,10 digit independently — no new test dependency.

Fixes #2399

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening it under my name. The fix was validated against `python-stdnum` as an independent oracle.*
