### PR TITLE
fix(pt_BR): allow repeated digits in numeric CNPJ roots

### DIFF
--- a/faker/providers/company/pt_BR/__init__.py
+++ b/faker/providers/company/pt_BR/__init__.py
@@ -107,7 +107,7 @@ class Provider(CompanyProvider):
     def _company_id_base(self, use_alphanumeric: bool) -> str:
         if use_alphanumeric:
             return "".join(self.random_choices(COMPANY_ID_ALPHABET, length=12))
-        digits = self.random_sample(range(10), 8)
+        digits = self.random_choices(range(10), length=8)
         return "".join(str(d) for d in digits) + "0001"
 
     def company_id(self, use_alphanumeric: bool = False) -> str:

--- a/tests/providers/test_company.py
+++ b/tests/providers/test_company.py
@@ -29,6 +29,7 @@ from faker.providers.company.pl_PL import (
     local_regon_checksum,
     regon_checksum,
 )
+from faker.providers.company.pt_BR import Provider as PtBrCompanyProvider
 from faker.providers.company.pt_BR import company_id_checksum
 from faker.providers.company.ro_RO import Provider as RoRoCompanyProvider
 from faker.providers.company.ru_RU import Provider as RuRuCompanyProvider
@@ -487,6 +488,17 @@ class TestPtBr:
             assert re.fullmatch(r"\d{8}0001\d{2}", company_id)
             values = [ord(c) - 48 for c in company_id[:12]]
             assert company_id[12:] == "".join(str(d) for d in company_id_checksum(values))
+
+    def test_numeric_company_id_allows_repeated_digits(self, faker):
+        provider = PtBrCompanyProvider(generator=faker)
+        repeated_digits = [1, 8, 7, 8, 1, 2, 0, 3]
+
+        with patch.object(provider, "random_choices", return_value=repeated_digits) as random_choices:
+            company_id = provider.company_id()
+
+        random_choices.assert_called_once_with(range(10), length=8)
+        assert company_id[:12] == "187812030001"
+        assert company_id[12:] == "28"
 
     def test_company_id_alphanumeric(self, faker, num_samples):
         for _ in range(num_samples):


### PR DESCRIPTION
### What does this change

Numeric Brazilian CNPJ generation now samples the eight root digits with replacement. A regression test uses the Receita Federal example `18.781.203/0001-28` to prove that repeated root digits are supported while preserving checksum generation.

### What was wrong

`_company_id_base(False)` used `random_sample(range(10), 8)`, which samples without replacement. That made every generated eight-digit root contain eight distinct digits, although valid numeric CNPJs may repeat digits.

As a result, Faker could generate only `10P8 = 1,814,400` roots out of the `10^8 = 100,000,000` possible numeric roots (about 1.8%).

### How this fixes it

Use `random_choices(range(10), length=8)` so each root position is sampled independently. The alphanumeric path, branch suffix, public API, and checksum calculation remain unchanged.

Fixes #2445

### Verification

- `pytest tests/providers/test_company.py -q`: 93 passed
- `tox -e py -- tests/providers/test_company.py`: 93 passed, then 101 passed in the locale module run
- Black (line length 120), isort, flake8, mypy, check-manifest, and test-class ordering checks passed
- `git diff --check` passed

### AI Assistance Disclosure (REQUIRED)

- [ ] No AI tools were used in the creation of this PR.
- [x] If AI tools were used, disclose how they were used and how you reviewed their output.

OpenAI Codex (GPT-5) assisted with repository/source-history inspection, duplicate searching, the reproducer, the regression test, the one-line implementation, and drafting this PR. I reviewed the diff and ran the listed tests and static checks locally.

### Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have read the Coding Style documentation.
- [ ] I have run `make lint`.

`make` is unavailable in the Windows development environment. Its Black, isort, flake8, and mypy components were run individually and passed; the complete GitHub Actions matrix is left to verify the repository-native workflow.