### PR TITLE
fix(da_DK): correct BBAN length so iban() generates valid Danish IBANs

### DIFF
--- a/faker/providers/bank/da_DK/__init__.py
+++ b/faker/providers/bank/da_DK/__init__.py
@@ -4,5 +4,5 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``da_DK`` locale."""
 
-    bban_format = "################"
+    bban_format = "##############"
     country_code = "DK"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -5,6 +5,7 @@ import pytest
 from faker.providers.bank import Provider as BankProvider
 from faker.providers.bank.az_AZ import Provider as AzAzBankProvider
 from faker.providers.bank.cs_CZ import Provider as CsCZBankProvider
+from faker.providers.bank.da_DK import Provider as DaDkBankProvider
 from faker.providers.bank.de_CH import Provider as DeChBankProvider
 from faker.providers.bank.el_GR import Provider as ElGrBankProvider
 from faker.providers.bank.en_GB import Provider as EnGbBankProvider
@@ -96,6 +97,21 @@ class TestCsCz:
             assert is_valid_iban(iban)
             assert iban[:2] == CsCZBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
+
+
+class TestDaDk:
+    """Test da_DK bank provider"""
+
+    def test_bban(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert re.fullmatch(r"\d{14}", faker.bban())
+
+    def test_iban(self, faker, num_samples):
+        for _ in range(num_samples):
+            iban = faker.iban()
+            assert is_valid_iban(iban)
+            assert iban[:2] == DaDkBankProvider.country_code
+            assert re.fullmatch(r"\d{2}\d{14}", iban[2:])
 
 
 class TestDeCh:


### PR DESCRIPTION
Re-opens #2406, which was closed in error (an automated cleanup pass on my account closed a batch of valid PRs and deleted their branches — this restores the work).

**Problem:** `Faker("da_DK").iban()` produced IBANs that fail checksum/length validation.

**Fix:** correct the `bban_format` so generated IBANs are structurally valid.

**Verified against `python-stdnum` (the reference validator):** 300/300 generated IBANs now pass `stdnum.iban.validate()`. Example: `DK6255575141148089`.

---
**AI disclosure:** Prepared with AI assistance (Claude / Claude Code). All output was human-reviewed and verified — generated IBANs validated against `python-stdnum` and the test suite passes.