### PR TITLE
fix(pt_BR): correct BBAN length so iban() generates valid Brazilian IBANs

### DIFF
--- a/faker/providers/bank/pt_BR/__init__.py
+++ b/faker/providers/bank/pt_BR/__init__.py
@@ -10,7 +10,7 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``pt_BR`` locale."""
 
-    bban_format: str = "#########################??"  # BRXX + 23 digits + 2 alhpanumber
+    bban_format: str = "#######################??"  # BRXX + 23 digits + 2 alphanumeric
     country_code: str = "BR"
 
     banks = (

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -20,6 +20,7 @@ from faker.providers.bank.mk_MK import Provider as MkMKBankProvider
 from faker.providers.bank.nl_BE import Provider as NlBeBankProvider
 from faker.providers.bank.no_NO import Provider as NoNoBankProvider
 from faker.providers.bank.pl_PL import Provider as PlPlBankProvider
+from faker.providers.bank.pt_BR import Provider as PtBrBankProvider
 from faker.providers.bank.pt_PT import Provider as PtPtBankProvider
 from faker.providers.bank.sk_SK import Provider as SkSKBankProvider
 from faker.providers.bank.th_TH import Provider as ThThBankProvider
@@ -432,6 +433,21 @@ class TestPlPl:
             assert is_valid_iban(iban)
             assert iban[:2] == PlPlBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{24}", iban[2:])
+
+
+class TestPtBr:
+    """Test pt_BR bank provider"""
+
+    def test_bban(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert re.fullmatch(r"\d{23}[A-Z]{2}", faker.bban())
+
+    def test_iban(self, faker, num_samples):
+        for _ in range(num_samples):
+            iban = faker.iban()
+            assert is_valid_iban(iban)
+            assert iban[:2] == PtBrBankProvider.country_code
+            assert re.fullmatch(r"\d{2}\d{23}[A-Z]{2}", iban[2:])
 
 
 class TestPtPt:


### PR DESCRIPTION
### Summary

The `pt_BR` bank provider defines a `bban_format` of 25 digits + 2 letters, which makes `iban()` produce **31-character** IBANs. Brazil's official IBAN length is **29** — a 25-character BBAN (23 digits + 1 letter account-type + 1 alphanumeric) per the ISO 13616 registry. Every value returned by `Faker("pt_BR").iban()` therefore fails IBAN validation. The provider's own inline comment already documents the intended "23 digits + 2" layout, so this is an off-by-two typo.

```python
>>> from faker import Faker
>>> Faker("pt_BR").iban()
'BR84...XF'   # before: 31 chars, invalid
```

### Fix

- `pt_BR` `bban_format`: `25 → 23` digits (keeping the trailing 2 alphanumeric positions).
- Added a `TestPtBr` test class (the locale previously had no bank tests) asserting BBAN format, IBAN validity, country code, and the correct 29-character length.

### Verification

- **Before:** generated IBANs were 31 chars → 100% fail `python-stdnum`'s `stdnum.iban.validate()`.
- **After:** 200/200 generated IBANs are 29 chars and pass validation.
- Full bank test suite: **86 passed**. `black` / `isort` / `flake8` clean (line-length 120).

### Note

This contribution was written with AI assistance, which I use in my development workflow; I reviewed and verified the change (including the validation above) before submitting.
