### PR TITLE
test: add boundary tests for text(max_nb_chars)

### DIFF
--- a/tests/providers/test_lorem.py
+++ b/tests/providers/test_lorem.py
@@ -19,6 +19,28 @@ from faker.providers.lorem.uk_UA import Provider as UkUaLoremProvider
 from faker.providers.lorem.vi_VN import Provider as ViVNLoremProvider
 
 
+class TestTextBounds:
+    """Tests for the boundary behavior of text(max_nb_chars=N)"""
+
+    def test_text_respects_upper_bound(self, faker, num_samples):
+        for max_nb_chars in (5, 24, 25, 99, 100, 200):
+            for _ in range(num_samples):
+                text = faker.text(max_nb_chars=max_nb_chars)
+                assert isinstance(text, str)
+                assert len(text) <= max_nb_chars
+
+    def test_text_minimum_length_raises(self, faker):
+        for bad_value in (0, 1, 4):
+            with pytest.raises(ValueError):
+                faker.text(max_nb_chars=bad_value)
+
+    def test_text_ext_word_list_only(self, faker, num_samples):
+        word_list = ["abc", "def", "ghi", "jkl"]
+        for _ in range(num_samples):
+            text = faker.text(max_nb_chars=20, ext_word_list=word_list)
+            words = text.lower().replace(".", "").split()
+            assert all(word in word_list for word in words)
+
 class TestAzAz:
     """Test az_AZ lorem provider"""
 


### PR DESCRIPTION
Related to #2389

Brief summary: adds three tests to tests/providers/test_lorem.py
pinning down the boundary behavior of text(max_nb_chars).

### What was wrong

The existing lorem tests exercise text() per locale but do not test
its boundary behavior. While testing Faker for a university course we
noticed this gap when investigating #2389.

### How this fixes it

Adds a TestTextBounds class with three tests:

- test_text_respects_upper_bound - output never exceeds max_nb_chars,
  checked around the internal mode switches at 25 and 100 characters
- test_text_minimum_length_raises - values below 5 raise ValueError
  (enforced in the code but previously untested)
- test_text_ext_word_list_only - with ext_word_list, every word in the
  output comes from the given list

All three pass locally: 3 passed in 0.67s on Python 3.10.12.