### PR TITLE
feat(finance): add stock option and option chain generators

### DIFF
--- a/faker/providers/finance/__init__.py
+++ b/faker/providers/finance/__init__.py
@@ -181,8 +181,9 @@ class Provider(BaseProvider):
         """Generate a future expiration date snapped to the weekly Friday cadence.
 
         ``quote_date`` is the as-of date the expiration is generated relative
-        to (defaults to today). Uses |date_between| under the hood, via
-        :meth:`self.generator.date_between() <faker.providers.date_time.Provider.date_between>`.
+        to (defaults to today). Uses
+        :meth:`self.generator.date_between() <faker.providers.date_time.Provider.date_between>`
+        under the hood.
         """
         if quote_date is None:
             quote_date = date.today()

--- a/faker/providers/finance/__init__.py
+++ b/faker/providers/finance/__init__.py
@@ -1,0 +1,385 @@
+import re
+
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from ...typing import DateParseType
+from .. import BaseProvider
+
+
+class Provider(BaseProvider):
+    """Implement default finance provider for Faker.
+
+    Generates fake listed call/put stock option contracts and option chains for
+    fintech application testing. Strike prices, premiums, and Greeks are
+    plausibility-shaped heuristics (moneyness- and time-to-expiry-aware), not
+    output from a real options-pricing model such as Black-Scholes.
+    """
+
+    stock_tickers: Tuple[str, ...] = (
+        "AAPL",
+        "MSFT",
+        "GOOGL",
+        "AMZN",
+        "META",
+        "TSLA",
+        "NVDA",
+        "JPM",
+        "V",
+        "MA",
+        "WMT",
+        "DIS",
+        "NFLX",
+        "INTC",
+        "AMD",
+        "BA",
+        "KO",
+        "PEP",
+        "MCD",
+        "NKE",
+        "ADBE",
+        "CSCO",
+        "ORCL",
+        "IBM",
+        "GE",
+        "F",
+        "GM",
+        "XOM",
+        "CVX",
+        "PFE",
+        "JNJ",
+        "UNH",
+        "HD",
+        "COST",
+        "PG",
+        "T",
+        "VZ",
+        "CRM",
+        "PYPL",
+        "SBUX",
+    )
+
+    # Number of calendar days a cadence value advances between expirations.
+    # Multiples of 7 so every cadence stays aligned to the same weekday once
+    # the first expiration is snapped to a Friday.
+    option_chain_cadences: Dict[str, int] = {
+        "weekly": 7,
+        "biweekly": 14,
+        "monthly": 28,
+    }
+
+    _relative_date_re = re.compile(r"^([+-]\d+)(d|w|y)$")
+
+    def option_type(self) -> str:
+        """Generate a random option type: ``CALL`` or ``PUT``."""
+        return self.random_element(("CALL", "PUT"))
+
+    def underlying_symbol(self, symbols: Optional[List[str]] = None) -> str:
+        """Generate a ticker symbol for an option's underlying stock.
+
+        If ``symbols`` is given, the ticker is picked from that list. Otherwise
+        it falls back to a built-in curated list of common stock tickers.
+        """
+        return self.random_element(symbols if symbols is not None else self.stock_tickers)
+
+    def strike_price(self, underlying_price: Optional[float] = None) -> float:
+        """Generate a strike price relative to an underlying price.
+
+        The strike is generated within roughly +/-20% of ``underlying_price``
+        (generated if not supplied) and snapped to standard exchange strike
+        increments.
+        """
+        if underlying_price is None:
+            underlying_price = self._generate_underlying_price()
+        offset = self.generator.random.uniform(-0.2, 0.2)
+        raw_strike = underlying_price * (1 + offset)
+        increment = self._strike_increment(underlying_price)
+        strike = round(raw_strike / increment) * increment
+        return max(increment, round(strike, 2))
+
+    def option_premium(
+        self,
+        strike_price: Optional[float] = None,
+        underlying_price: Optional[float] = None,
+        expiration_date: Optional[date] = None,
+        option_type: Optional[str] = None,
+    ) -> float:
+        """Generate an option premium.
+
+        Priced as intrinsic value plus a bounded random time-value component
+        that shrinks as ``expiration_date`` approaches today. Not a real
+        options-pricing model. Any omitted argument is generated internally,
+        so this can be called standalone as ``option_premium()``.
+        """
+        if underlying_price is None:
+            underlying_price = self._generate_underlying_price()
+        if strike_price is None:
+            strike_price = self.strike_price(underlying_price)
+        if expiration_date is None:
+            expiration_date = self.expiration_date()
+        if option_type is None:
+            option_type = self.option_type()
+
+        intrinsic_value = self._intrinsic_value(strike_price, underlying_price, option_type)
+        days_to_expiration = max((expiration_date - date.today()).days, 0)
+        time_value_cap = max(underlying_price * 0.05 * min(days_to_expiration, 90) / 90, 0.01)
+        time_value = self.generator.random.uniform(0, time_value_cap)
+        return round(intrinsic_value + time_value, 2)
+
+    def option_greeks(
+        self,
+        strike_price: Optional[float] = None,
+        underlying_price: Optional[float] = None,
+        expiration_date: Optional[date] = None,
+        option_type: Optional[str] = None,
+        quote_date: Optional[date] = None,
+    ) -> Dict[str, float]:
+        """Generate heuristic option Greeks: delta, gamma, theta, vega, and rho.
+
+        These are moneyness- and time-to-expiry-shaped approximations for
+        test-data purposes (delta scaled toward +/-1 deep in-the-money, toward
+        0 deep out-of-the-money; theta always negative and larger in magnitude
+        near expiration), not the output of a real Black-Scholes or binomial
+        pricing model. Any omitted argument is generated internally, so this
+        can be called standalone as ``option_greeks()``.
+        """
+        if quote_date is None:
+            quote_date = date.today()
+        if underlying_price is None:
+            underlying_price = self._generate_underlying_price()
+        if strike_price is None:
+            strike_price = self.strike_price(underlying_price)
+        if expiration_date is None:
+            expiration_date = self.expiration_date(quote_date)
+        if option_type is None:
+            option_type = self.option_type()
+
+        moneyness = (underlying_price - strike_price) / underlying_price
+        if option_type == "PUT":
+            moneyness = -moneyness
+        delta_magnitude = min(max(0.5 + moneyness * 2, 0.02), 0.98)
+        delta = delta_magnitude if option_type == "CALL" else -delta_magnitude
+
+        days_to_expiration = max((expiration_date - quote_date).days, 1)
+        time_factor = max(1 - min(days_to_expiration, 90) / 90, 0.05)
+        proximity_to_strike = max(1 - min(abs(moneyness), 1), 0.05)
+
+        gamma = self.generator.random.uniform(0.01, 0.05) * proximity_to_strike
+        theta = -self.generator.random.uniform(0.01, 0.10) * time_factor
+        vega = self.generator.random.uniform(0.02, 0.20) * proximity_to_strike
+        rho = self.generator.random.uniform(-0.05, 0.05)
+
+        return {
+            "delta": round(delta, 2),
+            "gamma": round(gamma, 2),
+            "theta": round(theta, 2),
+            "vega": round(vega, 2),
+            "rho": round(rho, 2),
+        }
+
+    def expiration_date(self, quote_date: Optional[date] = None) -> date:
+        """Generate a future expiration date snapped to the weekly Friday cadence.
+
+        ``quote_date`` is the as-of date the expiration is generated relative
+        to (defaults to today). Uses |date_between| under the hood, via
+        :meth:`self.generator.date_between() <faker.providers.date_time.Provider.date_between>`.
+        """
+        if quote_date is None:
+            quote_date = date.today()
+        horizon = self.generator.date_between(start_date=quote_date, end_date=quote_date + timedelta(days=180))
+        return self._snap_to_friday(horizon)
+
+    def stock_option(self, symbols: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Generate a fake listed call/put stock option contract.
+
+        Composes :meth:`underlying_symbol`, :meth:`option_type`,
+        :meth:`strike_price`, :meth:`expiration_date`, :meth:`option_premium`,
+        and :meth:`option_greeks`. Returns a flat ``dict`` with Greeks as
+        top-level keys (not nested under a ``"greeks"`` key).
+        """
+        quote_date = date.today()
+        underlying_symbol = self.underlying_symbol(symbols)
+        option_type = self.option_type()
+        underlying_price = self._generate_underlying_price()
+        strike_price = self.strike_price(underlying_price)
+        expiration_date = self.expiration_date(quote_date)
+
+        return self._build_quote(
+            underlying_symbol,
+            option_type,
+            strike_price,
+            underlying_price,
+            expiration_date,
+            quote_date,
+        )
+
+    def option_chain(
+        self,
+        symbol: Optional[str] = None,
+        symbols: Optional[List[str]] = None,
+        start_date: DateParseType = "today",
+        end_date: DateParseType = "+3w",
+        cadence: str = "weekly",
+    ) -> Dict[str, Dict[date, List[Dict[str, Any]]]]:
+        """Generate a fake option chain for a single underlying ticker.
+
+        Returns a nested ``dict``: ticker -> expiration date -> a list of flat
+        per-strike quotes (both a call and a put per strike), each quote in
+        the same shape as :meth:`stock_option`'s return value. Expirations are
+        generated between ``start_date`` and ``end_date`` (defaults to a
+        3-week window from today) spaced by ``cadence`` (default ``"weekly"``,
+        landing on Fridays; overridable to ``"biweekly"`` or ``"monthly"``).
+        Only a single ticker is populated per call.
+        """
+        ticker = symbol or self.underlying_symbol(symbols)
+        quote_date = date.today()
+        range_start = self._resolve_date(start_date)
+        range_end = self._resolve_date(end_date)
+        if range_end < range_start:
+            range_start, range_end = range_end, range_start
+
+        underlying_price = self._generate_underlying_price()
+        strikes = self._strike_ladder(underlying_price)
+        expirations = self._expiration_series(range_start, range_end, cadence)
+
+        by_expiration: Dict[date, List[Dict[str, Any]]] = {}
+        for expiration in expirations:
+            quotes = []
+            for strike in strikes:
+                for option_type in ("CALL", "PUT"):
+                    quotes.append(
+                        self._build_quote(
+                            ticker,
+                            option_type,
+                            strike,
+                            underlying_price,
+                            expiration,
+                            quote_date,
+                        )
+                    )
+            by_expiration[expiration] = quotes
+
+        return {ticker: by_expiration}
+
+    def _build_quote(
+        self,
+        underlying_symbol: str,
+        option_type: str,
+        strike_price: float,
+        underlying_price: float,
+        expiration_date: date,
+        quote_date: date,
+    ) -> Dict[str, Any]:
+        """Build one flat quote dict shared by :meth:`stock_option` and :meth:`option_chain`."""
+        premium = self.option_premium(strike_price, underlying_price, expiration_date, option_type)
+        greeks = self.option_greeks(strike_price, underlying_price, expiration_date, option_type, quote_date)
+        exercised, exercise_date = self._exercise_outcome(strike_price, underlying_price, expiration_date, option_type)
+
+        return {
+            "underlying_symbol": underlying_symbol,
+            "option_type": option_type,
+            "strike_price": strike_price,
+            "underlying_price": underlying_price,
+            "premium": premium,
+            "expiration_date": expiration_date,
+            "quote_date": quote_date,
+            "delta": greeks["delta"],
+            "gamma": greeks["gamma"],
+            "theta": greeks["theta"],
+            "vega": greeks["vega"],
+            "rho": greeks["rho"],
+            "exercised": exercised,
+            "exercise_date": exercise_date,
+        }
+
+    def _exercise_outcome(
+        self,
+        strike_price: float,
+        underlying_price: float,
+        expiration_date: date,
+        option_type: str,
+    ) -> Tuple[bool, Optional[date]]:
+        """Derive ``exercised``/``exercise_date`` probabilistically from moneyness at expiration.
+
+        Simulates a plausible underlying price at expiration via a bounded
+        random walk from the current underlying price, then weights the
+        exercise outcome heavily toward ``True`` when that hypothetical price
+        would leave the contract in-the-money, and toward ``False`` otherwise.
+        """
+        price_at_expiration = underlying_price * self.generator.random.uniform(0.85, 1.15)
+        in_the_money = self._intrinsic_value(strike_price, price_at_expiration, option_type) > 0
+        exercise_probability = 0.85 if in_the_money else 0.05
+        exercised = self.generator.random.random() < exercise_probability
+        exercise_date = expiration_date if exercised else None
+        return exercised, exercise_date
+
+    def _generate_underlying_price(self) -> float:
+        return round(self.generator.random.uniform(5.0, 500.0), 2)
+
+    def _intrinsic_value(self, strike_price: float, underlying_price: float, option_type: str) -> float:
+        if option_type == "CALL":
+            return max(0.0, underlying_price - strike_price)
+        return max(0.0, strike_price - underlying_price)
+
+    def _strike_increment(self, price: float) -> float:
+        if price < 25:
+            return 0.5
+        if price < 200:
+            return 1.0
+        return 5.0
+
+    def _strike_ladder(self, underlying_price: float, strikes_per_expiration: int = 5) -> List[float]:
+        increment = self._strike_increment(underlying_price)
+        half = strikes_per_expiration // 2
+        return sorted(
+            max(increment, round(underlying_price + (offset - half) * increment, 2))
+            for offset in range(strikes_per_expiration)
+        )
+
+    def _snap_to_friday(self, target_date: date) -> date:
+        days_until_friday = (4 - target_date.weekday()) % 7
+        return target_date + timedelta(days=days_until_friday)
+
+    def _expiration_series(self, start: date, end: date, cadence: str) -> List[date]:
+        if cadence not in self.option_chain_cadences:
+            raise ValueError(f"Unsupported cadence {cadence!r}; expected one of {sorted(self.option_chain_cadences)}")
+        step = timedelta(days=self.option_chain_cadences[cadence])
+        current = self._snap_to_friday(start)
+        expirations = []
+        while current <= end:
+            expirations.append(current)
+            current += step
+        return expirations
+
+    def _resolve_date(self, value: DateParseType) -> date:
+        """Resolve a small subset of |DateParseType| values to a concrete date.
+
+        Supports ``date``/``datetime`` objects, ``timedelta``, an ``int``
+        number of days from today, and the relative strings ``"today"``/
+        ``"now"`` and ``"[+-]<N><d|w|y>"`` (e.g. ``"+3w"``, ``"-30d"``). This
+        is a purposely small subset of the date-string grammar supported by
+        :meth:`faker.providers.date_time.Provider.date_between` sufficient for
+        :meth:`option_chain`'s ``start_date``/``end_date`` bounds.
+        """
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        today = date.today()
+        if isinstance(value, timedelta):
+            return today + value
+        if isinstance(value, int):
+            return today + timedelta(days=value)
+        if isinstance(value, str):
+            if value in ("today", "now"):
+                return today
+            match = self._relative_date_re.match(value)
+            if match:
+                amount, unit = match.groups()
+                amount = int(amount)
+                if unit == "d":
+                    return today + timedelta(days=amount)
+                if unit == "w":
+                    return today + timedelta(weeks=amount)
+                return today + timedelta(days=round(amount * 365.24))
+        raise ValueError(f"Unsupported date value for option_chain: {value!r}")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -82,6 +82,7 @@ class UtilsTestCase(unittest.TestCase):
                     "faker.providers.doi",
                     "faker.providers.emoji",
                     "faker.providers.file",
+                    "faker.providers.finance",
                     "faker.providers.geo",
                     "faker.providers.internet",
                     "faker.providers.isbn",


### PR DESCRIPTION
## Intent

Add synthetic stock option (call/put) generation to faker for fintech application testing, as faker.providers.finance. This follows a design scout phase where the captain reviewed two Lavish artifacts and made 10 explicit design decisions (full trail in /Users/jeremy/firstmate/data/faker-stockopt/report.md), including: new unlocalized faker/providers/finance package (auto-discovered via faker's pkgutil-based provider loading, no registration needed) rather than extending the existing currency provider; a two-tier composite design where stock_option() (single contract) and option_chain() (multiple strikes x multiple expirations) both compose the same set of smaller helper methods (option_type, underlying_symbol, strike_price, option_premium, option_greeks, expiration_date), mirroring the existing profile()/credit_card_full() composition pattern; a flat dict return shape throughout (not dataclass, not tuple, not nested) with Greeks (delta/gamma/theta/vega/rho) as top-level keys rather than nested under a 'greeks' key -- the captain corrected this twice during review (first wanted a dict keyed by strike price, then a tuple, then settled on flat dicts matching stock_option()'s own shape); option_chain() returns a nested dict[ticker][expiration_date] -> list[dict] (not a flat list) covering a strike ladder with both a CALL and a PUT per strike, defaulting to a 3-week window of weekly Friday-landing expirations, both overridable via start_date/end_date/cadence; underlying_symbol() picks from an optional caller-supplied symbols list, falling back to a built-in curated list of common stock tickers when omitted; exercised/exercise_date are derived probabilistically from simulated moneyness at expiration rather than static False/None placeholders; and multi-symbol batching in option_chain() is explicitly deferred/out of scope for this pass (single ticker per call only), as is a real options-pricing model (Black-Scholes/binomial) -- premium and Greeks are intentionally simplified moneyness- and time-to-expiry-shaped heuristics, not real pricing math, and this is documented in the code. Scope for this task is implementation only: tests/providers/test_finance.py is being written in parallel by a separate task (faker-stockopt-tests) and intentionally excluded here. While implementing I found and fixed a real bug: option_premium()/option_greeks() originally had required positional arguments with no defaults, which crashed faker's own documentation generator (faker/documentor.py calls every public provider method with zero arguments to produce example docs, and only catches AttributeError/ValueError, not TypeError) -- fixed by giving both methods the same 'every arg is Optional, generate a sensible default when omitted' pattern used throughout the rest of the codebase (e.g. date_time.Provider.date_between_dates). I also found and fixed an edge-case bug in my own option_chain() expiration-series generation: the first Friday-snapped expiration was being included unconditionally even if it fell after the caller's end_date, fixed to only include expirations within [start, end]. Separately, adding this new top-level provider broke tests/utils/test_utils.py::test_find_available_providers, which hardcodes the full alphabetical list of provider module paths; the captain explicitly authorized adding the one-line 'faker.providers.finance' entry to that list even though the ship instructions otherwise said not to touch files under tests/, since this is a mechanical, feature-agnostic consequence of adding any new top-level provider (unrelated to finance-specific test coverage) that would break identically for any other new provider.

## What Changed

- Add a new unlocalized `faker.providers.finance` provider (auto-discovered via faker's provider loading) exposing `stock_option()` and `option_chain()`, both composed from smaller helpers: `option_type()`, `underlying_symbol()`, `strike_price()`, `option_premium()`, `option_greeks()`, and `expiration_date()`.
- `stock_option()` returns a single flat quote dict (Greeks as top-level keys, not nested); `option_chain()` returns a `dict[ticker][expiration_date] -> list[dict]` covering a strike ladder with a CALL and PUT per strike, defaulting to a 3-week weekly Friday-landing window, overridable via `start_date`/`end_date`/`cadence`. `underlying_symbol()` picks from an optional caller-supplied symbol list, falling back to a built-in curated ticker list. `exercised`/`exercise_date` are derived probabilistically from simulated moneyness at expiration. Premiums and Greeks are simplified moneyness/time-to-expiry heuristics, not real options-pricing math, as documented in the module.
- Give `option_premium()` and `option_greeks()` fully optional arguments with sensible generated defaults so they can be called with zero arguments, fixing a crash in faker's documentation generator (which calls every public provider method with no args).
- Add `faker.providers.finance` to the hardcoded provider list in `tests/utils/test_utils.py::test_find_available_providers`.

## Risk Assessment

✅ Low: Single well-scoped new provider module with no external call sites yet; both claimed bug fixes (documentor zero-arg crash, off-by-window expiration inclusion) were verified empirically to work correctly, the return shapes and composition match every explicit design decision in the intent, and the one authorized test-file touch is mechanical and correctly placed.

## Testing

All targeted verification passed: the regression test for provider auto-discovery passes, the faker CLI documentor path (the reported crash site) runs clean end-to-end for the new finance provider, and manual exercise of the public API confirms every explicit design decision in the intent (flat dict shape, top-level Greeks, symbols fallback, default 3-week weekly Friday chain, overridable start/end/cadence, and the expiration-series edge-case fix). No test_finance.py exists yet, consistent with the intent that it's an intentionally excluded, separately-authored task. No issues found.

<details>
<summary>Evidence: faker CLI full doc generation (`python -m faker`) — finance provider section, reproducing the documentor zero-arg call path that previously crashed</summary>

```text
### faker.providers.finance

fake.expiration_date(quote_date=None) # 2026-10-23
fake.option_chain(symbol=None, symbols=None, start_date='today', # {'CVX': {datetime.date(2026, 8, 21): [{'underlying_symbol': 'CVX', ...
end_date='+3w', cadence='weekly')
... (exit code 0, no traceback, includes option_premium()/option_greeks() with all-default args)
```
</details>
<details>
<summary>Evidence: stock_option()/option_chain() end-to-end shape verification (flat dict, top-level Greeks, symbols override, default 3-week weekly Friday window, CALL/PUT parity per strike, cadence/date overrides)</summary>

```text
stock_option keys: ['delta','exercise_date','exercised','expiration_date','gamma','option_type','premium','quote_date','rho','strike_price','theta','underlying_price','underlying_symbol','vega']
custom symbols respected: XYZ
option_chain expirations (default 3wk weekly Fridays): [2026-08-21, 2026-08-28, 2026-09-04]
num quotes per expiration: 10 (5 strikes x CALL+PUT)
monthly cadence expirations: [2026-09-04, 2026-10-02] (28-day spacing confirmed)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d73533a180568d8e73fe45debbee9586568d1adc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff f33e820a..7f039b3a -- faker/providers/finance/__init__.py tests/utils/test_utils.py`
- `python -m pytest tests/utils/test_utils.py::UtilsTestCase::test_find_available_providers -q`
- `python -m faker (full CLI doc generation, exercising every public provider method incl. finance with zero args)`
- `Manual Documentor.get_provider_formatters(FinanceProvider(fake)) call for all finance methods`
- `Manual verification of Provider._expiration_series edge case: first Friday excluded when it exceeds end_date, included when within range`
- `Manual verification via Faker() of stock_option(), stock_option(symbols=[...]), option_chain() default window, option_chain(start_date=, end_date=, cadence='monthly')`
- `python -c "from faker.config import PROVIDERS; 'faker.providers.finance' in PROVIDERS" (auto-discovery check)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
