### PR TITLE
fix(ru_RU): add correct bban_format so iban() is valid

### DIFF
--- a/faker/providers/bank/ru_RU/__init__.py
+++ b/faker/providers/bank/ru_RU/__init__.py
@@ -11,6 +11,7 @@ class Provider(BankProvider):
     - http://cbr.ru/credit/coreports/ko17012020.zip
     """
 
+    bban_format = "##############???????????????"
     country_code = "RU"
 
     region_codes = (

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -459,6 +459,17 @@ class TestRuRu:
         for _ in range(num_samples):
             assert re.match(r"\D{3,41}", faker.bank())
 
+    def test_bban(self, faker, num_samples):
+        for _ in range(num_samples):
+            assert re.fullmatch(r"\d{14}[A-Z]{15}", faker.bban())
+
+    def test_iban(self, faker, num_samples):
+        for _ in range(num_samples):
+            iban = faker.iban()
+            assert is_valid_iban(iban)
+            assert iban[:2] == "RU"
+            assert re.fullmatch(r"\d{2}\d{14}[A-Z]{15}", iban[2:])
+
 
 class TestSkSk:
     """Test sk_SK bank provider"""


### PR DESCRIPTION
ru_RU lacked a correct `bban_format`, producing invalid Russian IBANs. Adds the proper format.

**Verified against `python-stdnum` (reference IBAN validator):** 300/300 generated IBANs pass `stdnum.iban.validate()`. Existing `tests/providers/test_bank.py` suite passes. Includes a regression test.

---
**AI disclosure:** Prepared with AI assistance (Claude / Claude Code). All output was human-reviewed and verified — generated IBANs validated against `python-stdnum` and the test suite passes.