### PR TITLE
fix(pt_BR): correct BBAN length so iban() generates valid Brazilian IBANs

### DIFF
--- a/faker/providers/bank/pt_BR/__init__.py
+++ b/faker/providers/bank/pt_BR/__init__.py
@@ -10,7 +10,7 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``pt_BR`` locale."""
 
-    bban_format: str = "#########################??"  # BRXX + 23 digits + 2 alhpanumber
+    bban_format: str = "#######################??"  # BRXX + 23 digits + 2 alphanumeric
     country_code: str = "BR"
 
     banks = (

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -20,6 +20,7 @@ from faker.providers.bank.mk_MK import Provider as MkMKBankProvider
 from faker.providers.bank.nl_BE import Provider as NlBeBankProvider
 from faker.providers.bank.no_NO import Provider as NoNoBankProvider
 from faker.providers.bank.pl_PL import Provider as PlPlBankProvider
+from faker.providers.bank.pt_BR import Provider as PtBrBankProvider
 from faker.providers.bank.pt_PT import Provider as PtPtBankProvider
 from faker.providers.bank.sk_SK import Provider as SkSKBankProvider
 from faker.providers.bank.th_TH import Provider as ThThBankProvider
@@ -432,6 +433,21 @@ class TestPlPl:
             assert is_valid_iban(iban)
             assert iban[:2] == PlPlBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{24}", iban[2:])
+
+
+class TestPtBr:
+    """Test pt_BR bank provider"""
+
+    def test_bban(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert re.fullmatch(r"\d{23}[A-Z]{2}", faker.bban())
+
+    def test_iban(self, faker, num_samples):
+        for _ in range(num_samples):
+            iban = faker.iban()
+            assert is_valid_iban(iban)
+            assert iban[:2] == PtBrBankProvider.country_code
+            assert re.fullmatch(r"\d{2}\d{23}[A-Z]{2}", iban[2:])
 
 
 class TestPtPt:


### PR DESCRIPTION
Re-opens #2407, which was closed in error (an automated cleanup pass on my account closed a batch of valid PRs and deleted their branches — this restores the work).

**Problem:** `Faker("pt_BR").iban()` produced IBANs that fail checksum/length validation.

**Fix:** correct the `bban_format` so generated IBANs are structurally valid.

**Verified against `python-stdnum` (the reference validator):** 300/300 generated IBANs now pass `stdnum.iban.validate()`. Example: `BR9887813621020815191610147AZ`.

---
**AI disclosure:** Prepared with AI assistance (Claude / Claude Code). All output was human-reviewed and verified — generated IBANs validated against `python-stdnum` and the test suite passes.