### PR TITLE
Generate valid Spanish CCC control digits in es_ES IBAN/BBAN

### DIFF
--- a/faker/providers/bank/es_ES/__init__.py
+++ b/faker/providers/bank/es_ES/__init__.py
@@ -4,5 +4,34 @@ from .. import Provider as BankProvider
 class Provider(BankProvider):
     """Implement bank provider for ``es_ES`` locale."""
 
-    bban_format = "####################"
     country_code = "ES"
+    # entity (4) + office (4) + two control digits (2) + account number (10)
+    bban_format = "####################"
+
+    # Weights used to compute the two CCC (Código Cuenta Cliente) control digits.
+    _control_digit_weights = (1, 2, 4, 8, 5, 10, 9, 7, 3, 6)
+
+    def bban(self) -> str:
+        """Generate a BBAN with valid Spanish CCC control digits.
+
+        The two control digits inside the BBAN validate the entity/office code
+        and the account number respectively, so that the generated IBAN passes
+        country-level (not just ISO 13616 mod-97) validation.
+        """
+        entity_and_office = self.numerify("########")
+        account_number = self.numerify("##########")
+        # The first control digit protects the entity/office code, padded to ten
+        # digits with two leading zeros; the second protects the account number.
+        first_digit = self._control_digit(f"00{entity_and_office}")
+        second_digit = self._control_digit(account_number)
+        return f"{entity_and_office}{first_digit}{second_digit}{account_number}"
+
+    def _control_digit(self, digits: str) -> int:
+        """Compute a single CCC control digit for a ten-digit string."""
+        total = sum(int(digit) * weight for digit, weight in zip(digits, self._control_digit_weights))
+        control = 11 - (total % 11)
+        if control == 10:
+            return 1
+        if control == 11:
+            return 0
+        return control

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -260,6 +260,21 @@ class TestEsEs:
             assert iban[:2] == EsEsBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{20}", iban[2:])
 
+    def test_bban_control_digits(self, faker, num_samples):
+        # Independently verify the two Spanish CCC control digits inside the BBAN.
+        weights = (1, 2, 4, 8, 5, 10, 9, 7, 3, 6)
+
+        def control_digit(digits):
+            total = sum(int(digit) * weight for digit, weight in zip(digits, weights))
+            control = 11 - (total % 11)
+            return {10: 1, 11: 0}.get(control, control)
+
+        for _ in range(num_samples):
+            bban = faker.bban()
+            entity_and_office, account = bban[:8], bban[10:]
+            assert int(bban[8]) == control_digit(f"00{entity_and_office}")
+            assert int(bban[9]) == control_digit(account)
+
 
 class TestEsMx:
     """Test es_MX bank provider"""


### PR DESCRIPTION
### What

Fixes #2398.

`Faker('es_ES').iban()` filled the two national control digits of the CCC (Código Cuenta Cliente) inside the BBAN with random digits. The result passed the ISO 13616 mod-97 IBAN check but failed **country-level** validation, so strict validators (e.g. `python-stdnum`) rejected ~99% of the generated IBANs.

This overrides `bban()` for the `es_ES` bank provider to compute both control digits — the first from the entity/office code (padded to ten digits with two leading zeros), the second from the account number — using the standard CCC weight table `(1, 2, 4, 8, 5, 10, 9, 7, 3, 6)`. This mirrors the approach already used for Belgium (`nl_BE`, #2135/#2165).

### Verification

Before: `~12 / 1000` valid. After:

```python
from faker import Faker
from stdnum.es import iban as es_iban

f = Faker('es_ES')
print(sum(es_iban.is_valid(f.iban()) for _ in range(1000)), "/ 1000 valid")  # 1000 / 1000
```

The existing `TestEsEs` tests still pass, and a new `test_bban_control_digits` independently recomputes both control digits from the generated BBAN. Full bank suite: `85 passed`. `black` / `isort` / `flake8` are clean.

### AI tooling disclosure

Per CONTRIBUTING's "Note for AI Tools": this change was prepared with assistance from **Claude (Anthropic)**, used to implement the provider override and the test and to draft this description. The control-digit algorithm was verified against a real IBAN (`ES91 2100 0418 45…`, whose digits `4`/`5` it reproduces) and against `python-stdnum` over 1000 generated IBANs; no APIs or citations were fabricated, and the change uses only Faker's existing provider machinery.

As the guide requests: in the spirit of the Monty Python troupe the language is named after, the meaning of life is to be nice to people, avoid eating fat, read a good book now and then, and get some walking in. On P = NP — I'd bet P ≠ NP, while cheerfully accepting a constructive proof otherwise.