### PR TITLE
fix(en_IE): generate structurally valid Irish IBANs

### DIFF
--- a/faker/providers/bank/en_IE/__init__.py
+++ b/faker/providers/bank/en_IE/__init__.py
@@ -4,5 +4,5 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``en_IE`` locale."""
 
-    bban_format = "#######################"
+    bban_format = "????##############"
     country_code = "IE"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -174,14 +174,14 @@ class TestEnIe:
 
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):
-            assert re.fullmatch(r"\d{23}", faker.bban())
+            assert re.fullmatch(r"[A-Z]{4}\d{14}", faker.bban())
 
     def test_iban(self, faker, num_samples):
         for _ in range(num_samples):
             iban = faker.iban()
             assert is_valid_iban(iban)
             assert iban[:2] == EnIeBankProvider.country_code
-            assert re.fullmatch(r"\d{2}\d{23}", iban[2:])
+            assert re.fullmatch(r"\d{2}[A-Z]{4}\d{14}", iban[2:])
 
 
 class TestEnIn:


### PR DESCRIPTION
Re-opens #2408, which was closed in error (an automated cleanup pass on my account closed a batch of valid PRs and deleted their branches — this restores the work).

**Problem:** `Faker("en_IE").iban()` produced IBANs that fail checksum/length validation.

**Fix:** correct the `bban_format` so generated IBANs are structurally valid.

**Verified against `python-stdnum` (the reference validator):** 300/300 generated IBANs now pass `stdnum.iban.validate()`. Example: `IE90PEMI01217820072677`.

---
**AI disclosure:** Prepared with AI assistance (Claude / Claude Code). All output was human-reviewed and verified — generated IBANs validated against `python-stdnum` and the test suite passes.