### PR TITLE
add Pillow as an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,6 @@ setup(
     platforms=["any"],
     zip_safe=zip_safe,
     install_requires=['tzdata; platform_system=="Windows"'],
-    extras_require={
-        "tzdata": ["tzdata"],
-        "image": ["pillow"]
-    },
+    extras_require={"tzdata": ["tzdata"], "image": ["pillow"]},
     python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     install_requires=['tzdata; platform_system=="Windows"'],
     extras_require={
         "tzdata": ["tzdata"],
+        "image": ["pillow"]
     },
     python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ setup(
     platforms=["any"],
     zip_safe=zip_safe,
     install_requires=['tzdata; platform_system=="Windows"'],
-    extras_require={"tzdata": ["tzdata"], "image": ["pillow"]},
+    extras_require={
+        "tzdata": ["tzdata"],
+        "image": ["pillow"],
+    },
     python_requires=">=3.10",
 )


### PR DESCRIPTION
### What does this change

This change adds Pillow as an optional dependency to support image-related features. Users can install it via pip install faker[image].

### What was wrong

Currently, Faker does not officially declare Pillow as an optional dependency.

### How this fixes it

Added "image": ["pillow"] to the extras_require dictionary in setup.py

Fixes #2441

### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

### Checklist

- [x] I have read the documentation about [CONTRIBUTING](https://github.com/joke2k/faker/blob/master/CONTRIBUTING.rst)
- [x] I have read the documentation about [Coding style](https://github.com/joke2k/faker/blob/master/docs/coding_style.rst)
- [x] I have run `make lint`
