### PR TITLE
Add ifsc() generator to en_IN bank provider

### DIFF
--- a/faker/providers/bank/en_IN/__init__.py
+++ b/faker/providers/bank/en_IN/__init__.py
@@ -53,5 +53,7 @@ class Provider(BankProvider):
         Example: HDFC0001234
         """
         bank_code = "".join(self.random_letters(length=4)).upper()
-        branch_code = self.bothify("######", letters="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        branch_code = self.bothify(
+            "######", letters="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        )
         return f"{bank_code}0{branch_code}"

--- a/faker/providers/bank/en_IN/__init__.py
+++ b/faker/providers/bank/en_IN/__init__.py
@@ -45,3 +45,13 @@ class Provider(BankProvider):
     def bank(self) -> str:
         """Generate a bank name."""
         return self.random_element(self.banks)
+
+    def ifsc(self) -> str:
+        """Generate a structurally valid IFSC code.
+
+        Format: 4 letters (bank code) + 0 + 6 alphanumeric characters (branch code)
+        Example: HDFC0001234
+        """
+        bank_code = "".join(self.random_letters(length=4)).upper()
+        branch_code = self.bothify("######", letters="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        return f"{bank_code}0{branch_code}"

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -208,6 +208,11 @@ class TestEnIn:
         for _ in range(num_samples):
             assert re.match(r"\D{7,25}", faker.bank())
 
+    def test_ifsc(self, faker, num_samples):
+        pattern = re.compile(r"^[A-Z]{4}0[A-Z0-9]{6}$")
+        for _ in range(num_samples):
+            assert pattern.fullmatch(faker.ifsc())
+
 
 class TestEnPh:
     """Test en_PH bank provider"""

--- a/tests/providers/test_bank.py
+++ b/tests/providers/test_bank.py
@@ -288,7 +288,9 @@ class TestEsEs:
             # the BBAN must carry valid Spanish CCC control digits
             bban = iban[4:]
             bank_branch, control, account = bban[:8], bban[8:10], bban[10:]
-            assert control == _ccc_control_digit("00" + bank_branch) + _ccc_control_digit(account)
+            assert control == _ccc_control_digit(
+                "00" + bank_branch
+            ) + _ccc_control_digit(account)
 
 
 class TestEsMx:
@@ -407,7 +409,10 @@ class TestNlBe:
             assert iban[:2] == NlBeBankProvider.country_code
             assert re.fullmatch(r"\d{2}\d{12}", iban[2:])
             rearranged_iban = iban[4:] + iban[:4]
-            numeric_iban = "".join(str(ord(char) - 55) if char.isalpha() else char for char in rearranged_iban)
+            numeric_iban = "".join(
+                str(ord(char) - 55) if char.isalpha() else char
+                for char in rearranged_iban
+            )
             assert int(numeric_iban) % 97 == 1
 
     def test_iban_stdnum(self, faker, num_samples):


### PR DESCRIPTION
### What does this change
Adds an `ifsc()` method to the en_IN bank provider that generates
structurally valid IFSC codes (Indian Financial System Code).
Format: 4 letters (bank code) + 0 + 6 alphanumeric characters (branch code).

### What was wrong
The en_IN bank provider only had `bank()` for generating bank names.
There was no way to generate IFSC codes, which are commonly needed
for Indian banking/fintech test data.

### How this fixes it
Added a new `ifsc()` method following the same pattern as existing
locale-specific identifier methods (like `pan()`/`gstin()`). Added
a corresponding test in test_bank.py that validates the output format
using a regex pattern.

Closes #2435
### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude (Anthropic) for guidance on identifying the gap, writing the method, and drafting the test. All code was reviewed and verified by me (tests pass locally).

### Checklist
- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`