### PR TITLE
fix(en_IE): generate structurally valid Irish IBANs

### DIFF
--- a/faker/providers/bank/en_IE/__init__.py
+++ b/faker/providers/bank/en_IE/__init__.py
@@ -4,5 +4,5 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``en_IE`` locale."""
 
-    bban_format = "#######################"
+    bban_format = "????##############"
     country_code = "IE"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -174,14 +174,14 @@ class TestEnIe:
 
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):
-            assert re.fullmatch(r"\d{23}", faker.bban())
+            assert re.fullmatch(r"[A-Z]{4}\d{14}", faker.bban())
 
     def test_iban(self, faker, num_samples):
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
             assert iban[:2] == EnIeBankProvider.country_code
-            assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
+            assert re.fullmatch(r"\d{2}[A-Z]{4}\d{14}", iban[2:])
 
 
 class TestEnIn:


### PR DESCRIPTION
### Summary

The `en_IE` bank provider defines a 23-digit `bban_format`, so `iban()` produces **27-character, all-numeric** IBANs. Ireland's IBAN is **22 characters** with an 18-character BBAN structured as **4 letters** (bank identifier) + **14 digits** (6-digit sort code + 8-digit account number), per the ISO 13616 registry. Every value returned by `Faker("en_IE").iban()` fails both length and structure validation.

```python
>>> from faker import Faker
>>> Faker("en_IE").iban()
'IE58...'   # before: 27 chars, all digits, invalid
```

### Fix

- `en_IE` `bban_format`: `"#######################"` (23 digits) → `"????##############"` (4 letters + 14 digits), matching the real IE BBAN layout (same shape as `en_GB`).
- Updated the existing `TestEnIe` assertions, which encoded the invalid 23-digit format, to expect the correct `[A-Z]{4}\d{14}` BBAN.

### Verification

- **Before:** generated IBANs were 27 chars / all digits → 100% fail `python-stdnum`'s `stdnum.iban.validate()`.
- **After:** 200/200 generated IBANs are 22 chars and pass validation.
- Full bank test suite: **84 passed**. `black` / `isort` / `flake8` clean (line-length 120).

### Note

This contribution was written with AI assistance, which I use in my development workflow; I reviewed and verified the change (including the validation above) before submitting.
