### PR TITLE
Validate positive=True against a non-positive max_value in pydecimal

### DIFF
--- a/faker/providers/python/__init__.py
+++ b/faker/providers/python/__init__.py
@@ -316,6 +316,8 @@ class Provider(BaseProvider):
             raise ValueError("Min and max value cannot be the same")
         if positive and min_value is not None and min_value <= 0:
             raise ValueError("Cannot combine positive=True with negative or zero min_value")
+        if positive and max_value is not None and max_value <= 0:
+            raise ValueError("Cannot combine positive=True with negative or zero max_value")
         if (
             left_digits is not None
             and max_value

--- a/tests/providers/test_python.py
+++ b/tests/providers/test_python.py
@@ -288,6 +288,19 @@ class TestPydecimal(unittest.TestCase):
         message = str(raises.exception)
         self.assertEqual(message, expected_message)
 
+    def test_positive_and_max_value_incompatible(self):
+        """
+        An exception should be raised if positive=True is set together with a
+        negative or zero max_value, instead of silently returning a negative
+        value.
+        """
+
+        expected_message = "Cannot combine positive=True with negative or zero max_value"
+        for max_value in (-3, 0):
+            with self.assertRaises(ValueError) as raises:
+                self.fake.pydecimal(max_value=max_value, positive=True)
+            self.assertEqual(str(raises.exception), expected_message)
+
     def test_positive_doesnt_return_zero(self):
         """
         Choose the right_digits and max_value so it's guaranteed to return zero,


### PR DESCRIPTION
### What does this change

Adds a validation guard so that `pydecimal(positive=True, ...)` rejects a non-positive `max_value`, instead of silently returning negative values.

### What was wrong

`pydecimal` already rejected `positive=True` combined with a negative or zero `min_value`, but it had no equivalent guard for `max_value`. In the sign logic, the negative sign is selected whenever `max_value <= 0`, and that branch runs before `positive` is taken into account. As a result, `positive=True` was silently ignored:

```python
>>> from faker import Faker
>>> f = Faker()
>>> f.pydecimal(positive=True, max_value=-3)
Decimal('-85374957039153.3649')   # a negative value, despite positive=True
```

### How this fixes it

It adds the symmetric guard directly after the existing `min_value` check: when `positive` is set together with a `max_value` that is not positive, it raises `ValueError("Cannot combine positive=True with negative or zero max_value")`. Valid cases are not affected, for example `pydecimal(positive=True, max_value=5)` and `pydecimal(positive=True)` still return positive values. A regression test is added.

Fixes # (no linked issue; small self-contained bug fix)

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Claude was used to understand the code structure and review the documentations.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`


