### PR TITLE
Docs: Add faker-observability-provider to community providers

### DIFF
--- a/docs/communityproviders.rst
+++ b/docs/communityproviders.rst
@@ -52,6 +52,10 @@ Here's a list of Providers written by the community:
 | Music         | Music genres, subgenres,  | `faker_music`_                   |
 |               | and instruments.          |                                  |
 +---------------+---------------------------+----------------------------------+
+| Observability | Fake logs, correlated     | `faker-observability-provider`_  |
+|               | OpenTelemetry-style       |                                  |
+|               | traces, and k8s metadata. |                                  |
++---------------+---------------------------+----------------------------------+
 | Posts         | Fake posts in markdown    | `mdgen`_                         |
 |               | format                    |                                  |
 +---------------+---------------------------+----------------------------------+
@@ -115,6 +119,7 @@ In order to be included, your provider must satisfy these requirements:
 .. _faker_marketdata: https://pypi.org/project/faker-marketdata/
 .. _faker_microservice: https://pypi.org/project/faker-microservice/
 .. _faker_music: https://pypi.org/project/faker_music/
+.. _faker-observability-provider: https://pypi.org/project/faker-observability-provider/
 .. _mdgen: https://pypi.org/project/mdgen/
 .. _faker_pyspark: https://pypi.org/project/faker-pyspark/
 .. _faker_vehicle: https://pypi.org/project/faker-vehicle/


### PR DESCRIPTION
### What does this change

Adds `faker-observability-provider` to the community providers list.

### Provider Details

- PyPI: https://pypi.org/project/faker-observability-provider/
- Repository: https://github.com/rodrigobnogueira/faker-observability-provider
- License: MIT (OSI-Approved)
- Tests: passing (95 tests, CI on Python 3.10–3.14)

### Features
- Correlated OpenTelemetry-style trace trees (paired CLIENT/SERVER spans, error propagation, OTLP/JSON rendering)
- Log lines in 9 formats (JSON, logfmt, Apache common/combined/error, syslog RFC 3164/5424, nginx error)
- W3C trace context ids, Kubernetes/resource metadata, per-language stacktraces
- Fully seedable via Faker's standard seeding

### Compliance
- ✅ Has tests
- ✅ Published on PyPI
- ✅ MIT License
- ✅ No duplicate functionality
- ✅ No profanity
- ✅ No telemetry