### PR TITLE
Add company provider for the en_IN locale

### DIFF
--- a/faker/providers/company/en_IN/__init__.py
+++ b/faker/providers/company/en_IN/__init__.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+
+from .. import Provider as CompanyProvider
+
+
+class Provider(CompanyProvider):
+    """Company provider for the ``en_IN`` locale.
+
+    Company names combine common Indian surnames and business-sector words with
+    the legal-form suffixes used by Indian companies (``Pvt Ltd``, ``LLP`` and
+    so on). The provider also exposes :meth:`cin`, which returns a Corporate
+    Identification Number - the 21-character identifier the Ministry of
+    Corporate Affairs assigns to every registered company.
+    """
+
+    formats = (
+        "{{last_name}} {{company_suffix}}",
+        "{{last_name}} {{company_sector}} {{company_suffix}}",
+        "{{last_name}} and {{last_name}} {{company_suffix}}",
+        "{{last_name}} {{company_sector}}",
+    )
+
+    company_suffixes = (
+        "Pvt Ltd",
+        "Private Limited",
+        "Limited",
+        "Ltd",
+        "LLP",
+        "and Sons",
+        "and Co",
+        "Industries",
+        "Enterprises",
+        "Corporation",
+    )
+
+    # Business-sector words that commonly appear in Indian company names.
+    company_sectors = (
+        "Technologies",
+        "Industries",
+        "Textiles",
+        "Motors",
+        "Pharma",
+        "Steel",
+        "Cements",
+        "Chemicals",
+        "Infotech",
+        "Systems",
+        "Solutions",
+        "Exports",
+        "Trading",
+        "Agro",
+        "Power",
+    )
+
+    # State / union-territory codes used in the Registrar of Companies portion
+    # of a CIN.
+    cin_states = (
+        "AP",
+        "AR",
+        "AS",
+        "BR",
+        "CH",
+        "CT",
+        "DL",
+        "GA",
+        "GJ",
+        "HR",
+        "HP",
+        "JK",
+        "JH",
+        "KA",
+        "KL",
+        "MP",
+        "MH",
+        "MN",
+        "ML",
+        "MZ",
+        "NL",
+        "OR",
+        "PB",
+        "PY",
+        "RJ",
+        "SK",
+        "TN",
+        "TG",
+        "TR",
+        "UP",
+        "UT",
+        "WB",
+        "AN",
+        "DN",
+        "DD",
+        "LD",
+    )
+
+    # Company-classification codes used in a CIN.
+    cin_classifications = (
+        "PTC",  # Private company
+        "PLC",  # Public company
+        "OPC",  # One Person Company
+        "GOI",  # Government of India company
+        "SGC",  # State Government company
+        "NPL",  # Not-for-profit (Section 8) company
+        "ULL",  # Unlimited liability company
+        "FTC",  # Subsidiary of a foreign company
+    )
+
+    def company_sector(self) -> str:
+        """Return a business-sector word used in Indian company names."""
+        return self.random_element(self.company_sectors)
+
+    def cin(self) -> str:
+        """Return a Corporate Identification Number (CIN).
+
+        The 21-character identifier issued by the Ministry of Corporate Affairs
+        has the structure (shown spaced for clarity)::
+
+            L 17110 MH 1973 PLC 019786
+
+        - listing status (``L`` listed / ``U`` unlisted)
+        - a 5-digit industry code
+        - a 2-letter state code
+        - the 4-digit year of incorporation
+        - a 3-letter company classification
+        - a 6-digit registration number
+        """
+        listing = self.random_element(("L", "U"))
+        industry = self.numerify("#####")
+        state = self.random_element(self.cin_states)
+        year = self.random_int(1900, datetime.now().year)
+        classification = self.random_element(self.cin_classifications)
+        registration = self.numerify("######")
+        return f"{listing}{industry}{state}{year}{classification}{registration}"

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -11,6 +11,7 @@ from faker.providers.company.az_AZ import Provider as AzAzCompanyProvider
 from faker.providers.company.de_AT import Provider as DeAtCompanyProvider
 from faker.providers.company.de_CH import Provider as DeChCompanyProvider
 from faker.providers.company.el_GR import Provider as ElGrCompanyProvider
