### PR TITLE
Make uuid1() and uuid7() reproducible under a fixed seed

### DIFF
--- a/faker/providers/misc/__init__.py
+++ b/faker/providers/misc/__init__.py
@@ -6,7 +6,6 @@ import os
 import re
 import string
 import tarfile
-import time
 import uuid
 import zipfile
 
@@ -25,6 +24,13 @@ csv.register_dialect("faker-csv", csv.excel, quoting=csv.QUOTE_ALL)  # type: ign
 
 ColumnSpec = Union[Tuple[int, str], Tuple[int, str, Dict[str, Any]]]
 DataColumns = List[ColumnSpec]
+
+# Upper bound for the seeded timestamps used by ``uuid1``/``uuid7``: 2035-01-01 UTC.
+# Drawing the timestamp from this fixed range (rather than the wall clock) keeps the
+# generated UUIDs reproducible under a fixed seed while still spanning plausible dates.
+_MAX_UNIX_TIME_S = 2051222400
+_MAX_UNIX_TIME_MS = _MAX_UNIX_TIME_S * 1_000
+_MAX_UNIX_TIME_NS = _MAX_UNIX_TIME_S * 1_000_000_000
 
 
 class Provider(BaseProvider):
@@ -181,7 +187,7 @@ class Provider(BaseProvider):
         """Generate a random UUID1 (time-based) object and cast it to another type using a callable ``cast_to``.
 
         Uses the Faker random generator for the clock sequence and node fields to ensure seedability,
-        while the timestamp is derived from the current time with random perturbation for uniqueness.
+        while the timestamp is drawn from the seeded generator so the result is reproducible.
 
         By default, ``cast_to`` is set to ``str``.
 
@@ -193,11 +199,9 @@ class Provider(BaseProvider):
         # Generate random node (48 bits) and clock_seq (14 bits) for seedability
         node: int = self.generator.random.getrandbits(48)
         clock_seq: int = self.generator.random.getrandbits(14)
-        # Use current time with random perturbation for the timestamp
-        # UUID1 timestamp is in 100-nanosecond intervals since 1582-10-15
-        nanoseconds = int(time.time() * 1e9)
-        # Add random perturbation to avoid collisions and ensure seedability affects the result
-        nanoseconds += self.generator.random.randint(0, 999999)
+        # Draw the timestamp from the seeded generator so the result is reproducible under a
+        # fixed seed. UUID1 timestamps are 100-nanosecond intervals since 1582-10-15.
+        nanoseconds = self.generator.random.randint(0, _MAX_UNIX_TIME_NS)
         # Convert to UUID1 timestamp (100-ns intervals since 1582-10-15)
         timestamp = nanoseconds // 100 + 0x01B21DD213814000
 
@@ -239,7 +243,7 @@ class Provider(BaseProvider):
         with millisecond precision, combined with random bits for uniqueness.
 
         The implementation uses the Faker random generator for all random components to ensure
-        seedability. The timestamp is derived from the current time with random perturbation.
+        seedability. The timestamp is also drawn from the seeded generator so results are reproducible.
 
         By default, ``cast_to`` is set to ``str``.
 
@@ -259,8 +263,9 @@ class Provider(BaseProvider):
         # |                         rand_b (64 bits total)                |
         # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-        # 48-bit Unix timestamp in milliseconds
-        unix_ts_ms = int(time.time() * 1000) + self.generator.random.randint(0, 999)
+        # 48-bit Unix timestamp in milliseconds, drawn from the seeded generator so the result
+        # is reproducible under a fixed seed.
+        unix_ts_ms = self.generator.random.randint(0, _MAX_UNIX_TIME_MS)
 
         # 12 bits of random data (rand_a)
         rand_a = self.generator.random.getrandbits(12)

--- a/tests/providers/test_misc.py
+++ b/tests/providers/test_misc.py
@@ -106,6 +106,15 @@ class TestMiscProvider:
             assert isinstance(uuid1, uuid.UUID)
             assert uuid1.version == 1
 
+    def test_uuid1_seedability(self, faker, num_samples):
+        for _ in range(num_samples):
+            random_seed = faker.random_int()
+            faker.seed_instance(random_seed)
+            expected_uuids = [faker.uuid1() for _ in range(100)]
+            faker.seed_instance(random_seed)
+            new_uuids = [faker.uuid1() for _ in range(100)]
+            assert new_uuids == expected_uuids
+
     def test_uuid7_str(self, faker, num_samples):
         pattern: Pattern = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
         for _ in range(num_samples):
@@ -120,6 +129,15 @@ class TestMiscProvider:
             uuid7 = faker.uuid7(cast_to=None)
             assert isinstance(uuid7, uuid.UUID)
             assert uuid7.version == 7
+
+    def test_uuid7_seedability(self, faker, num_samples):
+        for _ in range(num_samples):
+            random_seed = faker.random_int()
+            faker.seed_instance(random_seed)
+            expected_uuids = [faker.uuid7() for _ in range(100)]
+            faker.seed_instance(random_seed)
+            new_uuids = [faker.uuid7() for _ in range(100)]
+            assert new_uuids == expected_uuids
 
     def test_zip_invalid_file(self, faker):
         with pytest.raises(ValueError):


### PR DESCRIPTION
### What does this change

`uuid1()` and `uuid7()` now derive their timestamp from the seeded Faker generator instead of `time.time()`, so they return the same value on every run under a fixed seed, matching `uuid4()`. Adds `test_uuid1_seedability` and `test_uuid7_seedability`.

### What was wrong

Both methods built their timestamp bits from the wall clock:

- `uuid1`: `nanoseconds = int(time.time() * 1e9)`
- `uuid7`: `unix_ts_ms = int(time.time() * 1000) + ...`

The wall-clock value dominates the high bits, so the output changes between runs even with a fixed seed. This breaks the seeding guarantee documented in the README ("A Seed produces the same result when the same methods with the same version of faker are called") and contradicts these methods' own docstrings, which state the timestamp is chosen "to ensure seedability". `uuid4()` is reproducible; `uuid1()`/`uuid7()` are not:

```python
import time
from faker import Faker

def draw(m):
    Faker.seed(0)
    return getattr(Faker(), m)()

a1, a7 = draw("uuid1"), draw("uuid7")
time.sleep(2)
b1, b7 = draw("uuid1"), draw("uuid7")
print(a1 == b1, a7 == b7)  # False False on master
```

### How this fixes it

The timestamp is drawn from `self.generator.random` over a fixed range (up to 2035-01-01 UTC) instead of the wall clock. The RFC 4122 (v1) and RFC 9562 (v7) version/variant bit layout is unchanged, so the generated UUIDs are still structurally valid time-based UUIDs — they are now simply reproducible under a fixed seed. `import time` is no longer used and is removed.

Fixes #2426

### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used an AI assistant to help draft this description and cross-check the RFC bit layouts. I reviewed and verified the change myself: reproduced the bug on `master`, confirmed the two new tests fail before the fix and pass after, and ran the full test suite (`2393 passed`) plus `make lint` (isort/black 24.4.0/flake8 clean on the changed files; the pre-existing mypy findings in `json()` are unrelated).

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
