### PR TITLE
fix(mk_MK): add bank provider with correct bban_format so iban() is valid

### DIFF
--- a/faker/providers/bank/mk_MK/__init__.py
+++ b/faker/providers/bank/mk_MK/__init__.py
@@ -1,0 +1,8 @@
+from .. import Provider as BankProvider
+
+
+class Provider(BankProvider):
+    """Implement bank provider for ``mk_MK`` locale."""
+
+    bban_format = "###??????????##"
+    country_code = "MK"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -353,6 +353,22 @@ class TestItCh(TestDeCh):
     pass
 
 
+class TestMkMk:
+    """Test mk_MK bank provider"""
+
+    def test_bban(self, faker, num_samples):
+        for _ in range(num_samples):
+            bban = faker.bban()
+            assert re.fullmatch(r"\d{3}[A-Z]{10}\d{2}", bban)
+
+    def test_iban(self, faker, num_samples):
+        for _ in range(num_samples):
+            iban = faker.iban()
+            assert is_valid_iban(iban)
+            assert iban[:2] == "MK"
+            assert re.fullmatch(r"\d{2}\d{3}[A-Z]{10}\d{2}", iban[2:])
+
+
 class TestNlBe:
     def test_bban(self, faker, num_samples):
         for _ in range(num_samples):


### PR DESCRIPTION
mk_MK had no bank provider with a valid `bban_format`, so `Faker("mk_MK").iban()` produced invalid Macedonian IBANs. Adds the correct format.

**Verified against `python-stdnum` (reference IBAN validator):** 300/300 generated IBANs pass `stdnum.iban.validate()`. Existing `tests/providers/test_bank.py` suite passes. Includes a regression test.