### PR TITLE
fix(es_ES): generate valid Spanish CCC control digits in iban() (#2398)

### DIFF
--- a/faker/providers/bank/es_ES/__init__.py
+++ b/faker/providers/bank/es_ES/__init__.py
@@ -6,3 +6,19 @@ class Provider(BankProvider):
 
     bban_format = "####################"
     country_code = "ES"
+
+    @staticmethod
+    def _ccc_control_digit(number: str) -> str:
+        # Spanish CCC control digit (weights 2**i mod 11).
+        check = sum(int(n) * 2**i for i, n in enumerate(number)) % 11
+        return str(check if check < 2 else 11 - check)
+
+    def bban(self) -> str:
+        # Spanish CCC: bank (4) + branch (4) + 2 control digits + account (10).
+        # The control digits are computed, not random, so the BBAN passes
+        # country-level validation (ISO 13616 alone does not cover them).
+        bank = self.numerify("####")
+        branch = self.numerify("####")
+        account = self.numerify("##########")
+        control = self._ccc_control_digit("00" + bank + branch) + self._ccc_control_digit(account)
+        return bank + branch + control + account

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -245,11 +245,19 @@ class TestEsEs:
             assert re.fullmatch(r"\d{20}", faker.bban())
 
     def test_iban(self, faker, num_samples):
+        def _ccc_control_digit(number):
+            check = sum(int(n) * 2**i for i, n in enumerate(number)) % 11
+            return str(check if check < 2 else 11 - check)
+
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
             assert iban[:2] == EsEsBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
+            # the BBAN must carry valid Spanish CCC control digits
+            bban = iban[4:]
+            bank_branch, control, account = bban[:8], bban[8:10], bban[10:]
+            assert control == _ccc_control_digit("00" + bank_branch) + _ccc_control_digit(account)
 
 
 class TestEsMx:


### PR DESCRIPTION
## Problem

`Faker('es_ES').iban()` returns IBANs whose ISO 13616 (mod-97) check is correct, but whose **Spanish CCC control digits** (the two control digits inside the BBAN) are filled randomly. Strict validators reject them — `stdnum.es.iban` accepts only ~1% (see #2398).

```python
from faker import Faker
from stdnum.es import iban as es_iban
f = Faker('es_ES')
sum(es_iban.is_valid(f.iban()) for _ in range(1000))   # ~12 / 1000 before this change
```

## Fix

Override `bban()` for `es_ES` to compute the two CCC control digits (weights `2**i mod 11`) over `'00' + bank + branch` and over the account number, instead of leaving them random. The generic `iban()` then wraps the BBAN with the correct ISO 13616 check as before.

After this change the same loop returns **1000 / 1000**, verified against `python-stdnum` (2000/2000 over a larger sample locally).

## Test

Strengthens `TestEsEs.test_iban` to recompute and assert the CCC control digits (the previous assertion only checked the ISO mod-97 digits, which the buggy output already passed) — no new test dependency.

Fixes #2398

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening it under my name. Validated against `python-stdnum` as an independent oracle.*

---
**AI disclosure:** Prepared with AI assistance (Claude / Claude Code). All output was human-reviewed and verified — generated IBANs validated against `python-stdnum` and the test suite passes.