### PR TITLE
docs: clarify that text() max_nb_chars is an upper bound

### DIFF
--- a/faker/providers/lorem/__init__.py
+++ b/faker/providers/lorem/__init__.py
@@ -203,11 +203,16 @@ class Provider(BaseProvider):
     def text(self, max_nb_chars: int = 200, ext_word_list: Optional[Sequence[str]] = None) -> str:
         """Generate a text string.
 
-        The ``max_nb_chars`` argument controls the approximate number of
-        characters the text string will have, and depending on its value, this
-        method may use either |words|, |sentences|, or |paragraphs| for text
-        generation. The ``ext_word_list`` argument works in exactly the same way
-        it would in any of those methods.
+        The ``max_nb_chars`` argument is an upper bound, not a target: the
+        result will never be longer than ``max_nb_chars``, but it can be
+        substantially shorter. This is because the text is built from whole
+        words, sentences, or paragraphs (depending on the value of
+        ``max_nb_chars``), and the last complete unit that would push the
+        length past the limit is dropped. For example, ``max_nb_chars=200``
+        regularly produces strings of 100-190 characters. Values below 5
+        raise a ``ValueError``. The ``ext_word_list`` argument works in
+        exactly the same way it would in |words|, |sentences|, or
+        |paragraphs|.
 
         :sample: max_nb_chars=20
         :sample: max_nb_chars=80


### PR DESCRIPTION
Closes #2389

Brief summary: documentation-only fix. The text() docstring now states
explicitly that max_nb_chars is an upper bound, not a target.

### What was wrong

While testing Faker for a university software testing course, we noticed
that text(max_nb_chars=200) regularly returns strings of 100-190
characters, and even max_nb_chars=99999 returned 99908 characters. We
reported this in #2389.

Reading the implementation, this is by design: the output is assembled
from whole words/sentences/paragraphs and the last unit that would
exceed the limit is dropped, so the result is always under max_nb_chars
but can be well under it. The docstring only said the length is
"approximate", which reads as "close to N" rather than "at most N,
possibly much less" - that is what confused us and what the issue is
really about.

### How this fixes it

The docstring now states that:
- max_nb_chars is a strict upper bound
- the output can be substantially shorter, with an example
- values below 5 raise ValueError (already true in the code, but
  previously undocumented)

No behavior changes.