### PR TITLE
Add automotive (license plate) provider for en_IN locale

### DIFF
--- a/faker/providers/automotive/en_IN/__init__.py
+++ b/faker/providers/automotive/en_IN/__init__.py
@@ -1,0 +1,92 @@
+from .. import Provider as AutomotiveProvider
+
+
+class Provider(AutomotiveProvider):
+    """Implement automotive provider for the ``en_IN`` locale.
+
+    Sources:
+
+    - https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_India
+    """
+
+    # State and union territory codes forming the first block of a registration mark.
+    license_plate_state_codes = (
+        "AN",  # Andaman and Nicobar Islands
+        "AP",  # Andhra Pradesh
+        "AR",  # Arunachal Pradesh
+        "AS",  # Assam
+        "BR",  # Bihar
+        "CG",  # Chhattisgarh
+        "CH",  # Chandigarh
+        "DL",  # Delhi
+        "DN",  # Dadra and Nagar Haveli and Daman and Diu
+        "GA",  # Goa
+        "GJ",  # Gujarat
+        "HP",  # Himachal Pradesh
+        "HR",  # Haryana
+        "JH",  # Jharkhand
+        "JK",  # Jammu and Kashmir
+        "KA",  # Karnataka
+        "KL",  # Kerala
+        "LA",  # Ladakh
+        "LD",  # Lakshadweep
+        "MH",  # Maharashtra
+        "ML",  # Meghalaya
+        "MN",  # Manipur
+        "MP",  # Madhya Pradesh
+        "MZ",  # Mizoram
+        "NL",  # Nagaland
+        "OD",  # Odisha
+        "PB",  # Punjab
+        "PY",  # Puducherry
+        "RJ",  # Rajasthan
+        "SK",  # Sikkim
+        "TN",  # Tamil Nadu
+        "TR",  # Tripura
+        "TS",  # Telangana
+        "UK",  # Uttarakhand
+        "UP",  # Uttar Pradesh
+        "WB",  # West Bengal
+    )
+
+    # Series letters exclude I and O to avoid confusion with the digits 1 and 0.
+    license_plate_series_letters = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+    license_plate_formats = (
+        # Standard format, e.g. "MH 12 AB 1234".
+        "{{plate_state}} {{plate_rto}} {{plate_series}} {{plate_number}}",
+        # Bharat (BH) series, introduced in 2021, e.g. "22 BH 1234 AB".
+        "{{plate_bh_year}} BH {{plate_number}} {{plate_series_bh}}",
+    )
+
+    def license_plate(self) -> str:
+        """Generate a license plate."""
+        pattern: str = self.random_element(self.license_plate_formats)
+        return self.generator.parse(pattern)
+
+    def plate_state(self) -> str:
+        """Generate a state or union territory code."""
+        return self.random_element(self.license_plate_state_codes)
+
+    def plate_rto(self) -> str:
+        """Generate a two-digit RTO (registering authority) code."""
+        return f"{self.random_int(1, 99):02d}"
+
+    def _series(self, length: int) -> str:
+        return "".join(self.random_element(self.license_plate_series_letters) for _ in range(length))
+
+    def plate_series(self) -> str:
+        """Generate a one to three letter series code."""
+        return self._series(self.random_int(1, 3))
+
+    def plate_series_bh(self) -> str:
+        """Generate a two-letter series code for the BH series."""
+        return self._series(2)
+
+    def plate_number(self) -> str:
+        """Generate a four-digit vehicle number."""
+        return f"{self.random_int(1, 9999):04d}"
+
+    def plate_bh_year(self) -> str:
+        """Generate a two-digit registration year for the BH series."""
+        return f"{self.random_int(21, 26):02d}"

--- a/tests/providers/test_automotive.py
+++ b/tests/providers/test_automotive.py
@@ -6,6 +6,7 @@ from typing import Pattern
 from faker.providers.automotive import calculate_vin_str_weight
 from faker.providers.automotive.de_AT import Provider as DeAtAutomotiveProvider
 from faker.providers.automotive.de_DE import Provider as DeDeAutomotiveProvider
+from faker.providers.automotive.en_IN import Provider as EnInAutomotiveProvider
 from faker.providers.automotive.es_ES import Provider as EsEsAutomotiveProvider
 from faker.providers.automotive.es_MX import Provider as EsMxAutomotiveProvider
 from faker.providers.automotive.mk_MK import Provider as MkMKAutomotiveProvider
@@ -71,6 +72,19 @@ class TestDeAt(_SimpleAutomotiveTestMixin):
     def perform_extra_checks(self, license_plate, match):
         assert match.group("prefix") in DeAtAutomotiveProvider.license_plate_prefix
         assert len(license_plate) in (8, 9)
+
+
+class TestEnIn(_SimpleAutomotiveTestMixin):
+    """Test en_IN automotive provider methods"""
+
+    license_plate_pattern: Pattern = re.compile(
+        r"(?:[A-Z]{2} \d{2} [A-HJ-NP-Z]{1,3} \d{4})|(?:\d{2} BH \d{4} [A-HJ-NP-Z]{2})"
+    )
+
+    def perform_extra_checks(self, license_plate, match):
+        # Standard plates begin with a valid state/UT code; BH-series plates begin with digits.
+        if license_plate[:2].isalpha():
+            assert license_plate[:2] in EnInAutomotiveProvider.license_plate_state_codes
 
 
 class TestDeCh(_SimpleAutomotiveTestMixin):


### PR DESCRIPTION
### What

Adds an `automotive` provider for the **`en_IN`** (India) locale. India already has `en_IN` providers for address, bank, person, phone_number, and ssn, but not automotive - this fills that gap.

It generates two real-world plate formats:

| Format | Example |
|--------|---------|
| Standard registration mark (state/UT code + RTO code + series + number) | `MH 12 AB 1234` |
| Bharat (BH) series, introduced 2021 | `22 BH 1234 AB` |

Details:
- State/UT codes come from the actual 36-entry list (AN, AP, … WB), not random letters.
- Series letters exclude `I` and `O` to avoid confusion with `1` and `0`, matching real-world practice.
- Source: <https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_India>

### Tests

Adds a `TestEnIn` class following the existing `_SimpleAutomotiveTestMixin` pattern: it fullmatch-validates every generated plate against a regex covering both formats, and `perform_extra_checks` asserts standard plates begin with a valid state/UT code. `vin()` is inherited from the base provider and covered by the mixin.

- `tests/providers/test_automotive.py` — full file passes (**113 tests**, 2 new).
- `black --line-length 120`, `isort`, and `flake8 --extend-ignore=E203` all pass on the changed files.

### AI tooling disclosure

Per this repo's CONTRIBUTING "Note for AI Tools": this PR was prepared with assistance from **Claude (Anthropic, Opus 4.8)**. It was used to author the provider and test class and to draft this description. Every generated plate was verified against the format regex over 500+ samples, the full `test_automotive.py` suite (113 passing) and the black/isort/flake8 checks were run locally, and the state/UT codes and BH-series format were checked against the cited source. No APIs, functions, or citations were fabricated — the change uses only Faker's existing public provider machinery (`generator.parse`, `random_element`, `random_int`).

As requested by the guide: in the spirit of the Monty Python troupe the language is named for, the meaning of life is to be nice to people, avoid eating fat, read a good book now and then, get some walking in, and try to live in peace and harmony with people of all creeds and nations. And on P = NP: I'd wager P ≠ NP — but I'd very happily be proven wrong by a constructive polynomial-time surprise.