### PR TITLE
fix(ro_RO): generate valid CNP birth dates in ssn()

### DIFF
--- a/faker/providers/ssn/ro_RO/__init__.py
+++ b/faker/providers/ssn/ro_RO/__init__.py
@@ -1,3 +1,5 @@
+import calendar
+
 from .. import Provider as BaseProvider
 
 
@@ -71,7 +73,9 @@ class Provider(BaseProvider):
         gender = self.random_int(min=1, max=8)
         year = self.random_int(min=0, max=99)
         month = self.random_int(min=1, max=12)
-        day = self.random_int(min=1, max=31)
+        # Clamp the day to a real date; the century (for leap years) follows the gender digit per the CNP spec.
+        century = {1: 1900, 2: 1900, 3: 1800, 4: 1800, 5: 2000, 6: 2000}.get(gender, 1900)
+        day = self.random_int(min=1, max=calendar.monthrange(century + year, month)[1])
         county = int(
             self.random_element(
                 [

--- a/tests/providers/test_ssn.py
+++ b/tests/providers/test_ssn.py
@@ -1244,6 +1244,17 @@ class TestRoRO(unittest.TestCase):
         for _ in range(100):
             assert re.search(r"^\d{13}$", self.fake.ssn())
 
+    def test_ssn_birth_date_is_valid(self):
+        # The CNP encodes a birth date as S YY MM DD; those digits must form a
+        # real calendar date. The century (needed for leap years) follows the
+        # gender digit S.
+        centuries = {1: 1900, 2: 1900, 3: 1800, 4: 1800, 5: 2000, 6: 2000}
+        for _ in range(1000):
+            ssn = self.fake.ssn()
+            gender, year, month, day = int(ssn[0]), int(ssn[1:3]), int(ssn[3:5]), int(ssn[5:7])
+            # datetime raises ValueError on an impossible date (e.g. 09-31, 02-30).
+            datetime(centuries.get(gender, 1900) + year, month, day)
+
     def test_vat_checksum(self):
         assert ro_vat_checksum("1") == 9
         assert ro_vat_checksum("41") == 8


### PR DESCRIPTION
## Problem

`Faker("ro_RO").ssn()` builds the CNP birth-date field with `day = random_int(1, 31)` regardless of the month or leap year, so a small fraction of generated CNPs encode an impossible date (e.g. month 09 day 31, or Feb 30) and are rejected by the independent validator `python-stdnum` (`stdnum.ro.cnp`). The CNP checksum is already computed correctly — only the day is wrong.

```python
from faker import Faker
from stdnum.ro import cnp
f = Faker("ro_RO"); Faker.seed(0)
sum(cnp.is_valid(f.ssn()) for _ in range(20000))   # 19641 / 20000 before this change (359 fail, all "InvalidComponent" dates)
# example bad value: 7240931410866  ->  month=09, day=31
```

## Fix

Clamp the day to the month's length with `calendar.monthrange`, deriving the century from the gender digit — the CNP convention `1/2 → 1900s, 3/4 → 1800s, 5/6 → 2000s` — so February 29 only appears in real leap years. This matches exactly how `stdnum.ro.cnp` decodes the date segment, so validation lines up.

After the change the same loop returns `20000 / 20000`, and `50000 / 50000` across independent seeds.

## Test

Adds `TestRoRO::test_ssn_birth_date_is_valid`, which decodes the `S YY MM DD` digits and asserts they form a real calendar date via `datetime` (no new test dependency). It fails without the fix (`ValueError: day is out of range for month`) and passes with it. Full `tests/providers/test_ssn.py`: 159 passed; `black`/`isort`/`flake8` clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro against `python-stdnum` as an independent oracle, wrote the fix and the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