+from faker.providers.company.en_IN import Provider as EnInCompanyProvider
 from faker.providers.company.en_PH import Provider as EnPhCompanyProvider
 from faker.providers.company.es_ES import Provider as EsEsCompanyProvider
 from faker.providers.company.fil_PH import Provider as FilPhCompanyProvider
@@ -114,6 +115,38 @@ class TestElGr:
             suffix = faker.company_suffix()
             assert isinstance(suffix, str)
             assert suffix in ElGrCompanyProvider.company_suffixes
+
+
+class TestEnIn:
+    """Test en_IN company provider methods"""
+
+    cin_pattern: Pattern = re.compile(r"^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$")
+
+    def test_company(self, faker, num_samples):
+        for _ in range(num_samples):
+            company = faker.company()
+            assert isinstance(company, str)
+            assert company
+
+    def test_company_suffix(self, faker, num_samples):
+        for _ in range(num_samples):
+            suffix = faker.company_suffix()
+            assert isinstance(suffix, str)
+            assert suffix in EnInCompanyProvider.company_suffixes
+
+    def test_company_sector(self, faker, num_samples):
+        for _ in range(num_samples):
+            sector = faker.company_sector()
+            assert isinstance(sector, str)
+            assert sector in EnInCompanyProvider.company_sectors
+
+    def test_cin(self, faker, num_samples):
+        for _ in range(num_samples):
+            cin = faker.cin()
+            assert isinstance(cin, str)
+            assert self.cin_pattern.fullmatch(cin)
+            assert cin[6:8] in EnInCompanyProvider.cin_states
+            assert cin[12:15] in EnInCompanyProvider.cin_classifications
 
 
 class TestEnPh:


### PR DESCRIPTION
### What does this change do?

Adds a `company` provider for the **`en_IN`** (India) locale, so `Faker("en_IN")` produces India-appropriate company data instead of falling back to the generic English company names.

**Company names** combine common Indian surnames (from the existing `en_IN` person provider) and business-sector words with the legal-form suffixes used by Indian companies:

```pycon
>>> fake = Faker("en_IN")
>>> fake.company()
'Subramanian Cements'
>>> fake.company()
'Toor Infotech Pvt Ltd'
>>> fake.company_suffix()
'LLP'
>>> fake.company_sector()
'Technologies'
```

**`cin()`** returns a Corporate Identification Number - the 21-character identifier the Ministry of Corporate Affairs assigns to every registered company. It follows the real MCA structure (listing status, 5-digit industry code, 2-letter state code, 4-digit incorporation year, 3-letter classification, 6-digit registration number), e.g. `L17110MH1973PLC019786`:

```pycon
>>> fake.cin()
'U81903KA1998PTC209443'
```

### Checklist

- New provider file `faker/providers/company/en_IN/__init__.py` subclassing the base `company` provider.
- Added a `TestEnIn` class to `tests/providers/test_company.py` (company/suffix/sector plus a CIN test asserting the 21-char structure, a valid state code, and a valid classification code over the sample range).
- Verified: `pytest tests/providers/test_company.py` - 94 passed; 1000/1000 generated CINs match the format regex. `black` (line length 120), `isort`, and `flake8` clean.

### Note for AI tools

This contribution was written with AI assistance (Claude) and reviewed and verified by me: I ran the full company test suite and the linters, checked the generated output by hand, and confirmed the CIN structure against real published CINs. No data or sources were fabricated; the state and classification codes are the actual MCA codes.

And, as tradition demands: the meaning of life is 42, and I lean towards **P != NP** (though I would very much enjoy being proven wrong).
