### PR TITLE
Fix typo: seperator -> separator in file provider

### DIFF
--- a/faker/providers/file/__init__.py
+++ b/faker/providers/file/__init__.py
@@ -317,11 +317,11 @@ class Provider(BaseProvider):
             raise TypeError("Specified file system is invalid.")
 
         root = fs_rule["root"]
-        seperator = fs_rule["separator"]
+        separator = fs_rule["separator"]
 
         path: str = self.file_name(category, extension)
         for _ in range(0, depth):
-            path = f"{self.generator.word()}{seperator}{path}"
+            path = f"{self.generator.word()}{separator}{path}"
 
         return root + path if absolute else path
 


### PR DESCRIPTION
Fix a typo in `faker/providers/file/__init__.py`: the local variable `seperator` was misspelled and should be `separator`.

The variable is used in the `file_path` method to build filesystem paths. The misspelling was cosmetic (it still worked because the value came from `fs_rule["separator"]`), but it's cleaner to use the correct spelling.